### PR TITLE
Fix Win32Window.set_foreground() failures

### DIFF
--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -25,14 +25,15 @@ Window class for Windows
 """
 
 import os
+from ctypes          import windll, pointer, c_wchar, c_ulong
 
 import win32gui
 import win32con
-from ctypes          import windll, pointer, c_wchar, c_ulong
 
 from .base_window    import BaseWindow
 from .rectangle      import Rectangle, unit
 from .monitor        import monitors
+from ..actions.action_key import Key
 
 
 #===========================================================================
@@ -215,6 +216,16 @@ class Win32Window(BaseWindow):
     # Methods for miscellaneous window control.
 
     def set_foreground(self):
-        if self.is_minimized:
-            self.restore()
-        self._set_foreground()
+        # Bring this window into the foreground if it isn't already the
+        # current foreground window.
+        if self.handle != win32gui.GetForegroundWindow():
+            if self.is_minimized:
+                self.restore()
+
+            # Press a key so Windows allows us to use SetForegroundWindow()
+            # (received last input event). See Microsoft's documentation on
+            # SetForegroundWindow() for why this works.
+            Key("control:down,control:up").execute()
+
+            # Set the foreground window.
+            self._set_foreground()


### PR DESCRIPTION
Re: #86.

This is done by pressing the control key before calling `SetForegroundWindow()`. Doing this allows the process to call the function because it received the last input event (see [`SetForegroundWindow()` documentation](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow#remarks)).

This worked for me on Windows 7 and Windows 10. I don't really use metro applications, but it seems to work with the new calculator app.

As I mentioned in the issue for this bug, the function still won't work if the current window is running in elevated mode, i.e. as the administrator.

@jcaw Please let me know if this works for you.