### PR TITLE
Win32 keyboard improvements

### DIFF
--- a/dragonfly/actions/action_base_keyboard.py
+++ b/dragonfly/actions/action_base_keyboard.py
@@ -1,0 +1,105 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+import io
+import os
+from os.path import basename
+import sys
+
+from .action_base  import DynStrActionBase
+from .keyboard     import Keyboard
+
+
+UNICODE_KEYBOARD = False
+HARDWARE_APPS = [
+    "tvnviewer.exe", "vncviewer.exe", "mstsc.exe", "virtualbox.exe"
+]
+PAUSE_DEFAULT = 0.005
+
+
+def load_configuration():
+    """Locate and load configuration."""
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser
+
+    global UNICODE_KEYBOARD
+    global HARDWARE_APPS
+    global PAUSE_DEFAULT
+
+    home = os.path.expanduser("~")
+    config_folder = os.path.join(home, ".dragonfly2-speech")
+    config_file = "settings.cfg"
+    config_path = os.path.join(config_folder, config_file)
+
+    if not os.path.exists(config_folder):
+        os.mkdir(config_folder)
+    if not os.path.exists(config_path):
+        with io.open(config_path, "w") as f:
+            # Write the default values to the config file.
+            f.write(u'[Text]\n')
+            f.write(u'hardware_apps = %s\n' % "|".join(HARDWARE_APPS))
+            f.write(u'unicode_keyboard = %s\n' % UNICODE_KEYBOARD)
+            f.write(u'pause_default = %f\n' % PAUSE_DEFAULT)
+
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    if parser.has_option("Text", "hardware_apps"):
+        HARDWARE_APPS = parser.get("Text", "hardware_apps").lower().split("|")
+    if parser.has_option("Text", "unicode_keyboard"):
+        UNICODE_KEYBOARD = parser.getboolean("Text", "unicode_keyboard")
+    if parser.has_option("Text", "pause_default"):
+        PAUSE_DEFAULT = parser.getfloat("Text", "pause_default")
+
+
+load_configuration()
+
+
+class BaseKeyboardAction(DynStrActionBase):
+    """
+        Base keystroke emulation action.
+
+        This class isn't meant to be used directly.
+
+    """
+
+    _keyboard = Keyboard()
+    _pause_default = PAUSE_DEFAULT
+
+    def __init__(self, spec=None, static=False, use_hardware=False):
+        self._use_hardware = use_hardware
+        super(BaseKeyboardAction, self).__init__(spec, static)
+
+    def require_hardware_events(self):
+        """
+        Return `True` if the current context requires hardware emulation.
+        """
+        # Always use hardware_events for non-Windows platforms.
+        if not sys.platform.startswith("win") or self._use_hardware:
+            return True
+
+        # Otherwise check if hardware events should be used with the current
+        # foreground window.
+        from dragonfly.windows import Window
+        foreground_executable = basename(Window.get_foreground()
+                                         .executable.lower())
+        return ((not UNICODE_KEYBOARD) or
+                (foreground_executable in HARDWARE_APPS))

--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -182,18 +182,61 @@ with the *l*: ::
     Key("w-l").execute()
 
 
+Windows key support
+............................................................................
+
+Keyboard events sent by :class:`Key` actions on Windows are calculated using
+the current foreground window's keyboard layout. The class will fallback on
+Unicode events for keys not typeable with the current layout.
+
+The :class:`Key` action can be used to type arbitrary Unicode characters on
+Windows using the `relevant Windows API
+<https://docs.microsoft.com/en-us/windows/desktop/api/winuser/ns-winuser-tagkeybdinput#remarks>`__.
+This is disabled by default because it ignores the up/down status of
+modifier keys (e.g. ctrl).
+
+It can be enabled by changing the ``unicode_keyboard`` setting in
+`~/.dragonfly2-speech/settings.cfg` to ``True``::
+
+    unicode_keyboard = True
+
+The ``use_hardware`` parameter can be set to ``True`` if you need to
+selectively require hardware events for a :class:`Key` action::
+
+    # Only copy if 'c' is a typeable key.
+    Key("c-c", use_hardware=True).execute()
+
+If the Unicode keyboard is not enabled or the ``use_hardware`` parameter is
+``True``, then no keys will be typed and an error will be logged for
+untypeable keys::
+
+   action.exec (ERROR): Execution failed: Keyboard interface cannot type this character: 'c'
+
+Unlike the :class:`Text` action, individual :class:`Key` actions can send
+both hardware *and* Unicode events. So the following example will work if
+the Unicode keyboard is enabled::
+
+    # Type 'σμ' and then press ctrl-z.
+    Key(u"σ, μ, c-z").execute()
+
+Note that the 'z' in this example will be typed if the current layout cannot
+type the character.
+
+
 X11 key support
 ............................................................................
 
