### PR TITLE
WIP - Add more flexible Integer class

### DIFF
--- a/documentation/language.txt
+++ b/documentation/language.txt
@@ -25,3 +25,6 @@ and the supported languages for Windows Speech are listed on
 `its Wikipedia page <https://en.wikipedia.org/wiki/Windows_Speech_Recognition#Overview_and_features>`_.
 
 The Pocket Sphinx engine documentation has a `section on language support <https://dragonfly2.readthedocs.io/en/latest/sphinx_engine.html?highlight=language#spoken-language-support>`_.
+
+.. automodule:: dragonfly.language.en.short_number
+   :members:

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -3,18 +3,18 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
@@ -68,7 +68,7 @@ from .windows           import Window
 from .windows           import Monitor, monitors
 
 #---------------------------------------------------------------------------
-from .language          import (Integer, IntegerRef,
+from .language          import (Integer, IntegerRef, LineIntegerRef,
                                 Digits, DigitsRef,
                                 Number, NumberRef)
 

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -68,7 +68,7 @@ from .windows           import Window
 from .windows           import Monitor, monitors
 
 #---------------------------------------------------------------------------
-from .language          import (Integer, IntegerRef, LineIntegerRef,
+from .language          import (Integer, IntegerRef, ShortIntegerRef,
                                 Digits, DigitsRef,
                                 Number, NumberRef)
 

--- a/dragonfly/language/__init__.py
+++ b/dragonfly/language/__init__.py
@@ -18,6 +18,6 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-from .base.integer  import Integer,  IntegerRef, LineIntegerRef
+from .base.integer  import Integer,  IntegerRef, ShortIntegerRef
 from .base.digits   import Digits,   DigitsRef
 from .base.number   import Number,   NumberRef

--- a/dragonfly/language/__init__.py
+++ b/dragonfly/language/__init__.py
@@ -3,21 +3,21 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
-from .base.integer  import Integer,  IntegerRef
+from .base.integer  import Integer,  IntegerRef, LineIntegerRef
 from .base.digits   import Digits,   DigitsRef
 from .base.number   import Number,   NumberRef

--- a/dragonfly/language/base/integer.py
+++ b/dragonfly/language/base/integer.py
@@ -94,10 +94,10 @@ class IntegerRef(RuleWrap):
         element = Integer(None, min, max)
         RuleWrap.__init__(self, name, element, default=default)
 
-class LineIntegerRef(RuleWrap):
+class ShortIntegerRef(RuleWrap):
 
     def __init__(self, name, min, max, default=None):
-        element = Integer(None, min, max, content=language.LineIntegerContent)
+        element = Integer(None, min, max, content=language.ShortIntegerContent)
         RuleWrap.__init__(self, name, element, default=default)
 
 #---------------------------------------------------------------------------

--- a/dragonfly/language/base/integer.py
+++ b/dragonfly/language/base/integer.py
@@ -3,18 +3,18 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
@@ -93,3 +93,11 @@ class IntegerRef(RuleWrap):
     def __init__(self, name, min, max, default=None):
         element = Integer(None, min, max)
         RuleWrap.__init__(self, name, element, default=default)
+
+class LineIntegerRef(RuleWrap):
+
+    def __init__(self, name, min, max, default=None):
+        element = Integer(None, min, max, content=language.LineIntegerContent)
+        RuleWrap.__init__(self, name, element, default=default)
+
+#---------------------------------------------------------------------------

--- a/dragonfly/language/en/__init__.py
+++ b/dragonfly/language/en/__init__.py
@@ -3,22 +3,23 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
 
-from .number import    IntegerContent, DigitsContent
-from .calendar import  (AbsoluteDate, RelativeDate, Date,
-                        MilitaryTime, Time)
+from .number      import    IntegerContent, DigitsContent
+from .line_number import    LineIntegerContent
+from .calendar    import   (AbsoluteDate, RelativeDate, Date,
+                            MilitaryTime, Time)

--- a/dragonfly/language/en/__init__.py
+++ b/dragonfly/language/en/__init__.py
@@ -19,7 +19,7 @@
 #
 
 
-from .number      import    IntegerContent, DigitsContent
-from .line_number import    LineIntegerContent
-from .calendar    import   (AbsoluteDate, RelativeDate, Date,
+from .number       import    IntegerContent, DigitsContent
+from .short_number import    ShortIntegerContent
+from .calendar     import   (AbsoluteDate, RelativeDate, Date,
                             MilitaryTime, Time)

--- a/dragonfly/language/en/line_number.py
+++ b/dragonfly/language/en/line_number.py
@@ -1,0 +1,62 @@
+from ..base.integer_internal  import (MapIntBuilder, CollectionIntBuilder,
+                                      MagnitudeIntBuilder, IntegerContentBase)
+from .number import int_0, int_1_9, int_10_19, int_20_90_10
+
+# Twenty five
+int_20_99       = MagnitudeIntBuilder(
+                   factor      = 10,
+                   spec        = "<multiplier> [<remainder>]",
+                   multipliers = [int_20_90_10],
+                   remainders  = [int_1_9],
+                  )
+# Two five / seven zero
+int_10_99       = MagnitudeIntBuilder(
+                   factor      = 10,
+                   spec        = "<multiplier> <remainder>",
+                   multipliers = [int_1_9],
+                   remainders  = [int_0, int_1_9],
+                  )
+# Oh five
+int_and_1_9    = CollectionIntBuilder(
+                   spec        = "(oh | zero) <element>",
+                   set         = [int_1_9],
+                  )
+# Fifty five / five five
+int_and_10_99    = CollectionIntBuilder(
+                   spec        = "[and] <element>",
+                   set         = [int_10_19, int_20_99, int_10_99],
+                  )
+# Hundred fifty / two hundred / four hundred seventy nine
+int_x01_x99        = MagnitudeIntBuilder(
+                   factor      = 100,
+                   spec        = "[<multiplier>] hundred [<remainder>]",
+                   multipliers = [int_1_9, int_10_19, int_20_99],
+                   remainders  = [int_1_9, int_and_10_99],
+                  )
+# One oh nine / five fifty / one two five
+int_x10_x99        = MagnitudeIntBuilder(
+                   factor      = 100,
+                   spec        = "<multiplier> [hundred] <remainder>",
+                   multipliers = [int_1_9, int_10_19, int_20_99],
+                   remainders  = [int_and_1_9, int_and_10_99],
+                  )
+# One thousand fifty
+int_x000_x099       = MagnitudeIntBuilder(
+                   factor      = 1000,
+                   spec        = "<multiplier> thousand [<remainder>]",
+                   multipliers = [int_1_9],
+                   remainders  = [int_1_9, int_and_10_99]
+                  )
+# One thousand five fifty / one five fifty / one five five zero
+int_x100_x999       = MagnitudeIntBuilder(
+                   factor      = 1000,
+                   spec        = "<multiplier> [thousand] <remainder>",
+                   multipliers = [int_1_9],
+                   remainders  = [int_x01_x99, int_x10_x99]
+                  )
+
+#---------------------------------------------------------------------------
+
+class LineIntegerContent(IntegerContentBase):
+    builders = [int_0, int_1_9, int_10_19, int_20_99, int_10_99,
+                int_x01_x99, int_x10_x99, int_x000_x099, int_x100_x999]

--- a/dragonfly/language/en/line_number.py
+++ b/dragonfly/language/en/line_number.py
@@ -43,7 +43,7 @@ int_x10_x99        = MagnitudeIntBuilder(
 # One thousand fifty
 int_x000_x099       = MagnitudeIntBuilder(
                    factor      = 1000,
-                   spec        = "<multiplier> thousand [<remainder>]",
+                   spec        = "[<multiplier>] thousand [<remainder>]",
                    multipliers = [int_1_9],
                    remainders  = [int_1_9, int_and_10_99]
                   )

--- a/dragonfly/language/en/number.py
+++ b/dragonfly/language/en/number.py
@@ -3,18 +3,18 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
@@ -32,7 +32,7 @@ from ..base.digits_internal   import DigitsContentBase
 #---------------------------------------------------------------------------
 
 int_0           = MapIntBuilder({
-                                 "zero":       0,
+                                 "(zero | oh)":0,
                                })
 int_1_9         = MapIntBuilder({
                                  "one":        1,

--- a/dragonfly/language/en/short_number.py
+++ b/dragonfly/language/en/short_number.py
@@ -3,7 +3,7 @@
 ShortIntegerRef
 ============================================================================
 
-`ShortIntegerRef` is a modified version of :class:`IntegerRef` which allows for greater flexibility in the way that numbers may be pronounced, allowing for words like "hundred" to be dropped. This may be particularly useful when navigating files by line or page number.
+:class:`ShortIntegerRef` is a modified version of :class:`IntegerRef` which allows for greater flexibility in the way that numbers may be pronounced, allowing for words like "hundred" to be dropped. This may be particularly useful when navigating files by line or page number.
 
 Some examples of allowed pronunciations:
 
@@ -32,7 +32,7 @@ seventeen five three                  1753
 four thousand                         4000
 ================================     ======
 
-The class works in the same way as `IntegerRef`, by adding the following as an extra.
+The class works in the same way as :class:`IntegerRef`, by adding the following as an extra.
 
 .. code:: python
 

--- a/dragonfly/language/en/short_number.py
+++ b/dragonfly/language/en/short_number.py
@@ -57,6 +57,6 @@ int_x100_x999       = MagnitudeIntBuilder(
 
 #---------------------------------------------------------------------------
 
-class LineIntegerContent(IntegerContentBase):
+class ShortIntegerContent(IntegerContentBase):
     builders = [int_0, int_1_9, int_10_19, int_20_99, int_10_99,
                 int_x01_x99, int_x10_x99, int_x000_x099, int_x100_x999]

--- a/dragonfly/language/en/short_number.py
+++ b/dragonfly/language/en/short_number.py
@@ -1,3 +1,44 @@
+
+'''
+ShortIntegerRef
+============================================================================
+
+`ShortIntegerRef` is a modified version of :class:`IntegerRef` which allows for greater flexibility in the way that numbers may be pronounced, allowing for words like "hundred" to be dropped. This may be particularly useful when navigating files by line or page number.
+
+Some examples of allowed pronunciations:
+
+================================     ======
+Pronunciation                        Result
+================================     ======
+one                                   1
+ten                                   10
+twenty three                          23
+two three                             23
+seventy                               70
+seven zero                            70
+hundred                               100
+one oh three                          103
+hundred three                         103
+one twenty seven                      127
+one two seven                         127
+one hundred twenty seven              127
+seven hundred                         700
+thousand                              1000
+seventeen hundred                     1700
+seventeen hundred fifty three         1753
+seventeen fifty three                 1753
+one seven five three                  1753
+seventeen five three                  1753
+four thousand                         4000
+================================     ======
+
+The class works in the same way as `IntegerRef`, by adding the following as an extra.
+
+.. code:: python
+
+   ShortIntegerRef("name", 0, 1000),
+'''
+
 from ..base.integer_internal  import (MapIntBuilder, CollectionIntBuilder,
                                       MagnitudeIntBuilder, IntegerContentBase)
 from .number import int_0, int_1_9, int_10_19, int_20_90_10

--- a/dragonfly/test/test_language_en_number.py
+++ b/dragonfly/test/test_language_en_number.py
@@ -153,9 +153,9 @@ class Limit352TestCase(ElementTestCase):
 
 
 class LineIntegerTestCase(ElementTestCase):
-    """ Verify integer limits of range up to 352. """
+    """ Verify line integer class working as expected """
     def _build_element(self):
-        from dragonfly.language.en.number       import LineIntegerContent
+        from dragonfly.language.en.line_number       import LineIntegerContent
         return Integer(content=LineIntegerContent, min=0, max=10000)
     input_output = [
                     ("one",                           1),

--- a/dragonfly/test/test_language_en_number.py
+++ b/dragonfly/test/test_language_en_number.py
@@ -3,18 +3,18 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
@@ -62,7 +62,7 @@ class IntegerTestCase(ElementTestCase):
                     ("seventy four hundred",    7400),
                     ("seventy four thousand",  74000),
                     ("two hundred and thirty four thousand five hundred sixty seven", 234567),
-                   ]    
+                   ]
 
 
 class Limit3to14TestCase(ElementTestCase):
@@ -91,7 +91,7 @@ class Limit3to14TestCase(ElementTestCase):
                     ("seventeen",  RecognitionFailure),
                     ("eighteen",   RecognitionFailure),
                     ("nineteen",   RecognitionFailure),
-                   ]    
+                   ]
 
 
 class Limit23to47TestCase(ElementTestCase):
@@ -104,7 +104,7 @@ class Limit23to47TestCase(ElementTestCase):
                     ("twenty three",      23),
                     ("forty six",         46),
                     ("forty seven",       RecognitionFailure),
-                   ]    
+                   ]
 
 
 class Limit230to350TestCase(ElementTestCase):
@@ -122,7 +122,7 @@ class Limit230to350TestCase(ElementTestCase):
                     ("three hundred forty nine",    349),
                     ("three hundred fifty zero",    RecognitionFailure),
                     ("three hundred fifty",         RecognitionFailure),
-                   ]    
+                   ]
 
 
 class Limit351TestCase(ElementTestCase):
