### PR TITLE
Don't encode to windows-1252 in Python 3.

### DIFF
--- a/dragonfly/engines/backend_natlink/dictation.py
+++ b/dragonfly/engines/backend_natlink/dictation.py
@@ -32,6 +32,8 @@ dictation formatting for the Natlink and Dragon NaturallySpeaking engine.
 #  not available and the dictation container implemented here
 #  cannot be used.  However, we don't raise an exception because
 #  this file should still be importable for documentation purposes.
+import locale
+
 from six import text_type, PY2
 
 try:
@@ -39,7 +41,6 @@ try:
 except ImportError:
     natlink = None
 
-import logging
 from ..base import DictationContainerBase
 from .dictation_format import WordFormatter
 
@@ -71,6 +72,6 @@ class NatlinkDictationContainer(DictationContainerBase):
 
     def __str__(self):
         if PY2:
-            return self.__unicode__().encode("windows-1252")
+            return self.__unicode__().encode(locale.getpreferredencoding())
         else:
             return self.__unicode__()

--- a/dragonfly/engines/backend_sapi5/dictation.py
+++ b/dragonfly/engines/backend_sapi5/dictation.py
@@ -22,8 +22,9 @@
 Dictation container for the SAPI5 engine.
 
 """
+import locale
 
-import logging
+from six import PY2
 
 from ..base import DictationContainerBase
 
@@ -41,4 +42,7 @@ class Sapi5DictationContainer(DictationContainerBase):
         return " ".join(self._words)
 
     def __str__(self):
-        return self.__unicode__().encode("windows-1252")
+        if PY2:
+            return self.__unicode__().encode(locale.getpreferredencoding())
+        else:
+            return self.__unicode__()

--- a/dragonfly/engines/backend_text/dictation.py
+++ b/dragonfly/engines/backend_text/dictation.py
@@ -32,6 +32,7 @@ on a dictation container object. A tuple of the raw  spoken words can be
 retrieved using :attr:`~DictationContainerBase.words`.
 
 """
+import locale
 
 from six import PY2
 
@@ -58,6 +59,6 @@ class TextDictationContainer(DictationContainerBase):
         message = u"%s(%s)" % (self.__class__.__name__,
                                u", ".join(self._words))
         if PY2:
-            return message.encode("utf-8")
+            return message.encode(locale.getpreferredencoding())
         else:
             return message

--- a/dragonfly/engines/base/dictation.py
+++ b/dragonfly/engines/base/dictation.py
@@ -37,6 +37,10 @@ retrieved using :attr:`~DictationContainerBase.words`.
 #---------------------------------------------------------------------------
 # Dictation base class -- base class for SR engine-specific containers
 #  of dictated words.
+import locale
+
+from six import PY2
+
 
 class DictationContainerBase(object):
     """
@@ -76,7 +80,10 @@ class DictationContainerBase(object):
     def __repr__(self):
         message = u"%s(%s)" % (self.__class__.__name__,
                                u", ".join(self._words))
-        return message.encode("windows-1252")
+        if PY2:
+            return message.encode(locale.getpreferredencoding())
+        else:
+            return message
 
     @property
     def words(self):


### PR DESCRIPTION
In Python 3, `.encode("windows-1252")` returns a byte literal, which ends up causing errors when decoding grammars. This is perhaps not the most complete fix, but it's how we're handling it in other parts of the code. E.g. `backend_natlink/dictation.py`