### PR TITLE
Add additional Window classes and change the old one

### DIFF
--- a/documentation/window_classes.txt
+++ b/documentation/window_classes.txt
@@ -1,0 +1,21 @@
+﻿
+Window classes
+============================================================================
+
+Dragonfly's Window classes are interfaces to the window control and
+placement APIs for the current platform. Currently the Windows and X11
+(Linux) platforms are supported.
+
+The :class:`FakeWindow` class will be used on unsupported platforms.
+
+.. automodule:: dragonfly.windows.base_window
+   :members:
+
+.. automodule:: dragonfly.windows.fake_window
+   :members:
+
+.. automodule:: dragonfly.windows.win32_window
+   :members:
+
+.. automodule:: dragonfly.windows.x11_window
+   :members:

--- a/documentation/windows.txt
+++ b/documentation/windows.txt
@@ -12,3 +12,4 @@ Contents of Dragonfly's windows sub-package:
    :maxdepth: 2
 
    clipboard
+   window_classes

--- a/dragonfly/actions/__init__.py
+++ b/dragonfly/actions/__init__.py
@@ -34,13 +34,13 @@ from .typeables           import typeables
 from .action_key          import Key
 from .action_text         import Text
 from .action_paste        import Paste
+from .action_waitwindow   import WaitWindow
+from .action_focuswindow  import FocusWindow
+from .action_startapp     import StartApp, BringApp
 
 if sys.platform.startswith("win"):
     # Import Windows only classes and functions.
     from .action_mouse        import Mouse
