### PR TITLE
Custom words formatting

### DIFF
--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -339,6 +339,7 @@ class WordParserDns11(WordParserBase):
         "left-*":           WordFlags("no_cap_reset", "no_space_after"),
         "right-*":          WordFlags("no_cap_reset", "no_space_before", "no_space_reset"),
         "open paren":       WordFlags("no_space_after"),
+        "close paren":       WordFlags("no_space_before"),
         "slash":            WordFlags("no_space_after", "no_space_before"),
         
         # below are two examples of Dragon custom vocabulary with formatting

--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -325,7 +325,6 @@ class WordParserDns11(WordParserBase):
         "uppercase-letter": WordFlags("no_space_after"),
 
         "period":           WordFlags("two_spaces_after", "cap_next", "no_space_before", "not_after_period"),
-        "karp":           WordFlags("two_spaces_after", "cap_next", "no_space_before", "not_after_period"),
         "question-mark":    WordFlags("two_spaces_after", "cap_next", "no_space_before"),
         "exclamation-mark": WordFlags("two_spaces_after", "cap_next", "no_space_before"),
         "point":            WordFlags("no_space_after", "no_space_between", "no_space_before"),
@@ -342,8 +341,10 @@ class WordParserDns11(WordParserBase):
         "open paren":       WordFlags("no_space_after"),
         "slash":            WordFlags("no_space_after", "no_space_before"),
         
-        "len":              WordFlags("no_space_after"),
-        "ren":              WordFlags("no_space_before"),
+        # below are two examples of Dragon custom vocabulary with formatting
+        # these would have to be added to the Dragon vocabulary for users to use them
+        "len":              WordFlags("no_space_after"), # shorter name for (
+        "ren":              WordFlags("no_space_before"), # shorter name for )
     }
     
     def create_word_flags(self, property):
@@ -369,12 +370,7 @@ class WordParserDns11(WordParserBase):
             # encoded strings. Here we convert them to Unicode for internal
             # processing.
             input = text_type(input).encode("windows-1252")
-        # Alex
-        print("input: ", input)
-
         parts = input.split("\\")
-        # Alex
-        print("parts: ", parts)
         if len(parts) == 1:
             # Word doesn't have "written\property\spoken" form, so
             # written and spoken forms are equal to input and there are
@@ -399,9 +395,9 @@ class WordParserDns11(WordParserBase):
             written = "\\".join(parts[:-2])
             property = parts[-2]
             spoken = parts[-1]
-        # this allows users to add the spoken form (or the written form if and only if there isn't a spoken form)
-        # of their own custom Dragon vocabulary words into the property_mapping
-         
+        """ The if statement below allows users to add the spoken form
+        # (or the written form if and only if there isn't a spoken form)
+        # of their own custom Dragon vocabulary words into the property_mapping """
         if spoken in self.property_map:
             property = spoken
 

--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -325,6 +325,7 @@ class WordParserDns11(WordParserBase):
         "uppercase-letter": WordFlags("no_space_after"),
 
         "period":           WordFlags("two_spaces_after", "cap_next", "no_space_before", "not_after_period"),
+        "karp":           WordFlags("two_spaces_after", "cap_next", "no_space_before", "not_after_period"),
         "question-mark":    WordFlags("two_spaces_after", "cap_next", "no_space_before"),
         "exclamation-mark": WordFlags("two_spaces_after", "cap_next", "no_space_before"),
         "point":            WordFlags("no_space_after", "no_space_between", "no_space_before"),
@@ -338,8 +339,13 @@ class WordParserDns11(WordParserBase):
         "apostrophe-ess":   WordFlags("no_space_before"),
         "left-*":           WordFlags("no_cap_reset", "no_space_after"),
         "right-*":          WordFlags("no_cap_reset", "no_space_before", "no_space_reset"),
+        "open paren":       WordFlags("no_space_after"),
+        "slash":            WordFlags("no_space_after", "no_space_before"),
+        
+        "len":              WordFlags("no_space_after"),
+        "ren":              WordFlags("no_space_before"),
     }
-
+    
     def create_word_flags(self, property):
         if not property:
             # None indicates the word is not in DNS' vocabulary.
@@ -355,6 +361,7 @@ class WordParserDns11(WordParserBase):
             flags = WordFlags()
         return flags
 
+    
     def parse_input(self, input):
         # Not unicode (Python 2) or str (Python 3)
         if not isinstance(input, text_type):
@@ -362,8 +369,12 @@ class WordParserDns11(WordParserBase):
             # encoded strings. Here we convert them to Unicode for internal
             # processing.
             input = text_type(input).encode("windows-1252")
+        # Alex
+        print("input: ", input)
 
         parts = input.split("\\")
+        # Alex
+        print("parts: ", parts)
         if len(parts) == 1:
             # Word doesn't have "written\property\spoken" form, so
             # written and spoken forms are equal to input and there are
@@ -388,6 +399,11 @@ class WordParserDns11(WordParserBase):
             written = "\\".join(parts[:-2])
             property = parts[-2]
             spoken = parts[-1]
+        # this allows users to add the spoken form (or the written form if and only if there isn't a spoken form)
+        # of their own custom Dragon vocabulary words into the property_mapping
+         
+        if spoken in self.property_map:
+            property = spoken
 
         word_flags = self.create_word_flags(property)
 

--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -343,8 +343,8 @@ class WordParserDns11(WordParserBase):
         
         # below are two examples of Dragon custom vocabulary with formatting
         # these would have to be added to the Dragon vocabulary for users to use them
-        "len":              WordFlags("no_space_after"), # shorter name for (
-        "ren":              WordFlags("no_space_before"), # shorter name for )
+        # "len":              WordFlags("no_space_after"), # shorter name for (
+        # "ren":              WordFlags("no_space_before"), # shorter name for )
     }
     
     def create_word_flags(self, property):


### PR DESCRIPTION
The dragonfly file dictation_format.py provides autoformatting behavior for built-in Dragon vocabulary words with `property` values which indicate whether there should be for example a space before and/or after the word or whether the next word should be capitalized and things like that. However this does not currently work with custom words in the Dragon vocabulary. Even when you set those properties for your custom words in the Dragon vocabulary (using the word properties GUI or the XML file for your vocabulary), the value of `property` in dictation_format.py is just blank.

This pull request allows people to set formatting flags for their custom words. Two example customer words are provided (commented out): "len" which is supposed to be a short name for "(" and "ren" which is supposed to be a short name for ")".  In order for these to work, they would have to be added to the Dragon vocabulary by the user with (in the case of len) written form "(" and spoken form "len".

I also noticed that the formatting flags for the Dragon built-ins "slash", "open paren", "close paren" were not there, so I added them. There are other Dragon buildings like us but I didn't and them because they are less common and the ones I can think of or just other things that start with open and close (e.g. "open bracket") which are already covered by "left-*" and "right-*" which are included already.

Note: the autoformatting behavior appears only take into account what is said in the current utterance and does not use information from the previous utterance. 
In some ways, this is an important limitation which I discussed in the issue #110

Aside: Perhaps this should be somehow linked up with Natlink functionality for adding custom words, many a time. I don't know how that works. I know Dragon stores vocabulary in text files and XML files and the XML (which are quite messy) files carry a bit more formatting information than the text files (though again that extra formatting information appears to be lost by the time he gets to dragonfly). The Dragon vocabulary text files have just spoken and written forms (and don't allow backslashes in the written forms since that is used as a separator).

