### PR TITLE
Fix Unicode window titles with non-Natlink backends

### DIFF
--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -172,11 +172,11 @@ class BaseWindow(object):
     def title(self):
         """ Read-only access to the window's title. """
         window_text = self._get_window_text()
-        if isinstance(window_text, text_type):
-            return window_text
-        elif isinstance(window_text, binary_type):
+        # PY2
+        if isinstance(window_text, binary_type):
             return window_text.decode(getpreferredencoding())
-
+        else:
+            return window_text
 
     @property
     def classname(self):

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -24,7 +24,7 @@ Base Window class
 
 """
 
-from six import string_types, integer_types, text_type, binary_type
+from six import string_types, integer_types, binary_type
 from locale import getpreferredencoding
 
 from .window_movers import window_movers

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -24,7 +24,8 @@ Base Window class
 
 """
 
-from six import string_types, integer_types
+from six import string_types, integer_types, text_type, binary_type
+from locale import getpreferredencoding
 
 from .window_movers import window_movers
 
@@ -170,7 +171,12 @@ class BaseWindow(object):
     @property
     def title(self):
         """ Read-only access to the window's title. """
-        return self._get_window_text()
+        window_text = self._get_window_text()
+        if isinstance(window_text, text_type):
+            return window_text
+        elif isinstance(window_text, binary_type):
+            return window_text.decode(getpreferredencoding())
+
 
     @property
     def classname(self):


### PR DESCRIPTION
Ran into a bug when testing the Kaldi backend with Python 2. If the window title contains Unicode characters then `_win32gui_func("GetWindowText")` returns bytes, which get passed to the context matcher and cause an error.

This is not a problem with Natlink, which contains this function (`engine.py`):
```
def map_word(word, encoding=getpreferredencoding(do_setlocale=False)):
    if isinstance(word, text_type):
        return word
    elif isinstance(word, binary_type):
        return word.decode(encoding)
    return word
```

which it uses to sanitise the window info before it is processed:
```
def begin_callback(self, module_info):
        executable, title, handle = tuple(map_word(word)
                                          for word in module_info)
        self.grammar.process_begin(executable, title, handle)
```

The same is not done for other engines however, hence the issue. This is just a quick fix to make sure that window titles from `Window` objects are encoded correctly before they are returned. I assume that this will not be a problem once everything has been transitioned to Python 3.