### PR TITLE
Swap Repeat arguments

### DIFF
--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -3,18 +3,18 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
@@ -259,7 +259,7 @@ class Repeat(object):
 
         Integer Repeat factors ignore any supply data::
 
-            >>> integer = Repeat(3)
+            >>> integer = Repeat(count=3)
             >>> integer.factor()
             3
             >>> integer.factor({"foo": 4})  # Non-related data is ignored.
@@ -268,7 +268,7 @@ class Repeat(object):
         Named Repeat factors retrieved their factor-value from the
         supplied data::
 
-            >>> named = Repeat(extra="foo")
+            >>> named = Repeat("foo")
             >>> named.factor()
             Traceback (most recent call last):
               ...
@@ -279,7 +279,7 @@ class Repeat(object):
         Repeat factors with both integer count and named extra values set
         combined (add) these together to determine their factor-value::
 
-            >>> combined = Repeat(count=3, extra="foo")
+            >>> combined = Repeat(extra="foo", count=3)
             >>> combined.factor()
             Traceback (most recent call last):
               ...
@@ -289,10 +289,15 @@ class Repeat(object):
 
     """
 
-    def __init__(self, count=None, extra=None):
-        if count is not None:  self._count = count
-        else:                  self._count = 0
-        self._extra = extra
+    def __init__(self, extra=None, count=None):
+        # Backward compatibility for swapped arguments
+        # (#103)
+        if isinstance(extra, int):
+            self._count = extra
+            self._extra = count
+        else:
+            self._extra = extra
+            self._count = count if count is not None else 0
 
     def factor(self, data=None):
         count = self._count

--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -265,6 +265,18 @@ class Repeat(object):
             >>> integer.factor({"foo": 4})  # Non-related data is ignored.
             3
 
+        Integer Repeat factors can be specified with the ``*`` operator::
+
+            >>> from dragonfly import Function
+            >>> def func():
+            ...     print("executing 'func'")
+            ...
+            >>> action = Function(func) * 3
+            >>> action.execute()
+            executing 'func'
+            executing 'func'
+            executing 'func'
+
         Named Repeat factors retrieved their factor-value from the
         supplied data::
 

--- a/dragonfly/test/suites.py
+++ b/dragonfly/test/suites.py
@@ -38,6 +38,7 @@ setup_log()
 
 common_names = [
     "test_accessibility",
+    "test_actions",
     # "test_contexts",  # disabled for now
     "test_engine_nonexistent",
     "test_log",
@@ -53,7 +54,7 @@ common_names = [
 
 # Only include common Windows-only tests on Windows.
 if os.name == "nt":
-    common_names.extend(["test_window", "test_actions"])
+    common_names.extend(["test_window"])
 
 
 # Define spoken language test files. All of them work with the natlink and

--- a/dragonfly/test/test_actions.py
+++ b/dragonfly/test/test_actions.py
@@ -4,23 +4,24 @@
 # (c) Copyright 2007, 2008 by Christo Butcher
 # Licensed under the LGPL.
 #
-#   Dragonfly is free software: you can redistribute it and/or modify it 
-#   under the terms of the GNU Lesser General Public License as published 
-#   by the Free Software Foundation, either version 3 of the License, or 
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
 #   (at your option) any later version.
 #
-#   Dragonfly is distributed in the hope that it will be useful, but 
-#   WITHOUT ANY WARRANTY; without even the implied warranty of 
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 #   Lesser General Public License for more details.
 #
-#   You should have received a copy of the GNU Lesser General Public 
-#   License along with Dragonfly.  If not, see 
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
 #   <http://www.gnu.org/licenses/>.
 #
 
 
 import unittest
+from dragonfly.actions.action_base import Repeat
 from dragonfly.actions.action_text import Text
 from dragonfly.actions.action_paste import Paste
 from dragonfly.actions.action_mimic import Mimic
@@ -56,6 +57,20 @@ class TestNonAsciiMimic(unittest.TestCase):
 
         action = Mimic("touché")
         self.assertEqual(str(action), "Mimic(%r)" % ("touché",))
+
+class TestRepeat(unittest.TestCase):
+
+    def test_repeat(self):
+        """ Test handling of Repeat elements """
+
+        r1 = Repeat("n")
+        self.assertEqual(r1.factor({"n": 3}), 3)
+        r2 = Repeat("n", 3)
+        self.assertEqual(r2.factor({"n": 3}), 6)
+        r3 = Repeat(3)
+        self.assertEqual(r3.factor(), 3)
+        r4 = Repeat(3, "n")
+        self.assertEqual(r4.factor({"n": 3}), 6)
 
 
 #===========================================================================


### PR DESCRIPTION
As mentioned on Gitter, I think that the most natural and common use case for the `Repeat` class is to repeat actions an arbitrary number of times, rather than a prespecified number of times. For example:
```
"close tab [<n>]"         : Key("c-w/3")*Repeat(extra="n"),
```

This usage comes up over a hundred times in Caster, every time requiring the `extra` argument to be explicitly specified because it comes after the `count` argument.

Swapping the order of the arguments is a fairly minor change but I think it would be worthwhile. One less piece of syntax for users to remember for fairly basic operations is always a good thing.

In order to maintain backwards compatibility for e.g. `Repeat(3)` I have introduced a type check which should make it do what the user intended even if the order is incorrect. I have also added a unit test to make sure this works correctly.

(Feel free to veto this if you don't think it's a good idea :-))