### PR TITLE
Add ContextAction class from Aenea

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,3 +1,4 @@
+Alex Roper <alex@aroper.net>
 Christo Butcher <t4ngo@twizzy.biz>
 Christopher Schnick <c.schnick@monospark.org>
 Dane Finlay <Danesprite@gmail.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ commit history and will be placed under headings in this file over time.
 Unreleased_
 -----------
 
+Added
+~~~~~
+* Add modified ContextAction class from `Aenea`_
+  (thanks `@calmofthestorm`_).
+
 Fixed
 ~~~~~
 * Fix Sphinx engine bug where grammar searches could be overridden.
@@ -365,3 +370,5 @@ This release is the first in the Git version control system.
 .. _@daanzu: https://github.com/daanzu
 .. _@Versatilus: https://github.com/Versatilus
 .. _@wolfmanstout: https://github.com/wolfmanstout
+.. _@calmofthestorm: https://github.com/calmofthestorm
+.. _Aenea: https://github.com/dictation-toolbox/aenea

--- a/documentation/actions.txt
+++ b/documentation/actions.txt
@@ -129,5 +129,8 @@ Action class reference
 .. automodule:: dragonfly.actions.action_cmd
    :members:
 
+.. automodule:: dragonfly.actions.action_context
+   :members:
+
 .. automodule:: dragonfly.actions.action_pause
    :members:

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -53,7 +53,7 @@ from .actions           import (ActionBase, DynStrActionBase, ActionError,
                                 Typeable, Keyboard, typeables,
                                 KeyboardInput, MouseInput, HardwareInput,
                                 make_input_array, send_input_array,
-                                RunCommand
+                                RunCommand, ContextAction
                                 )
 
 #---------------------------------------------------------------------------

--- a/dragonfly/actions/__init__.py
+++ b/dragonfly/actions/__init__.py
@@ -28,6 +28,7 @@ from .action_base         import (ActionBase, DynStrActionBase,
                                   Repeat, ActionError)
 from .action_mimic        import Mimic
 from .action_cmd          import RunCommand
+from .action_context      import ContextAction
 
 # Import Windows OS dependent classes only for Windows
 if sys.platform.startswith("win"):

--- a/dragonfly/actions/action_context.py
+++ b/dragonfly/actions/action_context.py
@@ -1,0 +1,103 @@
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+
+
+'''
+ContextAction
+============================================================================
+
+'''
+
+
+from .action_base import ActionBase
+from ..windows import Window
+
+
+def _ensure_execution_context(data):
+    '''Populates the data field of execute with context information if
+    not present.'''
+    if data is None:
+        data = {}
+    if '_context' not in data:
+        data['_context'] = Window.get_foreground()
+    return data
+
+class ContextAction(ActionBase):
+    '''
+    Action class to execute a different action depending on which context is
+    currently active.
+
+    This is especially useful for allowing the same commands to work in
+    multiple applications without redefining them in other grammars. An
+    example of this is the redo shortcut. Some applications use
+    *Ctrl+Shift+Z*, while others might use *Ctrl+Y* instead.
+    ``ContextAction`` could be used to define *Ctrl+Y* as the default and
+    use *Ctrl+Shift+Z* for specific contexts::
+
+        redo = ContextAction(default=Key('c-y'), actions=[
+            # Use cs-z for rstudio
+            (AppContext(executable="rstudio"), Key('cs-z')),
+        ])
+
+    This class was originally written for the
+    `Aenea <https://github.com/dictation-toolbox/aenea>`__ project by Alex
+    Roper and has been modified to work without Aenea's functionality.
+    '''
+    def __init__(self, default=None, actions=[]):
+        '''
+            Constructor arguments:
+             - *default* (action object, default *do nothing*) -- the
+               default action to execute if there was no matching context in
+               *actions*.
+             - *actions* (iterable, default *empty list*) -- an iterable
+               object containing context-action pairs. The action of the
+               first matching context will be executed.
+
+        '''
+        # Use a new ActionBase action (to do nothing) if default is None.
+        self.default = default if default is not None else ActionBase()
+
+        # Set the actions list.
+        if isinstance(actions, dict):
+            actions = list(actions.items())
+        self.actions = actions
+        ActionBase.__init__(self)
+
+    def add_context(self, context, action):
+        '''
+        Add a context-action pair to the *actions* list.
+
+        :param context: dragonfly context
+        :param action: dragonfly action
+        :type context: Context
+        :type action: ActionBase
+        '''
+        self.actions.append((context, action))
+
+    def _execute(self, data=None):
+        data = _ensure_execution_context(data)
+        win = data['_context']
+        try:
+            for (context, action) in self.actions:
+                if context.matches(win.executable, win.title, win.handle):
+                    return action.execute(data)
+            else:
+                return self.default.execute(data)
+        except Exception as e:
+            self._log.exception("Exception from matching context or "
+                                "executing action %s: %s" % (self._str, e))
+            return False

--- a/dragonfly/actions/actions.py
+++ b/dragonfly/actions/actions.py
@@ -32,6 +32,7 @@ from .action_base         import (ActionBase, DynStrActionBase,
                                   Repeat, ActionError)
 from .action_mimic        import Mimic
 from .action_cmd          import RunCommand
+from .action_context      import ContextAction
 
 # Import Windows OS dependent classes only for Windows
 if sys.platform.startswith("win"):


### PR DESCRIPTION
Re: https://github.com/dictation-toolbox/Caster/issues/426

ContextAction is a utility class from Aenea that executes different actions depending on which context is currently active. This version of the class works without Aenea's functionality.

I've included some documentation, error handling for executing actions/matching contexts, as well as a usage example.

@calmofthestorm Just wondering if you are okay with this being merged. I have left the original license & copyright notice at the top of the file. I find this class invaluable and I think that some dragonfly and caster users might find it useful.