-    from .action_waitwindow   import WaitWindow
-    from .action_focuswindow  import FocusWindow
-    from .action_startapp     import StartApp, BringApp
     from .action_playsound    import PlaySound
     from .sendinput           import (KeyboardInput, MouseInput,
                                       HardwareInput, make_input_array,
@@ -48,7 +48,4 @@ if sys.platform.startswith("win"):
 else:
     # Import mocked classes and functions for other platforms.
     from ..os_dependent_mock import Mouse
-    from ..os_dependent_mock import WaitWindow
-    from ..os_dependent_mock import FocusWindow
-    from ..os_dependent_mock import StartApp, BringApp
     from ..os_dependent_mock import PlaySound

--- a/dragonfly/actions/action_focuswindow.py
+++ b/dragonfly/actions/action_focuswindow.py
@@ -25,9 +25,8 @@ FocusWindow action
 """
 
 
-import win32con
 from .action_base      import ActionBase, ActionError
-from ..windows.window  import Window
+from ..windows  import Window
 
 
 #---------------------------------------------------------------------------

--- a/dragonfly/actions/action_focuswindow.py
+++ b/dragonfly/actions/action_focuswindow.py
@@ -24,8 +24,6 @@ FocusWindow action
 
 """
 
-import os
-
 from .action_base      import ActionBase, ActionError
 from ..windows  import Window
 
@@ -67,27 +65,9 @@ class FocusWindow(ActionBase):
             if executable:  executable = (executable % data).lower()
             if title:       title = (title % data).lower()
 
-        windows = Window.get_all_windows()
-        for window in windows:
-            if not window.is_visible:
-                continue
-            if (os.name == 'nt'
-                and window.executable.endswith("natspeak.exe")
-                and window.classname == "#32770"
-                and window.get_position().dy < 50):
-                # If a window matches the above, it is very probably
-                #  the results-box of DNS.  We ignore this because
-                #  its title is the words of the last recognition,
-                #  which will often interfere with a search for
-                #  a window with a spoken title.
-                continue
-
-            if executable:
-                if window.executable.lower().find(executable) == -1:
-                    continue
-            if title:
-                if window.title.lower().find(title) == -1:
-                    continue
-            window.set_foreground()
-            return
-        raise ActionError("Failed to find window (%s)."  % self._str)
+        # Get the first matching window and bring it to the foreground.
+        windows = Window.get_matching_windows(executable, title)
+        if windows:
+            windows[0].set_foreground()
+        else:
+            raise ActionError("Failed to find window (%s)." % self._str)

--- a/dragonfly/actions/action_focuswindow.py
+++ b/dragonfly/actions/action_focuswindow.py
@@ -24,6 +24,7 @@ FocusWindow action
 
 """
 
+import os
 
 from .action_base      import ActionBase, ActionError
 from ..windows  import Window
@@ -70,7 +71,8 @@ class FocusWindow(ActionBase):
         for window in windows:
             if not window.is_visible:
                 continue
-            if (window.executable.endswith("natspeak.exe")
+            if (os.name == 'nt'
+                and window.executable.endswith("natspeak.exe")
                 and window.classname == "#32770"
                 and window.get_position().dy < 50):
                 # If a window matches the above, it is very probably

--- a/dragonfly/actions/action_waitwindow.py
+++ b/dragonfly/actions/action_waitwindow.py
@@ -26,9 +26,9 @@ WaitWindow action
 
 
 import time
-import win32con
+
 from dragonfly.actions.action_base import ActionBase, ActionError
-from dragonfly.windows.window import Window
+from ..windows import Window
 
 
 #---------------------------------------------------------------------------

--- a/dragonfly/actions/actions.py
+++ b/dragonfly/actions/actions.py
@@ -36,18 +36,15 @@ from .keyboard            import Keyboard, Typeable
 from .action_key          import Key
 from .action_text         import Text
 from .action_paste        import Paste
+from .action_waitwindow   import WaitWindow
+from .action_focuswindow  import FocusWindow
+from .action_startapp     import StartApp, BringApp
 
 if sys.platform.startswith("win"):
     # Import Windows only classes and functions.
     from .action_mouse        import Mouse
-    from .action_waitwindow   import WaitWindow
-    from .action_focuswindow  import FocusWindow
-    from .action_startapp     import StartApp, BringApp
     from .action_playsound    import PlaySound
 else:
     # Import mocked classes and functions for other platforms.
     from ..os_dependent_mock import Mouse
-    from ..os_dependent_mock import WaitWindow
-    from ..os_dependent_mock import FocusWindow
-    from ..os_dependent_mock import StartApp, BringApp
     from ..os_dependent_mock import PlaySound

--- a/dragonfly/actions/keyboard/_x11_xdotool.py
+++ b/dragonfly/actions/keyboard/_x11_xdotool.py
@@ -69,13 +69,14 @@ class XdotoolKeyboard(BaseX11Keyboard):
                 arguments += ['sleep', '%.3f' % timeout]
 
         # Press/release the keys using xdotool, catching any errors.
+        command = [cls.xdotool] + arguments
+        readable_command = ' '.join(command)
+        cls._log.debug(readable_command)
         try:
-            command = [cls.xdotool] + arguments
-            cls._log.debug(' '.join(command))
-            success = subprocess.call(command) > 0
-            if success:
+            return_code = subprocess.call(command)
+            if return_code > 0:
                 raise RuntimeError("xdotool command exited with non-zero "
-                                   "return code %d" % success)
+                                   "return code %d" % return_code)
         except Exception as e:
-            cls._log.exception("Failed to execute xdotool command '%s': %s",
-                               arguments, e)
+            cls._log.exception("Failed to execute xdotool command '%s': "
+                               "%s", readable_command, e)

--- a/dragonfly/os_dependent_mock.py
+++ b/dragonfly/os_dependent_mock.py
@@ -41,11 +41,9 @@ class Mouse(DynStrActionBase):
         DynStrActionBase.__init__(self, spec, static)
 
 
-WaitWindow = MockAction
-FocusWindow = MockAction
-StartApp = MockAction
-BringApp = MockAction
-PlaySound = MockAction
+class PlaySound(ActionBase):
+    def __init__(self, name=None, file=None):
+        ActionBase.__init__(self)
 
 
 class _WindowInfo(object):

--- a/dragonfly/os_dependent_mock.py
+++ b/dragonfly/os_dependent_mock.py
@@ -46,18 +46,6 @@ class PlaySound(ActionBase):
         ActionBase.__init__(self)
 
 
-class _WindowInfo(object):
-    executable = ""
-    title = ""
-    handle = ""
-
-
-class Window(object):
-    @staticmethod
-    def get_foreground():
-        return _WindowInfo
-
-
 monitors = []
 
 

--- a/dragonfly/test/suites.py
+++ b/dragonfly/test/suites.py
@@ -44,17 +44,13 @@ common_names = [
     "test_parser",
     "test_rpc",
     "test_timer",
+    "test_window",
     "doc:documentation/test_action_base_doctest.txt",
     "doc:documentation/test_grammar_elements_basic_doctest.txt",
     "doc:documentation/test_grammar_elements_compound_doctest.txt",
     "doc:documentation/test_grammar_list_doctest.txt",
     "doc:documentation/test_recobs_doctest.txt",
 ]
-
-# Only include common Windows-only tests on Windows.
-if os.name == "nt":
-    common_names.extend(["test_window", "test_actions"])
-
 
 # Define spoken language test files. All of them work with the natlink and
 # text engines. The English tests should work with sapi5 and sphinx by

--- a/dragonfly/windows/__init__.py
+++ b/dragonfly/windows/__init__.py
@@ -20,15 +20,17 @@
 
 import sys
 
-from .rectangle import Rectangle, unit
-from .point     import Point
+# Import classes that work on all platforms.
+from .rectangle   import Rectangle, unit
+from .point       import Point
+from .window      import Window
+from .fake_window import FakeWindow
 
 # Windows-specific
 if sys.platform.startswith("win"):
-    from .window    import Window
-    from .monitor   import Monitor, monitors
-    from .clipboard import Clipboard
-else:  # Mock imports
-    from ..os_dependent_mock      import Window
-    from ..os_dependent_mock      import Monitor, monitors
-    from ..util import Clipboard
+    from .monitor      import Monitor, monitors
+    from .clipboard    import Clipboard
+
+# Import mock classes.
+else:
+    from ..os_dependent_mock import Monitor, monitors

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -1,0 +1,224 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+Base Window class
+============================================================================
+
+"""
+
+from six import string_types, integer_types
+
+from .window_movers import window_movers
+
+#===========================================================================
+
+
+class BaseWindow(object):
+    """
+        The base Window class for controlling and placing windows.
+
+    """
+
+    #-----------------------------------------------------------------------
+    # Class attributes to retrieve existing Window objects.
+
+    _windows_by_name = {}
+    _windows_by_id = {}
+
+    #-----------------------------------------------------------------------
+    # Class methods to create new Window objects.
+
+    @classmethod
+    def get_foreground(cls):
+        """ Get the foreground window. """
+        raise NotImplementedError()
+
+    @classmethod
+    def get_all_windows(cls):
+        """ Get a list of all windows. """
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    def __init__(self, id):
+        self._id = None
+        self.id = id
+        self._names = set()
+
+    def __str__(self):
+        args = list(self._names)
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
+
+    #-----------------------------------------------------------------------
+    # Methods that control attribute access.
+
+    @property
+    def id(self):
+        """ Protected access to id attribute. """
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        self._set_id(value)
+
+    def _set_id(self, id):
+        if not isinstance(id, integer_types):
+            raise TypeError("Window id/handle must be integer or long,"
+                            " but received {0!r}".format(id))
+        self._id = id
+        self._windows_by_id[id] = self
+
+    # The 'handle' and '_handle' attributes have been kept in for backwards-
+    # compatibility. They just reference the BaseWindow 'id' property.
+
+    handle = property(fget=lambda self: self._id,
+                      fset=_set_id,
+                      doc="Protected access to handle attribute.")
+    _handle = property(fget=lambda self: self._id)
+
+    def _get_name(self):
+        if not self._names:
+            return None
+        for name in self._names:
+            return name
+
+    def _set_name(self, name):
+        assert isinstance(name, string_types)
+        self._names.add(name)
+        self._windows_by_name[name] = self
+
+    name = property(fget=_get_name,
+                    fset=_set_name,
+                    doc="Protected access to name attribute.")
+
+    #-----------------------------------------------------------------------
+    # Methods and properties for window attributes.
+
+    def _get_window_text(self):
+        # Method to get the window title.
+        raise NotImplementedError()
+
+    def _get_class_name(self):
+        # Method to get the window class name.
+        raise NotImplementedError()
+
+    def _get_window_module(self):
+        # Method to get the window executable.
+        raise NotImplementedError()
+
+    @property
+    def title(self):
+        """ Read-only access to the window's title. """
+        return self._get_window_text()
+
+    @property
+    def classname(self):
+        """ Read-only access to the window's class name. """
+        return self._get_class_name()
+
+    #: Alias of :attr:`classname`.
+    cls_name = classname
+
+    @property
+    def executable(self):
+        """ Read-only access to the window's executable. """
+        return self._get_window_module()
+
+    @property
+    def is_minimized(self):
+        """ Whether the window is currently minimized. """
+        raise NotImplementedError()
+
+    @property
+    def is_maximized(self):
+        """ Whether the window is currently maximized. """
+        raise NotImplementedError()
+
+    @property
+    def is_visible(self):
+        """
+        Whether the window is currently visible.
+
+        This may be indeterminable for some windows.
+        """
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+    # Methods related to window geometry.
+
+    def get_position(self):
+        """
+        Method to get the window's position as a :class:`Rectangle` object.
+
+        :returns: window position
+        :rtype: Rectangle
+        """
+        raise NotImplementedError()
+
+    def set_position(self, rectangle):
+        """
+        Method to set the window's position using a :class:`Rectangle`
+        object.
+
+        :param rectangle: window position
+        :type rectangle: Rectangle
+        """
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+    # Methods for miscellaneous window control.
+
+    def minimize(self):
+        """ Minimize the window (if possible). """
+        raise NotImplementedError()
+
+    def maximize(self):
+        """ Maximize the window (if possible). """
+        raise NotImplementedError()
+
+    def restore(self):
+        """ Restore the window if it is minimized or maximized. """
+        raise NotImplementedError()
+
+    def set_foreground(self):
+        """ Set the window as the foreground (active) window. """
+        raise NotImplementedError()
+
+    def move(self, rectangle, animate=None):
+        """
+        Move the window, optionally animating its movement.
+
+        :param rectangle: new window position and size
+        :param animate: name of window mover
+        :type rectangle: Rectangle
+        :type animate: str
+        """
+        if not animate:
+            self.set_position(rectangle)
+        else:
+            try:
+                window_mover = window_movers[animate]
+            except KeyError:
+                # If the given window mover name isn't found, don't animate.
+                self.set_position(rectangle)
+            else:
+                window_mover.move_window(self, self.get_position(), rectangle)

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -47,9 +47,51 @@ class BaseWindow(object):
     # Class methods to create new Window objects.
 
     @classmethod
+    def get_window(cls, id):
+        """
+        Get a :class:`Window` object given a window id.
+
+        Given the same id, this method will return the same object.
+        """
+        if id in cls._windows_by_id:
+            window = cls._windows_by_id[id]
+        else:
+            window = cls(id)
+            cls._windows_by_id[id] = window
+        return window
+
+    @classmethod
     def get_foreground(cls):
         """ Get the foreground window. """
         raise NotImplementedError()
+
+    @classmethod
+    def get_matching_windows(cls, executable=None, title=None):
+        """
+        Find windows with a matching executable or title.
+
+        If neither parameter is be specified, then it is effectively the
+        same as calling :meth:`get_all_windows`.
+
+        :param executable: -- part of the filename of the application's
+           executable to which the target window belongs; not case
+           sensitive.
+        :param title: -- part of the title of the target window; not case
+           sensitive.
+        :type executable: str
+        :type title: str
+        :rtype: list
+        """
+        matching = []
+        for window in cls.get_all_windows():
+            if executable:
+                if window.executable.lower().find(executable) == -1:
+                    continue
+            if title:
+                if window.title.lower().find(title) == -1:
+                    continue
+            matching.append(window)
+        return matching
 
     @classmethod
     def get_all_windows(cls):

--- a/dragonfly/windows/fake_window.py
+++ b/dragonfly/windows/fake_window.py
@@ -1,0 +1,91 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+from .base_window import BaseWindow
+from .rectangle import Rectangle
+
+
+class FakeWindow(BaseWindow):
+    """ Fake Window class used when no implementation is available. """
+
+    fake_title = ''
+    fake_classname = ''
+    fake_executable = ''
+
+    @classmethod
+    def get_foreground(cls):
+        return FakeWindow(id=0)
+
+    def __init__(self, id):
+        super(FakeWindow, self).__init__(id)
+        self._rectangle = Rectangle()
+
+    @classmethod
+    def get_all_windows(cls):
+        return []
+
+    #-----------------------------------------------------------------------
+    # Methods and properties for window attributes.
+
+    def _get_window_text(self):
+        return self.fake_title
+
+    def _get_class_name(self):
+        return self.fake_classname
+
+    def _get_window_module(self):
+        return self.fake_executable
+
+    @property
+    def is_minimized(self):
+        return False
+
+    @property
+    def is_maximized(self):
+        return False
+
+    @property
+    def is_visible(self):
+        return True
+
+    #-----------------------------------------------------------------------
+    # Methods related to window geometry.
+
+    def get_position(self):
+        return self._rectangle
+
+    def set_position(self, rectangle):
+        assert isinstance(rectangle, Rectangle)
+        self._rectangle = rectangle
+
+    #-----------------------------------------------------------------------
+    # Methods for miscellaneous window control.
+
+    def minimize(self):
+        pass
+
+    def maximize(self):
+        pass
+
+    def restore(self):
+        pass
+
+    def set_foreground(self):
+        pass

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -24,6 +24,8 @@ Window class for Windows
 
 """
 
+import os
+
 import win32gui
 import win32con
 from ctypes          import windll, pointer, c_wchar, c_ulong
@@ -60,6 +62,33 @@ class Win32Window(BaseWindow):
         argument = []
         win32gui.EnumWindows(function, argument)
         return argument
+
+    @classmethod
+    def get_matching_windows(cls, executable=None, title=None):
+        matching = []
+        for window in cls.get_all_windows():
+            if not window.is_visible:
+                continue
+            if (os.name == 'nt'
+                    and window.executable.endswith("natspeak.exe")
+                    and window.classname == "#32770"
+                    and window.get_position().dy < 50):
+                # If a window matches the above, it is very probably
+                #  the results-box of DNS.  We ignore this because
+                #  its title is the words of the last recognition,
+                #  which will often interfere with a search for
+                #  a window with a spoken title.
+                continue
+
+            if executable:
+                if window.executable.lower().find(executable) == -1:
+                    continue
+            if title:
+                if window.title.lower().find(title) == -1:
+                    continue
+            matching.append(window)
+
+        return matching
 
 #    @classmethod
 #    def get_window_by_executable(cls, executable):

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -1,0 +1,191 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+Window class for Windows
+============================================================================
+
+"""
+
+import win32gui
+import win32con
+from ctypes          import windll, pointer, c_wchar, c_ulong
+
+from .base_window    import BaseWindow
+from .rectangle      import Rectangle, unit
+from .monitor        import monitors
+
+
+#===========================================================================
+
+class Win32Window(BaseWindow):
+    """
+        The Window class is an interface to the Win32 window control
+        and placement.
+
+    """
+
+    #-----------------------------------------------------------------------
+    # Class methods to create new Window objects.
+
+    @classmethod
+    def get_foreground(cls):
+        handle = win32gui.GetForegroundWindow()
+        if handle in cls._windows_by_id:
+            return cls._windows_by_id[handle]
+        window = Win32Window(handle=handle)
+        return window
+
+    @classmethod
+    def get_all_windows(cls):
+        def function(handle, argument):
+            argument.append(Win32Window(handle))
+        argument = []
+        win32gui.EnumWindows(function, argument)
+        return argument
+
+#    @classmethod
+#    def get_window_by_executable(cls, executable):
+#        def function(handle, argument):
+#            title = windll.user32.GetWindowText(handle)
+#            print "title: %r" % title
+#        windll.user32.EnumWindows(function, argument)
+
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    def __init__(self, handle):
+        super(Win32Window, self).__init__(id=handle)
+
+    def __str__(self):
+        args = ["handle=%d" % self.handle] + list(self._names)
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
+
+    #-----------------------------------------------------------------------
+    # Direct access to various Win32 methods.
+
+    def _win32gui_func(name):
+        func = getattr(win32gui, name)
+        return lambda self: func(self._handle)
+
+    _get_rect           = _win32gui_func("GetWindowRect")
+    _destroy            = _win32gui_func("DestroyWindow")
+    _set_foreground     = _win32gui_func("SetForegroundWindow")
+    _bring_to_top       = _win32gui_func("BringWindowToTop")
+    _get_window_text    = _win32gui_func("GetWindowText")
+    _get_class_name     = _win32gui_func("GetClassName")
+
+    def _win32gui_test(name):
+        test = getattr(win32gui, name)
+        fget = lambda self: test(self._handle) and True or False
+        return property(fget=fget,
+                        doc="Shortcut to win32gui.%s() function." % name)
+
+    is_valid        = _win32gui_test("IsWindow")
+    is_enabled      = _win32gui_test("IsWindowEnabled")
+    is_visible      = _win32gui_test("IsWindowVisible")
+    is_minimized    = _win32gui_test("IsIconic")
+#   is_maximized    = _win32gui_test("IsZoomed")  # IsZoomed is unavailable
+
+    def _win32gui_show_window(state):
+        return lambda self: win32gui.ShowWindow(self._handle, state)
+
+    minimize        = _win32gui_show_window(win32con.SW_MINIMIZE)
+    maximize        = _win32gui_show_window(win32con.SW_MAXIMIZE)
+    restore         = _win32gui_show_window(win32con.SW_RESTORE)
+
+    def _get_window_module(self):
+        # Get this window's process ID.
+        pid = c_ulong()
+        windll.user32.GetWindowThreadProcessId(self._handle, pointer(pid))
+
+        # Get the process handle of this window's process ID.
+        #  Access permission flags:
+        #  0x0410 = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ
+        handle = windll.kernel32.OpenProcess(0x0410, 0, pid)
+
+        # Retrieve and return the process's executable path.
+        try:
+            # Try to use the QueryForProcessImageNameW function
+            #  available since Windows Vista.
+            buffer_len = c_ulong(256)
+            buffer = (c_wchar * buffer_len.value)()
+            windll.kernel32.QueryFullProcessImageNameW(handle, 0,
+                                                       pointer(buffer),
+                                                       pointer(buffer_len))
+            buffer = buffer[:]
+            buffer = buffer[:buffer.index("\0")]
+        except Exception:
+            # If the function above failed, fall back to the older
+            #  GetModuleFileNameEx function, available since windows XP.
+            #  Note that this fallback function seems to fail when
+            #  this process is 32 bit Python and handle refers to a
+            #  64-bit process.
+            buffer_len = 256
+            buffer = (c_wchar * buffer_len)()
+            windll.psapi.GetModuleFileNameExW(handle, 0, pointer(buffer),
+                                              buffer_len)
+            buffer = buffer[:]
+            buffer = buffer[:buffer.index("\0")]
+        finally:
+            windll.kernel32.CloseHandle(handle)
+
+        return str(buffer)
+
+    #-----------------------------------------------------------------------
+    # Methods related to window geometry.
+
+    def get_position(self):
+        l, t, r, b = self._get_rect()
+        w = r - l; h = b - t
+        return Rectangle(l, t, w, h)
+
+    def set_position(self, rectangle):
+        assert isinstance(rectangle, Rectangle)
+        l, t, w, h = rectangle.ltwh
+        win32gui.MoveWindow(self._handle, l, t, w, h, 1)
+
+    def get_containing_monitor(self):
+        center = self.get_position().center
+        for monitor in monitors:
+            if monitor.rectangle.contains(center):
+                return monitor
+        # Fall through, return first monitor.
+        return monitors[0]
+
+    def get_normalized_position(self):
+        monitor = self.get_containing_monitor()
+        rectangle = self.get_position()
+        rectangle.renormalize(monitor.rectangle, unit)
+        return rectangle
+
+    def set_normalized_position(self, rectangle, monitor=None):
+        if not monitor: monitor = self.get_containing_monitor()
+        rectangle.renormalize(unit, monitor.rectangle)
+        self.set_position(rectangle)
+
+    #-----------------------------------------------------------------------
+    # Methods for miscellaneous window control.
+
+    def set_foreground(self):
+        if self.is_minimized:
+            self.restore()
+        self._set_foreground()

--- a/dragonfly/windows/window.py
+++ b/dragonfly/windows/window.py
@@ -3,245 +3,32 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
-"""
-Window class
-============================================================================
+import sys
+import os
 
-"""
-from six import string_types, integer_types
+# Windows-specific
+if sys.platform.startswith("win"):
+    from .win32_window import Win32Window as Window
 
-import win32gui
-import win32con
-from ctypes          import windll, pointer, c_wchar, c_ulong
+# Linux/X11
+elif os.environ.get("XDG_SESSION_TYPE") == "x11":
+    from .x11_window import X11Window as Window
 
-from .rectangle      import Rectangle, unit
-from .monitor        import monitors
-from .window_movers  import window_movers
-
-
-#===========================================================================
-
-class Window(object):
-    """
-        The Window class is an interface to the Win32 window control
-        and placement.
-
-    """
-
-    #-----------------------------------------------------------------------
-    # Class attributes to retrieve existing Window objects.
-
-    _windows_by_name = {}
-    _windows_by_handle = {}
-
-    #-----------------------------------------------------------------------
-    # Class methods to create new Window objects.
-
-    @classmethod
-    def get_foreground(cls):
-        handle = win32gui.GetForegroundWindow()
-        if handle in cls._windows_by_handle:
-            return cls._windows_by_handle[handle]
-        window = Window(handle=handle)
-        return window
-
-    @classmethod
-    def get_all_windows(cls):
-        def function(handle, argument):
-            argument.append(Window(handle))
-        argument = []
-        win32gui.EnumWindows(function, argument)
-        return argument
-
-#    @classmethod
-#    def get_window_by_executable(cls, executable):
-#        def function(handle, argument):
-#            title = windll.user32.GetWindowText(handle)
-#            print "title: %r" % title
-#        windll.user32.EnumWindows(function, argument)
-
-
-    #=======================================================================
-    # Methods for initialization and introspection.
-
-    def __init__(self, handle):
-        self._handle = None
-        self._names = set()
-        self.handle = handle
-
-    def __str__(self):
-        args = ["handle=%d" % self._handle] + list(self._names)
-        return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
-
-    #-----------------------------------------------------------------------
-    # Methods that control attribute access.
-
-    def _set_handle(self, handle):
-        if not isinstance(handle, integer_types):
-            raise TypeError("Window handle must be integer or long,"
-                            " but received {0!r}".format(handle))
-        self._handle = handle
-        self._windows_by_handle[handle] = self
-    handle = property(fget=lambda self: self._handle,
-                      fset=_set_handle,
-                      doc="Protected access to handle attribute.")
-
-    def _get_name(self):
-        if not self._names:
-            return None
-        for name in self._names:
-            return name
-    def _set_name(self, name):
-        assert isinstance(name, string_types)
-        self._names.add(name)
-        self._windows_by_name[name] = self
-    name = property(fget=_get_name,
-                    fset=_set_name,
-                    doc="Protected access to name attribute.")
-
-    #-----------------------------------------------------------------------
-    # Direct access to various Win32 methods.
-
-    def _win32gui_func(name):
-        func = getattr(win32gui, name)
-        return lambda self: func(self._handle)
-
-    _get_rect           = _win32gui_func("GetWindowRect")
-    _destroy            = _win32gui_func("DestroyWindow")
-    _set_foreground     = _win32gui_func("SetForegroundWindow")
-    _bring_to_top       = _win32gui_func("BringWindowToTop")
-    _get_window_text    = _win32gui_func("GetWindowText")
-    _get_class_name     = _win32gui_func("GetClassName")
-
-    title               = property(fget=_get_window_text)
-    classname           = property(fget=_get_class_name)
-
-
-    def _win32gui_test(name):
-        test = getattr(win32gui, name)
-        fget = lambda self: test(self._handle) and True or False
-        return property(fget=fget,
-                        doc="Shortcut to win32gui.%s() function." % name)
-
-    is_valid        = _win32gui_test("IsWindow")
-    is_enabled      = _win32gui_test("IsWindowEnabled")
-    is_visible      = _win32gui_test("IsWindowVisible")
-    is_minimized    = _win32gui_test("IsIconic")
-#   is_maximized    = _win32gui_test("IsZoomed")
-
-
-    def _win32gui_show_window(state):
-        return lambda self: win32gui.ShowWindow(self._handle, state)
-
-    minimize        = _win32gui_show_window(win32con.SW_MINIMIZE)
-    maximize        = _win32gui_show_window(win32con.SW_MAXIMIZE)
-    restore         = _win32gui_show_window(win32con.SW_RESTORE)
-
-
-    def _get_window_module(self):
-        # Get this window's process ID.
-        pid = c_ulong()
-        windll.user32.GetWindowThreadProcessId(self._handle, pointer(pid))
-
-        # Get the process handle of this window's process ID.
-        #  Access permission flags:
-        #  0x0410 = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ
-        handle = windll.kernel32.OpenProcess(0x0410, 0, pid)
-
-        # Retrieve and return the process's executable path.
-        try:
-            # Try to use the QueryForProcessImageNameW function
-            #  available since Windows Vista.
-            buffer_len = c_ulong(256)
-            buffer = (c_wchar * buffer_len.value)()
-            windll.kernel32.QueryFullProcessImageNameW(handle, 0,
-                                                       pointer(buffer),
-                                                       pointer(buffer_len))
-            buffer = buffer[:]
-            buffer = buffer[:buffer.index("\0")]
-        except Exception:
-            # If the function above failed, fall back to the older
-            #  GetModuleFileNameEx function, available since windows XP.
-            #  Note that this fallback function seems to fail when
-            #  this process is 32 bit Python and handle refers to a
-            #  64-bit process.
-            buffer_len = 256
-            buffer = (c_wchar * buffer_len)()
-            windll.psapi.GetModuleFileNameExW(handle, 0, pointer(buffer),
-                                              buffer_len)
-            buffer = buffer[:]
-            buffer = buffer[:buffer.index("\0")]
-        finally:
-            windll.kernel32.CloseHandle(handle)
-
-        return str(buffer)
-
-    executable = property(fget=_get_window_module)
-
-
-    #-----------------------------------------------------------------------
-    # Methods related to window geometry.
-
-    def get_position(self):
-        l, t, r, b = self._get_rect()
-        w = r - l; h = b - t
-        return Rectangle(l, t, w, h)
-
-    def set_position(self, rectangle):
-        assert isinstance(rectangle, Rectangle)
-        l, t, w, h = rectangle.ltwh
-        win32gui.MoveWindow(self._handle, l, t, w, h, 1)
-
-    def get_containing_monitor(self):
-        center = self.get_position().center
-        for monitor in monitors:
-            if monitor.rectangle.contains(center):
-                return monitor
-        # Fall through, return first monitor.
-        return monitors[0]
-
-    def get_normalized_position(self):
-        monitor = self.get_containing_monitor()
-        rectangle = self.get_position()
-        rectangle.renormalize(monitor.rectangle, unit)
-        return rectangle
-
-    def set_normalized_position(self, rectangle, monitor=None):
-        if not monitor: monitor = self.get_containing_monitor()
-        rectangle.renormalize(unit, monitor.rectangle)
-        self.set_position(rectangle)
-
-    #-----------------------------------------------------------------------
-    # Methods for miscellaneous window control.
-
-    def set_foreground(self):
-        if self.is_minimized:
-            self.restore()
-        self._set_foreground()
-
-    def move(self, rectangle, animate=None):
-        if not animate:
-            self.set_position(rectangle)
-        else:
-            try:
-                window_mover = window_movers[animate]
-            except KeyError:
-                # If the given window mover name isn't found, don't animate.
-                self.set_position(rectangle)
-            else:
-                window_mover.move_window(self, self.get_position(), rectangle)
+# Unsupported
+else:
+    from .fake_window import FakeWindow as Window

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -363,9 +363,11 @@ class X11Window(BaseWindow):
         return Rectangle(geo['x'], geo['y'], geo['width'], geo['height'])
 
     def set_position(self, rectangle):
-        l, t, _, _ = rectangle.ltwh
+        l, t, w, h = rectangle.ltwh
+        id = self.id
         self._run_xdotool_command(
-            ['windowmove', '%i' % self.id, '%i' % l, '%i' % t])
+            ['windowmove', id, l, t,
+             'windowsize', id, w, h])
 
     #-----------------------------------------------------------------------
     # Methods for miscellaneous window control.

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -1,0 +1,383 @@
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+
+# Heavily modified from Aenea's xdotool implementation for X11.
+
+"""
+Window class for X11
+============================================================================
+
+"""
+
+import logging
+from subprocess import Popen, PIPE
+
+import psutil
+from six import binary_type
+
+from .base_window import BaseWindow
+from .rectangle import Rectangle
+
+
+_XPROP_PROPERTIES = {
+    '_NET_WM_DESKTOP(CARDINAL)': 'desktop',
+    'WM_WINDOW_ROLE(STRING)': 'role',
+    '_NET_WM_WINDOW_TYPE(ATOM)': 'type',
+    '_NET_WM_PID(CARDINAL)': 'pid',
+    'WM_NAME(STRING)': 'name',
+    '_NET_WM_STATE(ATOM)': 'state',
+}
+
+
+class X11Window(BaseWindow):
+    """
+        The Window class is an interface to the window control and
+        placement APIs for X11.
+
+    """
+
+    _log = logging.getLogger("window")
+
+    #-----------------------------------------------------------------------
+    # Methods and attributes for running commands.
+
+    # Commands
+    xdotool = "xdotool"
+    xprop = "xprop"
+
+    @classmethod
+    def _run_xdotool_command(cls, arguments, error_on_failure=True):
+        return cls._run_command(cls.xdotool, arguments, error_on_failure)
+
+    @classmethod
+    def _run_xprop_command(cls, arguments, error_on_failure=True):
+        return cls._run_command(cls.xprop, arguments, error_on_failure)
+
+    @classmethod
+    def _run_command(cls, command, arguments, error_on_failure=True):
+        """
+        Run a command with arguments and return the result.
+
+        :param command: command to run
+        :type command: str
+        :param arguments: arguments to append
+        :type arguments: list
+        :returns: stdout, stderr, return_code
+        :rtype: tuple
+        """
+        full_command = [command] + arguments
+        full_readable_command = ' '.join(full_command)
+        cls._log.debug(full_readable_command)
+        try:
+            p = Popen(full_command, stdout=PIPE, stderr=PIPE)
+            stdout, stderr = p.communicate()
+
+            # Decode output if it is binary.
+            if isinstance(stdout, binary_type):
+                stdout = stdout.decode('utf-8')
+            if isinstance(stderr, binary_type):
+                stderr = stderr.decode('utf-8')
+
+            # Handle non-zero return codes.
+            if p.wait() > 0 and error_on_failure:
+                print(stdout)
+                print(stderr)
+                raise RuntimeError("%s command exited with non-zero return"
+                                   " code %d" % (command, p.returncode))
+
+            # Return the process output and return code.
+            return stdout.rstrip(), stderr.rstrip(), p.returncode
+        except Exception as e:
+            cls._log.error("Failed to execute command '%s': %s",
+                           full_readable_command, e)
+
+    #-----------------------------------------------------------------------
+    # Class methods to create new Window objects.
+
+    @classmethod
+    def get_foreground(cls):
+        window_id, _, _ = cls._run_xdotool_command(["getactivewindow"])
+        window_id = int(window_id)
+        if window_id in cls._windows_by_id:
+            return cls._windows_by_id[window_id]
+        return X11Window(window_id)
+
+    @classmethod
+    def get_all_windows(cls):
+        # Get all window IDs using 'xdotool search' and return new or
+        # existing Window objects.
+        result = []
+        output, _, _ = cls._run_xdotool_command(['search', '--name', ''])
+        for line in output.split('\n'):
+            window_id = int(line)
+            if window_id in cls._windows_by_id:
+                result.append(cls._windows_by_id[window_id])
+            else:
+                result.append(X11Window(window_id))
+        return result
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    def __init__(self, id):
+        super(X11Window, self).__init__(id=id)
+        self._pid = -1  # initialized later if required
+        self._executable = -1
+
+    def __str__(self):
+        args = ["id=%d" % self._id] + list(self._names)
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(args))
+
+    #-----------------------------------------------------------------------
+    # Methods and properties for window attributes.
+
+    def _get_property_from_xprop(self, property):
+        properties = {}
+        output, _, return_code = self._run_xprop_command(
+            ['-id', '%i' % self.id], False)
+        if return_code > 0:
+            return None
+        for line in output.split('\n'):
+            line = line.split(' = ', 1)
+            if len(line) == 2:
+                raw_key, value = line
+                if raw_key in _XPROP_PROPERTIES:
+                    if '(STRING)' in raw_key:
+                        property_value = value[1:-1]
+                    else:
+                        property_value = value
+                    property_name = _XPROP_PROPERTIES[raw_key]
+                    properties[property_name] = property_value
+                elif raw_key == 'WM_CLASS(STRING)':
+                    window_class_name, window_class = value.split('", "')
+                    properties['cls_name'] = window_class_name[1:]
+                    properties['cls'] = window_class[:-1]
+
+        # Return the requested property.
+        result = properties.get(property, None)
+        if result is None:
+            self._log.debug('window has no "%s" property' % property)
+        return result
+
+    def _get_window_text(self):
+        # Get the title text.
+        args = ['getwindowname', '%i' % self.id]
+        return self._run_xdotool_command(args)[0]
+
+    def _get_class_name(self):
+        return self._get_property_from_xprop("cls_name") or ''
+
+    @property
+    def cls(self):
+        """ Read-only access to the window's class. """
+        return self._get_property_from_xprop("cls") or ''
+
+    @property
+    def pid(self):
+        """
+        Read-only access to the window's process ID.
+
+        This will be the PID of the window's process, not any subprocess.
+
+        If the window has no associated process id, this will return
+        ``None``.
+
+        :returns: pid
+        :rtype: int | None
+        """
+        # Set the pid once when it is needed.
+        if self._pid == -1:
+            pid, _, return_code = self._run_xdotool_command(
+                ['getwindowpid', '%i' % self.id], False)
+            if return_code == 0:
+                pid = int(pid)
+            self._pid = pid
+
+        return self._pid
+
+    @property
+    def role(self):
+        """
+        Read-only access to the window's X11 role attribute.
+
+        :returns: role
+        :rtype: str
+        """
+        return self._get_property_from_xprop('role') or ''
+
+    @property
+    def type(self):
+        """
+        Read-only access to the window's X11 type attribute.
+
+        :returns: type
+        :rtype: str
+        """
+        return self._get_property_from_xprop('type') or ''
+
+    @property
+    def state(self):
+        """
+        Read-only access to the X window state.
+
+        Windows can have multiple states, so this returns a tuple.
+
+        This property invokes a (relatively) long-running function, so
+        store the result locally instead of using it multiple times.
+
+        If the window does not have the _NET_WM_STATE property, then
+        ``None`` will be returned.
+
+        :return: window state (if any)
+        :rtype: tuple | None
+        """
+        net_wm_state = self._get_property_from_xprop('state')
+        if net_wm_state is None:
+            # Indicate to callers that _NET_WM_STATE was missing.
+            return None
+        elif not net_wm_state:
+            return tuple()
+        else:
+            return tuple(net_wm_state.split(', '))
+
+    @property
+    def _no_window_state(self):
+        return self.state is None
+
+    def _get_window_module(self):
+        # Get the executable using the process ID and psutil.
+        pid = self.pid
+        if pid is None:
+            self._executable = ''
+        elif self._executable == -1:
+            for p in psutil.process_iter(attrs=['pid', 'exe']):
+                if p.info['pid'] == pid:
+                    self._executable = p.info['exe']
+                    return self._executable
+
+            # Set to '' if it wasn't found.
+            self._executable = ''
+
+        return self._executable
+
+    @classmethod
+    def _is_minimized(cls, state):
+        return state is not None and '_NET_WM_STATE_HIDDEN' in state
+
+    @property
+    def is_minimized(self):
+        return self._is_minimized(self.state)
+
+    @property
+    def is_visible(self):
+        state = self.state
+        return state is not None and '_NET_WM_STATE_HIDDEN' not in state
+
+    @classmethod
+    def _is_maximized(cls, state):
+        # Note: this means a window must be maximized both horizontally and
+        # vertically, but that is typically what maximize means anyway.
+        return (state is not None and
+                '_NET_WM_STATE_MAXIMIZED_VERT' in state and
+                '_NET_WM_STATE_MAXIMIZED_HORZ' in state)
+
+    @property
+    def is_maximized(self):
+        return self._is_maximized(self.state)
+
+    @property
+    def is_fullscreen(self):
+        """
+        Whether the window is in fullscreen mode.
+
+        This does not work for all window types (e.g. pop up menus).
+
+        :rtype: bool
+        """
+        state = self.state
+        return state is not None and '_NET_WM_STATE_FULLSCREEN' in state
+
+    @property
+    def is_focused(self):
+        """
+        Whether the window has input focus.
+
+        This does not work for all window types (e.g. pop up menus).
+
+        :rtype: bool
+        """
+        state = self.state
+        return state is not None and '_NET_WM_STATE_FOCUSED' in state
+
+    #-----------------------------------------------------------------------
+    # Methods related to window geometry.
+
+    def get_position(self):
+        output, _, _ = self._run_xdotool_command(
+            ['getwindowgeometry', '--shell', '%i' % self.id])
+        geometry = output.strip().split('\n')
+        geo = dict([val.lower()
+                    for val in line.split('=')]
+                   for line in geometry)
+        geo = dict((key, int(value)) for (key, value) in geo.items())
+        return Rectangle(geo['x'], geo['y'], geo['width'], geo['height'])
+
+    def set_position(self, rectangle):
+        l, t, _, _ = rectangle.ltwh
+        self._run_xdotool_command(
+            ['windowmove', '%i' % self.id, '%i' % l, '%i' % t])
+
+    #-----------------------------------------------------------------------
+    # Methods for miscellaneous window control.
+
+    def minimize(self):
+        self._run_xdotool_command(['windowminimize', '%i' % self.id])
+
+    def _toggle_maximize(self):
+        # Doesn't seem possible with xdotool. We'll try pressing a-f10
+        # with the window focused.
+        self.set_foreground()
+        self._run_xdotool_command(['keydown', 'Alt_L', 'key', 'F10',
+                                   'keyup', 'Alt_L'])
+
+    def maximize(self):
+        if not self.is_maximized:
+            self._toggle_maximize()
+
+    def restore(self):
+        state = self.state
+        if self._is_minimized(state):
+            self._run_xdotool_command(['windowactivate', '%i' % self.id])
+        elif self._is_maximized(state):
+            self._toggle_maximize()
+
+    def set_foreground(self):
+        if self.is_minimized:
+            self.restore()
+        if not self.is_focused:
+            id = '%i' % self.id
+            self._run_xdotool_command(['windowactivate', id,
+                                       'windowfocus', id])
+
+    def set_focus(self):
+        """
+        Set the input focus to this window.
+
+        This method will set the input focus, but will not necessarily bring
+        the window to the front.
+        """
+        self._run_xdotool_command(['windowfocus', '%i' % self.id])

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
                         # Linux dependencies.
                         # "python-libxdo;platform_system=='Linux'",
                         # "Xlib;platform_system=='Linux'",
