### PR TITLE
Add close method to Window classes

### DIFF
--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -237,6 +237,10 @@ class BaseWindow(object):
         """ Maximize the window (if possible). """
         raise NotImplementedError()
 
+    def close(self):
+        """ Close the window (if possible). """
+        raise NotImplementedError()
+
     def restore(self):
         """ Restore the window if it is minimized or maximized. """
         raise NotImplementedError()

--- a/dragonfly/windows/fake_window.py
+++ b/dragonfly/windows/fake_window.py
@@ -87,5 +87,8 @@ class FakeWindow(BaseWindow):
     def restore(self):
         pass
 
+    def close(self):
+        pass
+
     def set_foreground(self):
         pass

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -142,6 +142,11 @@ class Win32Window(BaseWindow):
     maximize        = _win32gui_show_window(win32con.SW_MAXIMIZE)
     restore         = _win32gui_show_window(win32con.SW_RESTORE)
 
+    def _win32gui_post(message, w=0, l=0):
+        return lambda self: win32gui.PostMessage(self._handle, message, w, l)
+
+    close = _win32gui_post(win32con.WM_CLOSE)
+
     def _get_window_module(self):
         # Get this window's process ID.
         pid = c_ulong()

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -394,6 +394,9 @@ class X11Window(BaseWindow):
         elif self._is_maximized(state):
             self._toggle_maximize()
 
+    def close(self):
+        self._run_xdotool_command(['windowclose', self.id])
+
     def set_foreground(self):
         if self.is_minimized:
             self.restore()


### PR DESCRIPTION
As far as I can tell the window classes do not contain methods for closing windows. `Win32Window` has a `_destroy` method which gives me a permission error, and `win32gui` has a `CloseWindow` function which (obviously) *minimises* the window.

[This stack overflow post](https://stackoverflow.com/questions/27586411/how-do-i-close-window-with-handle-using-win32gui-in-python/27658320) post gives a functional windows implementation.

While `Key("a-f4")` obviously works fine for closing the active window, an example usage for this would be something like:

```
def close_program(title_match):
    program_windows = Window.get_matching_windows(title=title_match)
    for window in program_windows:
        window.close()
```