### PR TITLE
Fix some logging issues

### DIFF
--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -18,7 +18,10 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
+import logging
 import sys
+
+logging.basicConfig()
 
 # --------------------------------------------------------------------------
 from .config            import Config, Section, Item

--- a/dragonfly/log.py
+++ b/dragonfly/log.py
@@ -84,6 +84,8 @@ default_levels = {
                   "context.match":        (_warning, _info),
                   "rpc.server":           (_warning, _info),
                   "rpc.methods":          (_warning, _info),
+                  "werkzeug":             (_warning, _warning),
+                  "jsonrpc.manager":      (_critical, _critical),
                   "rule":                 (_warning, _info),
                   "config":               (_warning, _info),
                   "module":               (_info, _info),


### PR DESCRIPTION
This should fix the "No handlers for logger X" error message that occurs if using dragonfly without a module loader or the `setup_log()` function.

I've also added sane default log levels for dragonfly's RPC server dependencies. This only applies if `setup_log()` is called.

@MatthijsBurgh let me know if #115 is not fixed by this :-)