+                        "psutil >= 5.5.1;platform_system=='Linux'",
 
                         # Mac OS dependencies.
                         "pynput >= 1.4.2;platform_system=='Darwin'",


### PR DESCRIPTION
Related issues: #8 #35 #77 

This PR does quite a few things. This is a summary of the changes:
- Add `X11Window` class using xdotool and xprop.
Big thanks to @calmofthestorm for Aenea's xdotool/xprop code!
This class can do pretty much everything the Windows-only class can do:

  - Get various attributes available from xprop / xdotool (title, class, class name, executable, pid, id/handle). **This allows `AppContext` to work on X11**! 🎉🎉
  - Common operations like minimize, maximize, restore, set foreground, set focus.
  - Get/set geometry with `get_position()`, `set_position()` and `move()`. This includes the fun window movement functionality in `window_movers.py`, which animates windows as they move.
  - Get window state, e.g. if a window is focused, minimized, maximized, in fullscreen mode, etc.

- Add `FakeWindow` class that replaces the mocked classes in `dragonfly/os_dependent_mock.py`.
It is also used on Linux if the `XDG_SESSION_TYPE` environment variable isn't set to `"X11"`. So the Travis CI tests will use `FakeWindow` because they don't run in an X11 session.
This class may be useful for testing contexts.

- Add `BaseWindow` class containing many things from the old Window class.
- Rename the old `Window` class to `Win32Window` and move it into `win32_window.py`. It is still imported as `Window` though.

- Import the current platform's window class as `Window` in `window.py`.
This should make these changes backwards-compatible.

- Unmock `WaitWindow`, `FocusWindow`, `StartApp` and `BringApp` dragonfly actions.
~The `FocusWindow` action executes very slowly at the moment on X11 because of the large number of xdotool processes that it spawns via the `X11Window` properties and methods. I have some ideas on fixing this problem before merging.~ This should be fixed now.

- Add documentation page on window classes.