### PR TITLE
Fix WSR engine context bug with a hook for foreground window changes

### DIFF
--- a/dragonfly/examples/dfly-loader-wsr.py
+++ b/dragonfly/examples/dfly-loader-wsr.py
@@ -81,6 +81,10 @@ def main():
         window = Window.get_foreground()
         if hwnd == window.handle:
             for grammar in engine.grammars:
+                # Prevent 'notify_begin()' from being called.
+                if grammar.name == "_recobs_grammar":
+                    continue
+
                 grammar.process_begin(window.executable, window.title, window.handle)
 
     def set_hook(win_event_proc, event_type):

--- a/dragonfly/examples/dfly-loader-wsr.py
+++ b/dragonfly/examples/dfly-loader-wsr.py
@@ -13,14 +13,15 @@ for use with Window Speech Recognition.  It scans the
 directory it's in and loads any ``_*.py`` it finds.
 
 """
-
-
+import ctypes
+import ctypes.wintypes
 import time
 import os.path
 import logging
 import pythoncom
+import win32con
 
-from dragonfly import RecognitionObserver, get_engine
+from dragonfly import RecognitionObserver, get_engine, Window
 from dragonfly.loader import CommandModuleDirectory
 
 
@@ -71,6 +72,26 @@ def main():
 
     directory = CommandModuleDirectory(path, excludes=[__file__])
     directory.load()
+
+    WinEventProcType = ctypes.WINFUNCTYPE(None, ctypes.wintypes.HANDLE, ctypes.wintypes.DWORD, ctypes.wintypes.HWND,
+                                          ctypes.wintypes.LONG, ctypes.wintypes.LONG, ctypes.wintypes.DWORD,
+                                          ctypes.wintypes.DWORD)
+
+    def callback(hWinEventHook, event, hwnd, idObject, idChild, dwEventThread, dwmsEventTime):
+        window = Window.get_foreground()
+        if hwnd == window.handle:
+            for grammar in engine.grammars:
+                grammar.process_begin(window.executable, window.title, window.handle)
+
+    def set_hook(win_event_proc, event_type):
+        return ctypes.windll.user32.SetWinEventHook(event_type, event_type, 0, win_event_proc, 0, 0, win32con.WINEVENT_OUTOFCONTEXT)
+
+
+    win_event_proc = WinEventProcType(callback)
+    ctypes.windll.user32.SetWinEventHook.restype = ctypes.wintypes.HANDLE
+
+    [set_hook(win_event_proc, et) for et in
+     {win32con.EVENT_SYSTEM_FOREGROUND, win32con.EVENT_OBJECT_NAMECHANGE, }]
 
     engine.speak('beginning loop!')
     while 1:


### PR DESCRIPTION
WSR in particular has a lag where the context of the foreground windows is not loaded until after the first utterance in the new window. This adds the hook and an example of how to use it from the WSR loader.

Fixes #68 

This is certainly not the most elegant way to fix this bug, so someone should feel free to take the bones of this and make something more beautiful.