### PR TITLE
Add xdotool & libxdo keyboard implementations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,10 @@ upload releases to PyPI.org, but everything can still be imported using
 replace :code:`dragonfly` with :code:`dragonfly2` or remove lines like this
 altogether.
 
+If you are installing this on X11/Linux, you will also need to install the
+`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ program for the
+``Key`` and ``Text`` actions to work.
+
 If you have dragonfly installed under the original *dragonfly*
 distribution name, you'll need to remove the old version using:
 

--- a/documentation/installation.txt
+++ b/documentation/installation.txt
@@ -41,6 +41,10 @@ upload releases to PyPI.org, but everything can still be imported using
 replace :code:`dragonfly` with :code:`dragonfly2` or remove lines like this
 altogether.
 
+If you are installing this on X11/Linux, you will also need to install the
+`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ program for the
+``Key`` and ``Text`` actions to work.
+
 If you have dragonfly installed under the original *dragonfly*
 distribution name, you'll need to remove the old version using:
 

--- a/dragonfly/actions/_test_x11_text_key.py
+++ b/dragonfly/actions/_test_x11_text_key.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# encoding: utf-8
 
 """
 Script to test the Key and Text action on X11 using the "xev" program.
@@ -68,6 +69,11 @@ def main():
         "volmute", "tracknext", "trackprev", "playpause", "playpause",
         "browserback", "browserforward",
 
+        # Include some keys not defined in typeables.py. There are a lot of
+        # these in X11. The first two are browser-specific media keys. The
+        # others are the Cyrillic л and Japanese ぁ letters.
+        "XF86Refresh", "XF86HomePage", "Cyrillic_el", "U3041",
+
         # Modifiers.
         "shift:down", "shift:up",
         "ctrl:down", "ctrl:up",
@@ -87,8 +93,9 @@ def main():
     ])
 
     # Define text to type using all alphanumeric characters and valid
-    # symbols.
-    text = alphas + digits + symbols + ",:-/ \n\t"
+    # symbols. Also test some Unicode characters.
+    other_symbols = u"é—…ôêěèźżėфй№😱ß°⌷⅕€¨§™ぁ"
+    text = alphas + digits + symbols + ",:-/ \n\t" + other_symbols
 
     # Start xev and selectively print lines from it in the background.
     # Exit if the command fails.
@@ -99,7 +106,7 @@ def main():
                                 stdin=subprocess.PIPE)
         def print_key_events():
             for line in iter(proc.stdout.readline, b''):
-                line = line.decode()
+                line = line.decode('utf-8')
                 if "keysym" in line:
                     print(line.strip())
 
@@ -115,6 +122,7 @@ def main():
     time.sleep(5)
 
     print("--------------------Starting Key tests--------------------")
+    keys.extend(other_symbols)
     Key("/10,".join(keys)).execute()
     print("Done.")
 

--- a/dragonfly/actions/_test_x11_text_key.py
+++ b/dragonfly/actions/_test_x11_text_key.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 import threading
 import time
+import logging
+logging.basicConfig()
 
 from dragonfly import Key, Text
 
@@ -52,13 +54,14 @@ def main():
         # Navigation keys
         "up", "down", "left", "right", "pageup", "pagedown", "home", "end",
 
-        # Number pad keys (except npsep)
-        "npmul", "npadd", "npsub", "npdec", "npdiv", "np0", "np1",
+        # Number pad keys
+        "npmul", "npadd", "npsub", "npdec", "npdiv", "npsep", "np0", "np1",
         "np2", "np3", "np4", "np5", "np6", "np7", "np8", "np9",
 
-        # Function keys (not including F13-24)
+        # Function keys
         "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11",
-        "f11", "f12",
+        "f11", "f12", "f13", "f14", "f15", "f16", "f17", "f18", "f19",
+        "f20", "f21", "f22", "f23", "f24",
 
         # Multimedia keys (press toggle keys twice)
         "volumeup", "volup", "volumedown", "voldown", "volumemute",

--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #
 # This file is part of Dragonfly.
 # (c) Copyright 2007, 2008 by Christo Butcher
@@ -29,6 +30,9 @@ type of action is used for sending keystrokes to the foreground
 application.  This works on Windows, Mac OS and with X11 (e.g. on Linux).
 Examples of how to use this class are given in :ref:`RefKeySpecExamples`.
 
+To use this class on X11/Linux, the
+`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ program must be
+installed.
 
 .. _RefKeySpec:
 
@@ -176,6 +180,43 @@ The following code locks the screen by pressing the *Windows* key together
 with the *l*: ::
 
     Key("w-l").execute()
+
+
+X11 key support
+............................................................................
+
+This class can be used to type arbitrary keys and Unicode characters on
+X11/Linux. It is not limited to the key names listed above, although all of
+them will work too.
+
+Unicode characters are supported by passing their Unicode code point to the
+keyboard implementation. For example, the character ``'€'`` is converted to
+``'U20AC'``. The Unicode code point can also be passed directly, e.g. with
+``Key('U20AC')``.
+
+
+
+Example X11 key actions
+----------------------------------------------------------------------------
+
+In addition to the examples in the previous section, the following example
+will work on X11/Linux.
+
+The following code will type 'σμ' into the foreground application and then
+press ctrl+z: ::
+
+    Key("σ,μ,c-z").execute()
+
+The following code will press 'µ' while holding control and alt: ::
+
+    Key("ca-μ").execute()
+
+The following code will press the browser refresh multimedia key: ::
+
+    Key("XF86Refresh").execute()
+
+Although this key is not defined in dragonfly's typeables list, it still
+works because it is passed directly to xdotool.
 
 
 Key class reference

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -73,7 +73,7 @@ Text class reference
 
 import sys
 
-from six import text_type
+from six import PY2
 
 from ..engines import get_engine
 from ..util.clipboard import Clipboard
@@ -200,7 +200,9 @@ class Text(DynStrActionBase):
         unicode_events = []
         hardware_error_message = None
         unicode_error_message = None
-        for character in text_type(spec):
+        if PY2 and isinstance(spec, str):
+            spec = spec.decode('utf-8')
+        for character in spec:
             if character in self._specials:
                 typeable = self._specials[character]
                 hardware_events.extend(typeable.events(self._pause))

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -26,6 +26,10 @@ This section describes the :class:`Text` action object. This type of
 action is used for typing text into the foreground application.  This works
 on Windows, Mac OS and with X11 (e.g. on Linux).
 
+To use this class on X11/Linux, the
+`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ program must be
+installed.
+
 It differs from the :class:`Key` action in that :class:`Text` is used for
 typing literal text, while :class:`dragonfly.actions.action_key.Key`
 emulates pressing keys on the keyboard.  An example of this is that the
@@ -55,7 +59,8 @@ parameter for :class:`Text` as follows:
 
 .. code:: python
 
-   Text(u"σμ") + Key("ctrl:down") + Text("]", use_hardware=True) + Key("ctrl:up")
+   action = Text("σμ") + Key("ctrl:down") + Text("]", use_hardware=True) + Key("ctrl:up")
+   action.execute()
 
 
 Some applications require hardware emulation versus Unicode keyboard
@@ -64,6 +69,30 @@ emulation. If you use such applications, add their executable names to the
 dragonfly always use hardware emulation for them.
 
 These settings and parameters have no effect on other platforms.
+
+
+X11/Linux Unicode Keyboard Support
+............................................................................
+
+The :class:`Text` action can also type arbitrary Unicode characters on X11.
+This works regardless of the ``use_hardware`` parameter or
+``unicode_keyboard`` setting.
+
+Unlike on Windows, modifier keys will be respected by :class:`Text` actions
+on X11. As such, the previous Windows example will work and can even be
+simplified a little:
+
+.. code:: python
+
+   action = Text("σμ") + Key("ctrl:down") + Text("]") + Key("ctrl:up")
+   action.execute()
+
+
+It can also be done with one :class:`Key` action:
+
+.. code:: python
+
+   Key("σ,μ,c-]").execute()
 
 
 Text class reference

--- a/dragonfly/actions/keyboard/__init__.py
+++ b/dragonfly/actions/keyboard/__init__.py
@@ -37,14 +37,24 @@ doc_build = bool(os.environ.get("SPHINX_BUILD_RUNNING"))
 if sys.platform.startswith("win") and not doc_build:
     # Import classes for Windows.
     from ._win32 import Keyboard, Typeable, Win32KeySymbols as KeySymbols
+
 elif sys.platform == "darwin" and not doc_build:
     # Import classes for Mac OS.
     from ._pynput import Keyboard, Typeable, DarwinKeySymbols as KeySymbols
+
 elif os.environ.get("XDG_SESSION_TYPE") == "x11" and not doc_build:
     # Import classes for X11 (typically used on Linux systems).
     # The XDG_SESSION_TYPE environment variable may not be set in some
     # circumstances, in which case it can be set manually in ~/.profile.
-    from ._pynput import Keyboard, Typeable, X11KeySymbols as KeySymbols
+    from ._x11_base import XdoKeySymbols as KeySymbols, Typeable
+
+    # Import the keyboard for typing through xdotool.
+    from ._x11_xdotool import XdotoolKeyboard as Keyboard
+
+    # libxdo does work and is a bit faster, but doesn't work with Python 3.
+    # Unfortunately python-libxdo also hasn't been updated recently.
+    # from ._x11_libxdo import LibxdoKeyboard as Keyboard
+
 else:
     from ._base import (BaseKeyboard as Keyboard, Typeable,
                         MockKeySymbols as KeySymbols)

--- a/dragonfly/actions/keyboard/__init__.py
+++ b/dragonfly/actions/keyboard/__init__.py
@@ -46,7 +46,7 @@ elif os.environ.get("XDG_SESSION_TYPE") == "x11" and not doc_build:
     # Import classes for X11 (typically used on Linux systems).
     # The XDG_SESSION_TYPE environment variable may not be set in some
     # circumstances, in which case it can be set manually in ~/.profile.
-    from ._x11_base import XdoKeySymbols as KeySymbols, Typeable
+    from ._x11_base import Typeable, XdoKeySymbols as KeySymbols
 
     # Import the keyboard for typing through xdotool.
     from ._x11_xdotool import XdotoolKeyboard as Keyboard

--- a/dragonfly/actions/keyboard/_x11_base.py
+++ b/dragonfly/actions/keyboard/_x11_base.py
@@ -17,13 +17,8 @@
 
 # This file is based on Aenea's X11 key_press implementations.
 
-from ._base import Typeable as BaseTypeable
-
-
-MODIFIER_KEYS = {
-    'Alt_L', 'Shift_L', 'Control_L', 'Super_L',
-    'Alt_R', 'Shift_R', 'Control_R', 'Super_R'
-}
+from six import PY2
+from ._base import BaseKeyboard, Typeable
 
 
 KEY_TRANSLATION = {
@@ -89,14 +84,32 @@ def _update_key_translation(translation):
 _update_key_translation(KEY_TRANSLATION)
 
 
-class Typeable(BaseTypeable):
-    """ Typeable class for X11. """
+class BaseX11Keyboard(BaseKeyboard):
+    """ Base Keyboard class for X11. """
 
     @classmethod
     def get_typeable(cls, char, is_text=False):
         """ Get a Typeable object. """
-        key_name = KEY_TRANSLATION[char]
-        return Typeable(cls, key_name, is_text=is_text)
+        # Get a key translation if one exists. Otherwise use the character
+        # as the key name.
+        key = KEY_TRANSLATION.get(char, char)
+        if PY2 and isinstance(key, str):
+            key = key.decode('utf-8')
+
+        # Convert single character keys to their Unicode code points.
+        # This allows typing any Unicode character with the Text and Key
+        # actions. It works with both X11 keyboard implementations.
+        if not is_text and len(key) == 1:
+            # Get the Unicode code point for the character.
+            code_point = key.encode("unicode_escape")[2:].decode('utf-8')
+
+            # Handle ASCII keys by getting the hex code without '0x'.
+            if not code_point:
+                code_point = hex(ord(key))[2:]
+
+            # Create a key name that xdotool will accept (e.g. U20AC).
+            key = 'U' + code_point.upper()
+        return Typeable(code=key, name=char, is_text=is_text)
 
 
 class XdoKeySymbols(object):

--- a/dragonfly/actions/keyboard/_x11_base.py
+++ b/dragonfly/actions/keyboard/_x11_base.py
@@ -1,0 +1,200 @@
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+
+# This file is based on Aenea's X11 key_press implementations.
+
+from ._base import Typeable as BaseTypeable
+
+
+MODIFIER_KEYS = {
+    'Alt_L', 'Shift_L', 'Control_L', 'Super_L',
+    'Alt_R', 'Shift_R', 'Control_R', 'Super_R'
+}
+
+
+KEY_TRANSLATION = {
+    # Dragonfly references character keys as characters internally.
+    '&': 'ampersand',
+    '*': 'asterisk',
+    '@': 'at',
+    '\\': 'backslash',
+    '`': 'grave',
+    '|': 'bar',
+    '^': 'asciicircum',
+    ':': 'colon',
+    ',': 'comma',
+    '$': 'dollar',
+    '.': 'period',
+    '"': 'quotedbl',
+    '=': 'equal',
+    '!': 'exclam',
+    '#': 'numbersign',
+    '-': 'minus',
+    '<': 'less',
+    '{': 'braceleft',
+    '[': 'bracketleft',
+    '(': 'parenleft',
+    '%': 'percent',
+    '+': 'plus',
+    '?': 'question',
+    '>': 'greater',
+    '}': 'braceright',
+    ']': 'bracketright',
+    ')': 'parenright',
+    ';': 'semicolon',
+    '/': 'slash',
+    "'": 'apostrophe',
+    '~': 'asciitilde',
+    '_': 'underscore',
+    ' ': 'space',
+}
+
+
+def _update_key_translation(translation):
+    caps_keys = [
+        'left',
+        'right',
+        'up',
+        'down',
+        'home',
+        'end',
+        'tab',
+        'insert',
+        'escape'
+        ]
+    caps_keys.extend('f%i' % i for i in range(1, 13))
+    for key in caps_keys:
+        translation[key] = key[0].upper() + key[1:]
+    for index in range(10):
+        translation['np%i' % index] = 'KP_%i' % index
+    letters = tuple(range(ord('a'), ord('z')))
+    digits = tuple(range(ord('0'), ord('9')))
+    for char in letters + digits:
+        translation[chr(char)] = chr(char)
+        translation[chr(char).upper()] = chr(char).upper()
+_update_key_translation(KEY_TRANSLATION)
+
+
+class Typeable(BaseTypeable):
+    """ Typeable class for X11. """
+
+    @classmethod
+    def get_typeable(cls, char, is_text=False):
+        """ Get a Typeable object. """
+        key_name = KEY_TRANSLATION[char]
+        return Typeable(cls, key_name, is_text=is_text)
+
+
+class XdoKeySymbols(object):
+    """ Key symbols for libxdo. """
+
+    # Whitespace and editing keys
+    RETURN = 'Return'
+    TAB = 'Tab'
+    SPACE = 'space'
+    BACK = 'BackSpace'
+    DELETE = 'Delete'
+
+    # Main modifier keys
+    SHIFT = 'Shift_L'
+    CONTROL = 'Control_L'
+    ALT = 'Alt_L'
+
+    # Right modifier keys
+    RSHIFT = 'Shift_R'
+    RCONTROL = 'Control_R'
+    RALT = 'Alt_R'
+
+    # Special keys
+    ESCAPE = 'Escape'
+    INSERT = 'Insert'
+    PAUSE = 'Pause'
+    LSUPER = 'Super_L'
+    RSUPER = 'Super_R'
+    APPS = 'Menu'
+    SNAPSHOT = 'Print'
+
+    # Lock keys
+    SCROLL_LOCK = 'Scroll_Lock'
+    NUM_LOCK = 'Num_Lock'
+    CAPS_LOCK = 'Caps_Lock'
+
+    # Navigation keys
+    UP = 'Up'
+    DOWN = 'Down'
+    LEFT = 'Left'
+    RIGHT = 'Right'
+    PAGE_UP = 'Prior'
+    PAGE_DOWN = 'Next'
+    HOME = 'Home'
+    END = 'End'
+
+    # Number pad keys
+    MULTIPLY = 'KP_Multiply'
+    ADD = 'KP_Add'
+    SEPARATOR = 'KP_Separator'
+    SUBTRACT = 'KP_Subtract'
+    DECIMAL = 'KP_Decimal'
+    DIVIDE = 'KP_Divide'
+
+    # Number pad number keys
+    NUMPAD0 = 'KP_0'
+    NUMPAD1 = 'KP_1'
+    NUMPAD2 = 'KP_2'
+    NUMPAD3 = 'KP_3'
+    NUMPAD4 = 'KP_4'
+    NUMPAD5 = 'KP_5'
+    NUMPAD6 = 'KP_6'
+    NUMPAD7 = 'KP_7'
+    NUMPAD8 = 'KP_8'
+    NUMPAD9 = 'KP_9'
+
+    # Function keys
+    F1 = 'F1'
+    F2 = 'F2'
+    F3 = 'F3'
+    F4 = 'F4'
+    F5 = 'F5'
+    F6 = 'F6'
+    F7 = 'F7'
+    F8 = 'F8'
+    F9 = 'F9'
+    F10 = 'F10'
+    F11 = 'F11'
+    F12 = 'F12'
+    F13 = 'F13'
+    F14 = 'F14'
+    F15 = 'F15'
+    F16 = 'F16'
+    F17 = 'F17'
+    F18 = 'F18'
+    F19 = 'F19'
+    F20 = 'F20'
+    F21 = 'F21'
+    F22 = 'F22'
+    F23 = 'F23'
+    F24 = 'F24'
+
+    # Multimedia keys
+    VOLUME_DOWN = 'XF86AudioLowerVolume'
+    VOLUME_MUTE = 'XF86AudioMute'
+    VOLUME_UP = 'XF86AudioRaiseVolume'
+    MEDIA_PREV_TRACK = 'XF86AudioPrev'
+    MEDIA_NEXT_TRACK = 'XF86AudioNext'
+    MEDIA_PLAY_PAUSE = 'XF86AudioPlay'
+    BROWSER_BACK = 'XF86Back'
+    BROWSER_FORWARD = 'XF86Forward'

--- a/dragonfly/actions/keyboard/_x11_libxdo.py
+++ b/dragonfly/actions/keyboard/_x11_libxdo.py
@@ -24,11 +24,10 @@ import time
 import xdo
 import Xlib.display
 
-from ._base import BaseKeyboard
-from ._x11_base import Typeable, KEY_TRANSLATION
+from ._x11_base import BaseX11Keyboard, KEY_TRANSLATION
 
 
-class LibxdoKeyboard(BaseKeyboard):
+class LibxdoKeyboard(BaseX11Keyboard):
     """Static class for typing keys with python-libxdo."""
 
     _log = logging.getLogger("keyboard")
@@ -58,11 +57,10 @@ class LibxdoKeyboard(BaseKeyboard):
         for event in events:
             (key, down, timeout) = event
             delay_micros = int(timeout * 1000.0)
+            key = KEY_TRANSLATION.get(key, key)
 
             # Press/release the key, catching any errors.
             try:
-                key = KEY_TRANSLATION.get(key, key)
-
                 if down:
                     cls.libxdo.send_keysequence_window_down(0, key, delay_micros)
                 else:
@@ -74,7 +72,3 @@ class LibxdoKeyboard(BaseKeyboard):
             # Sleep after the keyboard event if necessary.
             if timeout:
                 time.sleep(timeout)
-
-    @classmethod
-    def get_typeable(cls, char, is_text=False):
-        return Typeable(char, is_text=is_text)

--- a/dragonfly/actions/keyboard/_x11_libxdo.py
+++ b/dragonfly/actions/keyboard/_x11_libxdo.py
@@ -1,0 +1,80 @@
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+
+# This keyboard implementation is based on Aenea's x11_libxdo.py file.
+
+import logging
+import os
+import time
+
+import xdo
+import Xlib.display
+
+from ._base import BaseKeyboard
+from ._x11_base import Typeable, KEY_TRANSLATION
+
+
+class LibxdoKeyboard(BaseKeyboard):
+    """Static class for typing keys with python-libxdo."""
+
+    _log = logging.getLogger("keyboard")
+    display = Xlib.display.Display()
+    libxdo = xdo.Xdo(os.environ.get('DISPLAY', ''))
+
+    @classmethod
+    def send_keyboard_events(cls, events):
+        """
+        Send a sequence of keyboard events.
+
+        Positional arguments:
+        events -- a sequence of tuples of the form
+            (keycode, down, timeout), where
+                keycode (str): key symbol.
+                down (boolean): True means the key will be pressed down,
+                    False means the key will be released.
+                timeout (int): number of seconds to sleep after
+                    the keyboard event.
+
+        """
+        cls._log.debug("Keyboard.send_keyboard_events %r", events)
+
+        # TODO: We can distill this entire loop down to a single libxdo function
+        # call when we figure out how to properly user charcode_t entities from
+        # libxdo.
+        for event in events:
+            (key, down, timeout) = event
+            delay_micros = int(timeout * 1000.0)
+
+            # Press/release the key, catching any errors.
+            try:
+                key = KEY_TRANSLATION.get(key, key)
+
+                if down:
+                    cls.libxdo.send_keysequence_window_down(0, key, delay_micros)
+                else:
+                    cls.libxdo.send_keysequence_window_up(0, key, delay_micros)
+            except Exception as e:
+                cls._log.exception("Failed to type key code %s: %s",
+                                   key, e)
+
+            # Sleep after the keyboard event if necessary.
+            if timeout:
+                time.sleep(timeout)
+
+    @classmethod
+    def get_typeable(cls, char, is_text=False):
+        return Typeable(char, is_text=is_text)

--- a/dragonfly/actions/keyboard/_x11_xdotool.py
+++ b/dragonfly/actions/keyboard/_x11_xdotool.py
@@ -20,18 +20,10 @@
 import logging
 import subprocess
 
-from ._base import BaseKeyboard
-from ._x11_base import Typeable, KEY_TRANSLATION
+from ._x11_base import BaseX11Keyboard, KEY_TRANSLATION
 
 
-_KEY_PRESSES = {
-    'press': '',
-    'up': 'up',
-    'down': 'down'
-}
-
-
-class XdotoolKeyboard(BaseKeyboard):
+class XdotoolKeyboard(BaseX11Keyboard):
     """Static class for typing keys with xdotool."""
 
     _log = logging.getLogger("keyboard")
@@ -87,7 +79,3 @@ class XdotoolKeyboard(BaseKeyboard):
         except Exception as e:
             cls._log.exception("Failed to execute xdotool command '%s': %s",
                                arguments, e)
-
-    @classmethod
-    def get_typeable(cls, char, is_text=False):
-        return Typeable(char, is_text=is_text)

--- a/dragonfly/actions/keyboard/_x11_xdotool.py
+++ b/dragonfly/actions/keyboard/_x11_xdotool.py
@@ -1,0 +1,93 @@
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+
+# This keyboard implementation is based on Aenea's x11_xdotool.py file.
+
+import logging
+import subprocess
+
+from ._base import BaseKeyboard
+from ._x11_base import Typeable, KEY_TRANSLATION
+
+
+_KEY_PRESSES = {
+    'press': '',
+    'up': 'up',
+    'down': 'down'
+}
+
+
+class XdotoolKeyboard(BaseKeyboard):
+    """Static class for typing keys with xdotool."""
+
+    _log = logging.getLogger("keyboard")
+
+    # xdotool command
+    xdotool = "xdotool"
+
+    @classmethod
+    def send_keyboard_events(cls, events):
+        """
+        Send a sequence of keyboard events.
+
+        Positional arguments:
+        events -- a sequence of tuples of the form
+            (keycode, down, timeout), where
+                keycode (str): key symbol.
+                down (boolean): True means the key will be pressed down,
+                    False means the key will be released.
+                timeout (float): number of seconds to sleep after
+                    the keyboard event.
+
+        """
+        cls._log.debug("Keyboard.send_keyboard_events %r", events)
+
+        # Return early if there are no events (e.g. for Key("")).
+        if not events:
+            return
+
+        arguments = []
+        for event in events:
+            (key, down, timeout) = event
+            key = KEY_TRANSLATION.get(key, key)
+
+            # Add arguments for pressing keys.
+            if down:
+                arguments += ['keydown', key]
+            else:
+                arguments += ['keyup', key]
+
+            # Instruct xdotool to sleep after the keyboard event if
+            # necessary.
+            if timeout:
+                arguments += ['sleep', '%.3f' % timeout]
+
+        # Press/release the keys using xdotool, catching any errors.
+        try:
+            command = [cls.xdotool] + arguments
+            cls._log.debug(' '.join(command))
+            success = subprocess.call(command) > 0
+            if success:
+                raise RuntimeError("xdotool command exited with non-zero "
+                                   "return code %d" % success)
+        except Exception as e:
+            cls._log.exception("Failed to execute xdotool command '%s': %s",
+                               arguments, e)
+
+    @classmethod
+    def get_typeable(cls, char, is_text=False):
+        return Typeable(char, is_text=is_text)

--- a/setup.py
+++ b/setup.py
@@ -60,14 +60,22 @@ setup(
 
       install_requires=[
                         "setuptools >= 0.6c7",
-                        "comtypes;platform_system=='Windows'",
-                        "pywin32;platform_system=='Windows'",
-                        "pynput >= 1.4.2;platform_system!='Windows'",
                         "six",
                         "pyperclip >= 1.7.0",
                         "enum34;python_version<'3.4'",
                         "regex",
                         "decorator",
+
+                        # Windows-only dependencies.
+                        "comtypes;platform_system=='Windows'",
+                        "pywin32;platform_system=='Windows'",
+
+                        # Linux dependencies.
+                        # "python-libxdo;platform_system=='Linux'",
+                        # "Xlib;platform_system=='Linux'",
+
+                        # Mac OS dependencies.
+                        "pynput >= 1.4.2;platform_system=='Darwin'",
 
                         # RPC requirements
                         "json-rpc",


### PR DESCRIPTION
Xdotool should be replacing the current pynput implementation used on Linux. A libxdo implementation has also been added, which is faster than xdotool, but is disabled because it doesn't work properly with Python 3.x. Both of these have been adapted from Aenea's implementations.

This should fix #79 from my testing. Keys are not marked as synthetic any more and keyboard shortcuts seem to be working correctly.

I would like to allow specifying other key symbols and characters through `Key` and `Text`. E.g. `Key("XF86Mail")` and `Text("€", is_text=True)`. Example 2 is already possible on Windows.

I am hoping to use more of Aenea's xdotool implementation for X11 `Mouse` and `Window` classes.

@shervinemami @dwks @GoNZooo @calmofthestorm You all may be interested in this :-)