### PR TITLE
Add optimization for Repetition elements

### DIFF
--- a/documentation/test_grammar_elements_basic_doctest.txt
+++ b/documentation/test_grammar_elements_basic_doctest.txt
@@ -89,7 +89,7 @@ Usage::
     >>> # Repetition is given a dragonfly element, in this case a Sequence.
     >>> seq = Sequence([Literal("hello"), Literal("world")])
     >>> # Specify min and max values to allow more than one repetition.
-    >>> rep = Repetition(seq, min=1, max=16)
+    >>> rep = Repetition(seq, min=1, max=16, optimize=False)
     >>> test_rep = ElementTester(rep)
     >>> test_rep.recognize("hello world")
     [[u'hello', u'world']]
@@ -103,6 +103,13 @@ Usage::
     >>> # Too many recognitions also result in recognition failure.
     >>> test_rep.recognize(" ".join(["hello world"] * 17))
     RecognitionFailure
+    >>> # Using the 'optimize' argument:
+    rep = Repetition(seq, min=1, max=16, optimize=True)
+    >>> test_rep = ElementTester(rep)
+    >>> test_rep.recognize("hello world")
+    [[u'hello', u'world']]
+    >>> test_rep.recognize("hello world hello world")
+    [[u'hello', u'world'], [u'hello', u'world']]
 
 
 RuleRef element class

--- a/dragonfly/engines/backend_natlink/compiler.py
+++ b/dragonfly/engines/backend_natlink/compiler.py
@@ -30,6 +30,8 @@ from six import string_types, text_type, PY2
 
 from ..base import CompilerBase, CompilerError
 
+import dragonfly.grammar.elements as elements_
+
 
 #===========================================================================
 
@@ -64,10 +66,17 @@ class NatlinkCompiler(CompilerBase):
     def _compile_sequence(self, element, compiler):
         children = element.children
         if len(children) > 1:
-            compiler.start_sequence()
-            for c in children:
-                self.compile_element(c, compiler)
-            compiler.end_sequence()
+            # Compile Sequence and Repetition elements differently.
+            is_rep = isinstance(element, elements_.Repetition)
+            if is_rep and element.optimize:
+                compiler.start_repetition()
+                self.compile_element(children[0], compiler)
+                compiler.end_repetition()
+            else:
+                compiler.start_sequence()
+                for c in children:
+                    self.compile_element(c, compiler)
+                compiler.end_sequence()
         elif len(children) == 1:
             self.compile_element(children[0], compiler)
 

--- a/dragonfly/grammar/elements_basic.py
+++ b/dragonfly/grammar/elements_basic.py
@@ -539,15 +539,24 @@ class Repetition(Sequence):
            exactly *min* times (i.e. *max = min + 1*)
          - *name* (*str*, default: *None*) --
            the name of this element
+         - *optimize* (*bool*, default: *True*) --
+           whether the engine's compiler should compile the element
+           optimally
 
         For a recognition to match, at least one of the child elements
         must match the recognition.  The first matching child is
         used.  Child elements are searched in the order they are given
         in the *children* constructor argument.
 
+        If the *optimize* argument is set to *True*, the compiler will
+        ignore the *min* and *max* limits to reduce grammar complexity. If
+        the number of repetitions recognized is more than the *max* value,
+        the rule will fail to match.
+
     """
 
-    def __init__(self, child, min=1, max=None, name=None, default=None):
+    def __init__(self, child, min=1, max=None, name=None, default=None,
+                 optimize=True):
         if not isinstance(child, ElementBase):
             raise TypeError("Child of %s object must be an"
                             " ElementBase instance." % self)
@@ -559,6 +568,7 @@ class Repetition(Sequence):
         self._min = min
         if max is None: self._max = min + 1
         else:           self._max = max
+        self._optimize = optimize
 
         optional_length = self._max - self._min - 1
         if optional_length > 0:
@@ -577,15 +587,25 @@ class Repetition(Sequence):
 
         Sequence.__init__(self, children, name=name, default=default)
 
-    min = property(lambda self: self._min,
-                   doc="The minimum number of times that the child element must be"
-                       "recognized; may be 0. (Read-only)")
+    min = property(
+        lambda self: self._min,
+        doc="The minimum number of times that the child element must be "
+        "recognized; may be 0. (Read-only)"
+    )
 
-    max = property(lambda self: self._max,
-                   doc="The maximum number of times that the child element must be"
-                       "recognized; if *None*, the child element must be "
-                       "recognized exactly *min* times (i.e. *max = min + 1*). "
-                       "(Read-only)")
+    max = property(
+        lambda self: self._max,
+        doc="The maximum number of times that the child element must be "
+        "recognized; if *None*, the child element must be "
+        "recognized exactly *min* times (i.e. *max = min + 1*). "
+        "(Read-only)"
+    )
+
+    optimize = property(
+        lambda self: self._optimize,
+        doc="Whether the engine's compiler should compile the element "
+        "optimally. (Read-only)"
+    )
 
     def dependencies(self, memo):
         if self in memo:


### PR DESCRIPTION
So after a few discussions on the Gitter channel with @lunixbochs regarding dragonfly's Repetition elements, I have done the following:

- Added an 'optimize' argument to the Repetition element.
- Modified the natlink compiler to compile Repetition elements using Dragon's repeat tag if 'optimize' is set to true.
- Changed the relevant doctest to test with 'optimize' set to both true and false.
- Updated documentation.

The 'optimize' argument is set to true by default. Dragon will not know about the min/max limits, but this should **decrease grammar complexity**! You can get the old behaviour by using `optimize=False`.

I've done a bit of testing with a grammar that would normally produce complexity errors and it didn't with this patch.

@LexiconCode IIRC Caster defines a max repetition limit in the settings. You may want to adjust that when this change is released; it won't have any effect on complexity warnings if optimization is used. This is only for natlink though, so it would still have an effect if WSR was used. Just thought I'd let you know :)