### PR TITLE
Add FuncContext class that determines context activity by callable arg

### DIFF
--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -38,7 +38,7 @@ from .grammar.elements  import (ElementBase, Sequence, Alternative,
                                 ListRef, DictListRef, Dictation,
                                 RuleRef, RuleWrap, Empty, Compound, Choice)
 
-from .grammar.context   import Context, AppContext
+from .grammar.context   import Context, AppContext, FuncContext
 from .grammar.list      import ListBase, List, DictList
 from .grammar.recobs    import (RecognitionObserver, RecognitionHistory,
                                 PlaybackHistory)


### PR DESCRIPTION
Context class that evaluates a given function, whose return value is interpreted as a *bool*, determining whether the context is active.

The foreground application details are optionally passed to the function as arguments named *executable*, *title*, and/or *handle*, if any/each matches a so-named keyword argument of the function. Default arguments may also be passed to the function, through this class's constructor.