-This class can be used to type arbitrary keys and Unicode characters on
-X11/Linux. It is not limited to the key names listed above, although all of
-them will work too.
+This :class:`Key` action can be used to type arbitrary keys and Unicode
+characters on X11/Linux. It is not limited to the key names listed above,
+although all of them will work too.
 
-Unicode characters are supported by passing their Unicode code point to the
-keyboard implementation. For example, the character ``'€'`` is converted to
-``'U20AC'``. The Unicode code point can also be passed directly, e.g. with
-``Key('U20AC')``.
+Unicode characters are supported on X11 by passing their Unicode code point
+to the keyboard implementation. For example, the character ``'€'`` is
+converted to ``'U20AC'``. The Unicode code point can also be passed
+directly, e.g. with ``Key('U20AC')``.
 
+Unlike on Windows, the :class:`Key` action is able to use modifiers with
+Unicode characters on X11.
 
 
 Example X11 key actions

--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -224,13 +224,9 @@ Key class reference
 
 """
 
-import os
-
 from .action_base  import DynStrActionBase, ActionError
 from .typeables    import typeables
 from .keyboard     import Keyboard
-
-_ON_X11 = os.environ.get("XDG_SESSION_TYPE") == "x11"
 
 #---------------------------------------------------------------------------
 
@@ -341,14 +337,12 @@ class Key(DynStrActionBase):
 
         # Check if the key name is valid.
         code = typeables.get(keyname)
-        if code is None and _ON_X11:
-            # Delegate to the keyboard class on X11/Linux. Any invalid keys
-            # will cause error messages later than normal, but this allows
-            # using valid key symbols that dragonfly doesn't define.
+        if code is None:
+            # Delegate to the keyboard class. Any invalid keys will cause
+            # error messages later than normal, but this allows using valid
+            # key symbols that dragonfly doesn't define.
             code = self._keyboard.get_typeable(keyname)
-        elif code is None:
-            # Raise an error on other platforms.
-            raise ActionError("Invalid key name: %r" % keyname)
+            typeables[keyname] = code
 
         if inner_pause is not None:
             s = inner_pause

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -107,70 +107,14 @@ from six import binary_type
 
 from ..engines import get_engine
 from ..util.clipboard import Clipboard
-from ..windows import Window
-from .action_base import ActionError, DynStrActionBase
+from .action_base import ActionError
+from .action_base_keyboard import BaseKeyboardAction
 from .action_key import Key
-from .keyboard import Keyboard
 from .typeables import typeables
 
 # ---------------------------------------------------------------------------
 
-UNICODE_KEYBOARD = False
-HARDWARE_APPS = [
-    "tvnviewer.exe", "vncviewer.exe", "mstsc.exe", "virtualbox.exe"
-]
-PAUSE_DEFAULT = 0.005
-
-
-def load_configuration():
-    """Locate and load configuration."""
-    import io
-    import os
-    try:
-        import configparser
-    except ImportError:
-        import ConfigParser as configparser
-
-    global UNICODE_KEYBOARD
-    global HARDWARE_APPS
-    global PAUSE_DEFAULT
-
-    home = os.path.expanduser("~")
-    config_folder = os.path.join(home, ".dragonfly2-speech")
-    config_file = "settings.cfg"
-    config_path = os.path.join(config_folder, config_file)
-
-    if not os.path.exists(config_folder):
-        os.mkdir(config_folder)
-    if not os.path.exists(config_path):
-        with io.open(config_path, "w") as f:
-            # Write the default values to the config file.
-            f.write(u'[Text]\n')
-            f.write(u'hardware_apps = %s\n' % "|".join(HARDWARE_APPS))
-            f.write(u'unicode_keyboard = %s\n' % UNICODE_KEYBOARD)
-            f.write(u'pause_default = %f\n' % PAUSE_DEFAULT)
-
-    parser = configparser.ConfigParser()
-    parser.read(config_path)
-    if parser.has_option("Text", "hardware_apps"):
-        HARDWARE_APPS = parser.get("Text", "hardware_apps").lower().split("|")
-    if parser.has_option("Text", "unicode_keyboard"):
-        UNICODE_KEYBOARD = parser.getboolean("Text", "unicode_keyboard")
-    if parser.has_option("Text", "pause_default"):
-        PAUSE_DEFAULT = parser.getfloat("Text", "pause_default")
-
-load_configuration()
-
-
-def require_hardware_emulation():
-    """Return `True` if the current context requires hardware emulation."""
-    from os.path import basename
-    foreground_executable = basename(Window.get_foreground()
-                                     .executable.lower())
-    return (not UNICODE_KEYBOARD) or (foreground_executable in HARDWARE_APPS)
-
-
-class Text(DynStrActionBase):
+class Text(BaseKeyboardAction):
     """
     `Action` that sends keyboard events to type text.
 
