### PR TITLE
Add RPC methods for speech state & recognition history

### DIFF
--- a/dragonfly/rpc/methods.py
+++ b/dragonfly/rpc/methods.py
@@ -213,6 +213,23 @@ def get_recognition_history():
 
 
 @_add_method
+def is_in_speech():
+    """
+    Whether the user is currently speaking.
+
+    The :meth:`register_history` method **must** be called to register the
+    observer first.
+
+    :rtype: bool
+    """
+    obs = _history_closure[0]
+    if obs is None:
+        raise RuntimeError("the recognition observer is not registered")
+
+    return not obs.complete
+
+
+@_add_method
 def unregister_history():
     """
     Unregister the internal recognition observer.

--- a/dragonfly/rpc/methods.py
+++ b/dragonfly/rpc/methods.py
@@ -68,6 +68,7 @@ Built-in RPC methods
 
 from six import string_types
 
+from dragonfly.grammar.recobs import RecognitionHistory
 from .. import get_engine, CompoundRule, MappingRule
 from ..engines.base import MimicFailure
 
@@ -153,3 +154,71 @@ def get_engine_language():
     :rtype: str
     """
     return get_engine().language
+
+
+_history_closure = [None]
+
+class RPCRecognitionHistory(RecognitionHistory):
+    """"""
+
+    def __init__(self, length=10, record_failures=False):
+        RecognitionHistory.__init__(self, length)
+        self._record_failures = record_failures
+
+    def on_failure(self):
+        # Include recognition failures if requested.
+        if self._record_failures:
+            self.append(False)
+            if self._length:
+                while len(self) > self._length:
+                    self.pop(0)
+
+
+@_add_method
+def register_history(length=10, record_failures=False):
+    """
+    Register an internal recognition observer.
+
+    :param length: length to initialize the ``RecognitionHistory`` instance
+        with (default ``10``).
+    :param record_failures: whether to record recognition failures
+        (default ``False``).
+    :type record_failures: bool
+    :type length: int
+    """
+    if _history_closure[0] is not None:
+        raise RuntimeError("history has already been registered")
+
+    obs = RPCRecognitionHistory(length, record_failures)
+    obs.register()
+    _history_closure[0] = obs
+
+
+@_add_method
+def get_recognition_history():
+    """
+    Get the recognition history if an observer is registered.
+
+    The :meth:`register_history` method **must** be called to register the
+    observer first.
+
+    :returns: history
+    :rtype: list
+    """
+    obs = _history_closure[0]
+    if obs is None:
+        raise RuntimeError("the recognition observer is not registered")
+
+    return list(obs)
+
+
+@_add_method
+def unregister_history():
+    """
+    Unregister the internal recognition observer.
+    """
+    if _history_closure[0] is None:
+        raise RuntimeError("the recognition observer is not registered")
+
+    _history_closure[0].unregister()
+    _history_closure[0] = None

--- a/dragonfly/test/test_rpc.py
+++ b/dragonfly/test/test_rpc.py
@@ -274,6 +274,44 @@ class RPCTestCase(unittest.TestCase):
         self.assertIn("result", response)
         self.assertEqual(response["result"], "en")
 
+    def test_recognition_history_methods(self):
+        """ Verify that the recognition history RPC methods work correctly.
+        """
+        # Load a grammar for testing that recognitions are saved.
+        g = Grammar("history_test")
+        g.add_rule(CompoundRule(name="compound", spec="test history",
+                                exported=True))
+        g.load()
+        g.set_exclusiveness(True)
+        try:
+            # Test 'register_history()'.
+            response = self.send_request("register_history", [])
+            self.assertIn("result", response)
+
+            # Test that the method raises an error if used when the observer
+            # is already registered.
+            self.assertRaises(RuntimeError, self.send_request,
+                              "register_history", [])
+
+            # Send a mimic and check that it is returned by the
+            # 'get_recognition_history()' method.
+            self.send_request("mimic", ["test history"])
+            response = self.send_request("get_recognition_history", [])
+            self.assertIn("result", response)
+            self.assertListEqual(response["result"], [["test", "history"]])
+
+            # Test 'unregister_observer()'.
+            response = self.send_request("unregister_history", [])
+            self.assertIn("result", response)
+
+            # Test that the method raises an error if used when the observer
+            # is not registered.
+            self.assertRaises(RuntimeError, self.send_request,
+                              "unregister_history", [])
+        finally:
+            g.set_exclusiveness(False)
+            g.unload()
+
 
 if __name__ == '__main__':
     # Use the "text" engine by default and disable timer manager callbacks


### PR DESCRIPTION
Closes #80.

This includes 3 new RPC methods:

* `register_history(length=10, record_failures=False)` - registers an internal `RecognitionHistory` observer. Can optionally record recognition failures.
* `get_recognition_history()` - get a list of recognition history
* `unregister_history()` - unregister the observer.

@LexiconCode When you have the time, let me know if this is what you had in mind.