### PR TITLE
Further Dictation additions

### DIFF
--- a/dragonfly/engines/base/dictation.py
+++ b/dragonfly/engines/base/dictation.py
@@ -111,6 +111,18 @@ class DictationContainerBase(object):
     def __rmul__(self, other):
         return self.__str__() * other
 
+    def __getitem__(self, key):
+        return self.__str__()[key]
+
+    def __nonzero__(self):
+        return bool(self.__str__())
+
+    def __len__(self):
+        return len(self.__str__())
+
+    def __contains__(self, item):
+        return item in self.__str__()
+
     @property
     def words(self):
         """ Sequence of the words forming this dictation. """
@@ -126,5 +138,17 @@ class DictationContainerBase(object):
         """
         result = joined_words
         for method in self._methods:
-            result = getattr(result, method[0])(*method[1], **method[2])
+            if method[0] == "camel":
+                result = result[0] + (
+                    result.title().replace(" ", "")[1:]
+                    if len(result)>1 else "")
+            elif method[0] == "apply":
+                if len(method[1])>0 and callable(method[1][0]):
+                    result = method[1][0](result)
+                else:
+                    raise TypeError("Argument passed to 'Dictation.%s' method must be callable, taking and returning a string." % method[0])
+            elif hasattr(result, method[0]):
+                result = getattr(result, method[0])(*method[1], **method[2])
+            else:
+                raise AttributeError("'%s' is not a valid string method" % method[0])
         return result

--- a/dragonfly/grammar/elements_basic.py
+++ b/dragonfly/grammar/elements_basic.py
@@ -923,8 +923,17 @@ class Dictation(ElementBase):
               the name of this element
 
         Returns a string-like :class:`DictationContainerBase` object containing the recognised words.
-        By default this is formatted as a lowercase sentence, but alternative formatting can be applied by calling string methods
-        like `replace` or `upper` on a :class:`Dictation` object.
+        By default this is formatted as a lowercase sentence.
+        Alternative formatting can be applied by calling string methods like `replace` or `upper` on a :class:`Dictation` object, or
+        by passing an arbitrary formatting function (taking and returning a string) to the `apply` method.
+        Camel case text can be produced using the `camel` method. For example:
+
+        .. code:: python
+
+            str_func = lambda s: s.upper()
+            Dictation("formattedtext").apply(str_func)
+            Dictation("snake_text").lower().replace(" ", "_")
+            Dictation("camelText").camel()
     """
     def __init__(self, name=None, format=True, default=None):
         ElementBase.__init__(self, name, default=default)
@@ -942,6 +951,7 @@ class Dictation(ElementBase):
             self._string_methods.append((name, args, kwargs))
             return self
         return call
+
     #-----------------------------------------------------------------------
     # Methods for load-time setup.
 

--- a/dragonfly/test/test_dictation.py
+++ b/dragonfly/test/test_dictation.py
@@ -127,13 +127,16 @@ class CamelDictationTestCase(ElementTestCase):
 
 class ApplyDictationTestCase(ElementTestCase):
     """ Verify handling of arbitrary formatting applied to Dictation objects using apply() """
-    f = lambda s: "".join("_".join(s.split(" ")[:-1] + [s.split(" ")[-1].upper()]))
+
+    f = lambda self, s: "".join(
+        "_".join(s.split(" ")[:-1] + [s.split(" ")[-1].upper()])
+    )
 
     def _build_element(self):
         def value_func(node, extras):
             return str(extras["text"])
         return Compound("test <text>",
-                        extras=[Dictation(name="text").apply(f)],
+                        extras=[Dictation(name="text").apply(self.f)],
                         value_func=value_func)
 
     input_output = [

--- a/dragonfly/test/test_dictation.py
+++ b/dragonfly/test/test_dictation.py
@@ -94,7 +94,7 @@ class NonAsciiStrDictationTestCase(ElementTestCase):
 
 
 class FormattedDictationTestCase(ElementTestCase):
-    """ Verify handling of formatting applied to Dictation objects """
+    """ Verify handling of string methods applied to Dictation objects """
 
     def _build_element(self):
         def value_func(node, extras):
@@ -106,6 +106,39 @@ class FormattedDictationTestCase(ElementTestCase):
     input_output = [
                     ("test some random dictation", "SOME/RANDOM/DICTATION"),
                     ("test touché jalapeño",       "TOUCHÉ/JALAPEÑO"),
+                   ]
+
+
+class CamelDictationTestCase(ElementTestCase):
+    """ Verify handling of camelCase formatting applied to Dictation objects """
+
+    def _build_element(self):
+        def value_func(node, extras):
+            return str(extras["text"])
+        return Compound("test <text>",
+                        extras=[Dictation(name="text").camel()],
+                        value_func=value_func)
+
+    input_output = [
+                    ("test some random dictation", "someRandomDictation"),
+                    ("test touché jalapeño",       "touchéJalapeño"),
+                   ]
+
+
+class ApplyDictationTestCase(ElementTestCase):
+    """ Verify handling of arbitrary formatting applied to Dictation objects using apply() """
+    f = lambda s: "".join("_".join(s.split(" ")[:-1] + [s.split(" ")[-1].upper()]))
+
+    def _build_element(self):
+        def value_func(node, extras):
+            return str(extras["text"])
+        return Compound("test <text>",
+                        extras=[Dictation(name="text").apply(f)],
+                        value_func=value_func)
+
+    input_output = [
+                    ("test some random dictation", "some_random_DICTATION"),
+                    ("test touché jalapeño",       "touché_JALAPEÑO"),
                    ]
 
 #===========================================================================


### PR DESCRIPTION
Apologies for the second PR on the same thing, but I pretty quickly realised that the functionality I added in the last is somewhat limited and it will bug me if I don't fix it.

I still like the idea of calling methods on Dictation objects to modify the output, but only having access to string methods limits what you can do, for example there is no way (that I can see) to get camel case text using only string methods.

Two additions solve this problem. Firstly since camel case comes up a lot, if the user calls `Dictation().camel()` it will formatTextThisWay in the same way that e.g. `title()` would capitalise it. Secondly, for arbitrary formattings that can't be done using string methods, you can call `Dictation().apply(f)` where f is a function taking a string and returning the formatted version.

I have also implemented a few more passthrough magic methods for `DictationContainer`s and added some error handling, tests and docs.