@@ -204,8 +148,6 @@ class Text(DynStrActionBase):
             self.unicode_events = unicode_events
             self.unicode_error_message = unicode_error_message
 
-    _keyboard = Keyboard()
-    _pause_default = PAUSE_DEFAULT
     _specials = {
                  "\n": typeables["enter"],
                  "\t": typeables["tab"],
@@ -220,12 +162,12 @@ class Text(DynStrActionBase):
 
         # Set other members and call the super constructor.
         self._autofmt = autofmt
-        self._use_hardware = use_hardware
 
         if isinstance(spec, binary_type):
             spec = spec.decode(getpreferredencoding())
 
-        DynStrActionBase.__init__(self, spec=spec, static=static)
+        BaseKeyboardAction.__init__(self, spec=spec, static=static,
+                                    use_hardware=use_hardware)
 
     def _parse_spec(self, spec):
         """Convert the given *spec* to keyboard events."""
@@ -303,13 +245,7 @@ class Text(DynStrActionBase):
             events = self._parse_spec(prefix + text + suffix)
 
         # Send keyboard events.
-        use_hardware_events = (
-            self._use_hardware or require_hardware_emulation() or
-
-            # Always use hardware_events for non-Windows platforms.
-            not sys.platform.startswith("win")
-        )
-        if use_hardware_events:
+        if self.require_hardware_events():
             error_message = events.hardware_error_message
             keyboard_events = events.hardware_events
         else:

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -68,6 +68,13 @@ emulation. If you use such applications, add their executable names to the
 ``hardware_apps`` list in the configuration file mentioned above to make
 dragonfly always use hardware emulation for them.
 
+If hardware emulation is required, then the action will use the keyboard
+layout of the foreground window when calculating keyboard events. If any of
+the specified characters are not typeable using the current window's
+keyboard layout, then an error will be logged and no keys will be typed::
+
+    action.exec (ERROR): Execution failed: Keyboard interface cannot type this character: 'c'
+
 These settings and parameters have no effect on other platforms.
 
 

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -229,7 +229,6 @@ class Text(DynStrActionBase):
 
     def _parse_spec(self, spec):
         """Convert the given *spec* to keyboard events."""
-        from struct import unpack
         hardware_events = []
         unicode_events = []
         hardware_error_message = None
@@ -254,18 +253,14 @@ class Text(DynStrActionBase):
                 if not sys.platform.startswith("win"):
                     continue
 
-                # Add Unicode events.
-                byte_stream = character.encode("utf-16-le")
-                for short in unpack("<" + str(len(byte_stream) // 2) + "H",
-                                    byte_stream):
-                    try:
-                        typeable = self._keyboard.get_typeable(short,
-                                                               is_text=True)
-                        unicode_events.extend(typeable.events(self._pause * 0.5))
-                    except ValueError:
-                        unicode_error_message = ("Keyboard interface cannot type "
-                                                 "this character: %r (in %r)" %
-                                                 (character, spec))
+                try:
+                    typeable = self._keyboard.get_typeable(character,
+                                                           is_text=True)
+                    unicode_events.extend(typeable.events(self._pause * 0.5))
+                except ValueError:
+                    unicode_error_message = ("Keyboard interface cannot type "
+                                             "this character: %r (in %r)" %
+                                             (character, spec))
         return self.Events(hardware_events, hardware_error_message,
                            unicode_events, unicode_error_message)
 

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -249,6 +249,11 @@ class Text(DynStrActionBase):
                     hardware_error_message = ("Keyboard interface cannot type this"
                                               " character: %r (in %r)"
                                               % (character, spec))
+
+                # Calculate and add Unicode events only if necessary.
+                if not sys.platform.startswith("win"):
+                    continue
+
                 # Add Unicode events.
                 byte_stream = character.encode("utf-16-le")
                 for short in unpack("<" + str(len(byte_stream) // 2) + "H",

--- a/dragonfly/actions/keyboard/_base.py
+++ b/dragonfly/actions/keyboard/_base.py
@@ -57,6 +57,10 @@ class Typeable(object):
         # between platforms.
         self._is_text = is_text
 
+    def update(self):
+        """Update keypress information."""
+        pass
+
     def __repr__(self):
         """Return information useful for debugging."""
         return ("%s(%s)" % (self.__class__.__name__, self._name) +

--- a/dragonfly/actions/keyboard/_base.py
+++ b/dragonfly/actions/keyboard/_base.py
@@ -57,9 +57,14 @@ class Typeable(object):
         # between platforms.
         self._is_text = is_text
 
-    def update(self):
-        """Update keypress information."""
-        pass
+    def update(self, hardware_events_required):
+        """
+        Update keypress information.
+
+        :rtype: bool
+        :returns: success
+        """
+        return True
 
     def __repr__(self):
         """Return information useful for debugging."""

--- a/dragonfly/actions/keyboard/_base.py
+++ b/dragonfly/actions/keyboard/_base.py
@@ -52,6 +52,9 @@ class Typeable(object):
         self._code = code
         self._modifiers = modifiers
         self._name = name
+
+        # Only used on Windows, but kept here for argument compatibility
+        # between platforms.
         self._is_text = is_text
 
     def __repr__(self):
@@ -61,31 +64,21 @@ class Typeable(object):
 
     def on_events(self, timeout=0):
         """Return events for pressing this key down."""
-        if self._is_text:
-            events = [(self._code, True, timeout, True)]
-        else:
-            events = [(m, True, 0) for m in self._modifiers]
-            events.append((self._code, True, timeout))
+        events = [(m, True, 0) for m in self._modifiers]
+        events.append((self._code, True, timeout))
         return events
 
     def off_events(self, timeout=0):
         """Return events for releasing this key."""
-        if self._is_text:
-            events = [(self._code, False, timeout, True)]
-        else:
-            events = [(m, False, 0) for m in self._modifiers]
-            events.append((self._code, False, timeout))
-            events.reverse()
+        events = [(m, False, 0) for m in self._modifiers]
+        events.append((self._code, False, timeout))
+        events.reverse()
         return events
 
     def events(self, timeout=0):
         """Return events for pressing and then releasing this key."""
-        if self._is_text:
-            events = [(self._code, True, timeout, True),
-                      (self._code, False, timeout, True)]
-        else:
-            events = [(self._code, True, 0), (self._code, False, timeout)]
-            for m in self._modifiers[-1::-1]:
-                events.insert(0, (m, True, 0))
-                events.append((m, False, 0))
+        events = [(self._code, True, 0), (self._code, False, timeout)]
+        for m in self._modifiers[-1::-1]:
+            events.insert(0, (m, True, 0))
+            events.append((m, False, 0))
         return events

--- a/dragonfly/actions/keyboard/_win32.py
+++ b/dragonfly/actions/keyboard/_win32.py
@@ -143,21 +143,26 @@ class Typeable(BaseTypeable):
         BaseTypeable.__init__(self, code, modifiers, name, is_text)
         self._char = char
 
-    def update(self):
+    def update(self, hardware_events_required):
         # Nothing to do for virtual keys.
         if self._char is None:
-            return
+            return True
 
         # Get updated key code and modifiers for this Typeable.
         try:
+            self._is_text = False
             code, modifiers = Keyboard.get_keycode_and_modifiers(self._char)
         except ValueError:
+            if hardware_events_required:
+                return False
+
             # Fallback on Unicode events.
             code, modifiers = self._char, ()
             self._is_text = True
 
         # Set key code and modifiers.
         self._code, self._modifiers = code, modifiers
+        return True
 
     def _unicode_events(self, down, timeout):
         character = self._code

--- a/dragonfly/actions/keyboard/_win32.py
+++ b/dragonfly/actions/keyboard/_win32.py
@@ -21,10 +21,13 @@
 """This file implements the Win32 keyboard interface using sendinput."""
 
 from contextlib import contextmanager
-from ctypes import windll, c_char, c_wchar
+from ctypes import windll
+from locale import getpreferredencoding
 import time
 
-from six import text_type, PY2, string_types
+from six import binary_type, string_types
+
+import win32api
 import win32con
 import win32gui
 import win32process
@@ -243,12 +246,11 @@ class Keyboard(BaseKeyboard):
             win32gui.GetForegroundWindow()
         )[0]
         layout = windll.user32.GetKeyboardLayout(thread_id)
-        if isinstance(char, str) and PY2:
-            code = windll.user32.VkKeyScanExA(c_char(char), layout)
-        elif isinstance(char, text_type):  # unicode for PY2, str for PY3
-            code = windll.user32.VkKeyScanExW(c_wchar(char), layout)
-        else:
-            code = -1
+        if isinstance(char, binary_type):
+            char = char.decode(getpreferredencoding())
+
+        # Get the code for this character.
+        code = win32api.VkKeyScanEx(char, layout)
         if code == -1:
             raise ValueError("Unknown char: %r" % char)
         return code

--- a/dragonfly/actions/keyboard/_win32.py
+++ b/dragonfly/actions/keyboard/_win32.py
@@ -191,6 +191,14 @@ class Keyboard(BaseKeyboard):
     alt_code = win32con.VK_MENU
 
     @classmethod
+    def get_current_layout(cls):
+        # Get the current window's keyboard layout.
+        thread_id = win32process.GetWindowThreadProcessId(
+            win32gui.GetForegroundWindow()
+        )[0]
+        return win32api.GetKeyboardLayout(thread_id)
+
+    @classmethod
     def send_keyboard_events(cls, events):
         """
         Send a sequence of keyboard events.
@@ -213,11 +221,7 @@ class Keyboard(BaseKeyboard):
                 is_text (boolean): True means that the keypress is targeted
                     at a window or control that accepts Unicode text.
         """
-        # Get the current window's keyboard layout.
-        thread_id = win32process.GetWindowThreadProcessId(
-            win32gui.GetForegroundWindow()
-        )[0]
-        layout = windll.user32.GetKeyboardLayout(thread_id)
+        layout = cls.get_current_layout()
 
         # Process and send keyboard events.
         items = []

--- a/dragonfly/actions/sendinput.py
+++ b/dragonfly/actions/sendinput.py
@@ -96,7 +96,7 @@ class KeyboardInput(Structure):
                                                           0, layout)
 
         flags = 0
-        if virtual_keycode is 0:
+        if virtual_keycode == 0:
             flags |= 4  # KEYEVENTF_UNICODE
         elif virtual_keycode not in self.soft_keys:
             flags |= 8  # KEYEVENTF_SCANCODE

--- a/dragonfly/actions/sendinput.py
+++ b/dragonfly/actions/sendinput.py
@@ -85,10 +85,15 @@ class KeyboardInput(Structure):
                      win32con.VK_RWIN,
                     )
 
-    def __init__(self, virtual_keycode, down, scancode=-1):
+    def __init__(self, virtual_keycode, down, scancode=-1, layout=None):
         """Initialize structure based on key type."""
         if scancode == -1:
-            scancode = windll.user32.MapVirtualKeyW(virtual_keycode, 0)
+            if not layout:
+                scancode = windll.user32.MapVirtualKeyW(virtual_keycode, 0)
+            else:
+                # Assume that 'layout' is a keyboard layout (HKL).
+                scancode = windll.user32.MapVirtualKeyExW(virtual_keycode,
+                                                          0, layout)
 
         flags = 0
         if virtual_keycode is 0:
@@ -101,6 +106,7 @@ class KeyboardInput(Structure):
             flags |= win32con.KEYEVENTF_EXTENDEDKEY
 
         extra = pointer(c_ulong(0))
+        # print(virtual_keycode, scancode, flags, 0, extra)
         Structure.__init__(self, virtual_keycode, scancode, flags, 0, extra)
 
 


### PR DESCRIPTION
Re: #81, #114.

This adds a Windows-specific `Typeable` class and changes the keyboard class to call `get_keycode_and_modifiers()` during the `Typeable` event methods instead, so that the current foreground window's keyboard layout is taken into consideration when typing keys. This applies to the `Key` and `Text` actions.

Unknown character errors aren't completely removed by this. One way to remove them altogether is to fallback on the Unicode keyboard interface if [`VkKeyScanEx()`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-vkkeyscanexw) returns `-1`. As I mentioned in https://github.com/dictation-toolbox/dragonfly/issues/81#issuecomment-515762324, this means modifier keys won't work in some circumstances, e.g. executing `Key("c-c")` when the current layout doesn't have the `"c"` key.

# TODO

- [X] Make Win32 keyboard classes type keys with the current layout

- [X] Modify the `Key` and `Text` classes to accept any characters and get new `Typeable` objects when necessary.
    This is how the `Key` and `Text` actions work on Linux (X11).

- [x] Move the keyboard event logic for the Unicode keyboard from `action_text.py` to `keyboard/_win32.py` (into the new `Typeable` class) and use it for unknown characters.

- [x] Solve issues (Python 3.x specific?) with passing Unicode to `VkKeyScanEx()`.
    E.g. some Unicode characters have a length > 1, which the function won't accept. Perhaps Unicode events should be used instead?

- [x] Only calculate Unicode events on Windows.
    AFAIK they are not useful on other platforms. 