@@ -135,7 +135,7 @@ class Limit351TestCase(ElementTestCase):
                     ("three hundred fifty",         350),
                     ("three hundred fifty zero",    RecognitionFailure),
                     ("three hundred fifty one",     RecognitionFailure),
-                   ]    
+                   ]
 
 
 class Limit352TestCase(ElementTestCase):
@@ -149,4 +149,33 @@ class Limit352TestCase(ElementTestCase):
                     ("three hundred fifty zero",    RecognitionFailure),
                     ("three hundred fifty one",     351),
                     ("three hundred fifty two",     RecognitionFailure),
-                   ]    
+                   ]
+
+
+class LineIntegerTestCase(ElementTestCase):
+    """ Verify integer limits of range up to 352. """
+    def _build_element(self):
+        from dragonfly.language.en.number       import LineIntegerContent
+        return Integer(content=LineIntegerContent, min=0, max=10000)
+    input_output = [
+                    ("one",                           1),
+                    ("ten",                           10),
+                    ("twenty three",                  23),
+                    ("two three",                     23),
+                    ("seventy",                       70),
+                    ("seven zero",                    70),
+                    ("hundred",                       100),
+                    ("one oh three",                  103),
+                    ("hundred three",                 103),
+                    ("one twenty seven",              127),
+                    ("one two seven",                 127),
+                    ("one hundred twenty seven",      127),
+                    ("seven hundred",                 700),
+                    ("thousand",                      1000),
+                    ("seventeen hundred",             1700),
+                    ("seventeen hundred fifty three", 1753),
+                    ("seventeen fifty three",         1753),
+                    ("one seven five three",          1753),
+                    ("seventeen five three",          1753),
+                    ("four thousand",                 4000),
+                   ]

--- a/dragonfly/test/test_language_en_number.py
+++ b/dragonfly/test/test_language_en_number.py
@@ -152,11 +152,11 @@ class Limit352TestCase(ElementTestCase):
                    ]
 
 
-class LineIntegerTestCase(ElementTestCase):
+class ShortIntegerTestCase(ElementTestCase):
     """ Verify line integer class working as expected """
     def _build_element(self):
-        from dragonfly.language.en.line_number       import LineIntegerContent
-        return Integer(content=LineIntegerContent, min=0, max=10000)
+        from dragonfly.language.en.short_number       import ShortIntegerContent
+        return Integer(content=ShortIntegerContent, min=0, max=10000)
     input_output = [
                     ("one",                           1),
                     ("ten",                           10),


### PR DESCRIPTION
The motivation for this change was the following text editor function:

```
"<action> [line] <n> [to <nn>]"  : Function(action_lines),
```

```
Choice("action", {
            "select": "",
            "copy": "c-c",
            "cut": "c-x",
            "delete": "backspace",
            "replace": "c-v",
            }),
```

```
def action_lines(action, n, nn):
    if nn:
        num_lines = int(nn)-int(n)+1 if nn>n else int(n)-int(nn)+1
        top_line = min(int(nn), int(n))
    else:
        num_lines = 1
        top_line = int(n)
    command = Key("c-g") + Text(str(top_line)) + Key("enter, s-down:" + str(num_lines) + ", " + action)
    command.execute()
```

Which allows commands like "copy five to fifteen", etc. Quite useful.

The problem comes in large files where you are having to say commands like "replace line five hundred fifteen to five hundred twenty three", which is kind of verbose and unnatural.

The LineIntegerRef class works the same way as IntegerRef but allows for a wider variety of number pronunciations. For example:
* Line fifty five, line five five
* Line hundred three, line one oh three
* Line two hundred fifty three, line two fifty three, line two five three
* Line two thousand two hundred fifty three, line two two fifty three

At the moment I've only gone as far as thousands, since this is adequate for this purpose and for testing.

The implementation ended up being more complex than I would have liked in order to take care of edge cases. For example if you just make it `[<multiplier>] [hundred] [<remainder>]` this will overlap a lot with other numbers and you will end up with hundreds everywhere.

The name could probably do with changing to something more general, I'm only using this for line numbers at the moment but there are no doubt other use cases.

Thoughts?