### PR TITLE
Implement Modifier element and fix Dictation deep copy issue

### DIFF
--- a/documentation/elements.txt
+++ b/documentation/elements.txt
@@ -56,6 +56,10 @@ Dictation class
 .. autoclass:: dragonfly.grammar.elements_basic.Dictation
    :members: dependencies, gstring, decode, value, children
 
+Modifier class
+----------------------------------------------------------------------------
+.. autoclass:: dragonfly.grammar.elements_basic.Modifier
+
 Compound class
 ----------------------------------------------------------------------------
 .. autoclass:: dragonfly.grammar.elements_compound.Compound

--- a/documentation/test_grammar_elements_basic_doctest.txt
+++ b/documentation/test_grammar_elements_basic_doctest.txt
@@ -111,6 +111,21 @@ Usage::
     >>> test_rep.recognize("hello world hello world")
     [[u'hello', u'world'], [u'hello', u'world']]
 
+Modifier element class
+============================================================================
+
+Basic usage::
+
+    >>> # Repetition is given a dragonfly element, in this case an IntegerRef.
+    >>> i = IntegerRef("n", 1, 10)
+    >>> # Specify min and max values to allow more than one repetition.
+    >>> rep = Repetition(i, min=1, max=16, optimize=False)
+    >>> # Modify the element to format the output
+    >>> mod = Modifier(rep, lambda rep: ", ".join(map(str, rep)))
+    >>> test_rep = ElementTester(mod)
+    >>> test_rep.recognize("one two three four")
+    '1, 2, 3, 4'
+
 
 RuleRef element class
 ============================================================================

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -38,7 +38,7 @@ from .grammar.rule_compound      import CompoundRule
 from .grammar.rule_mapping       import MappingRule
 from .grammar.elements  import (ElementBase, Sequence, Alternative,
                                 Optional, Repetition, Literal,
-                                ListRef, DictListRef, Dictation,
+                                ListRef, DictListRef, Dictation, Modifier,
                                 RuleRef, RuleWrap, Empty, Compound, Choice)
 
 from .grammar.context   import Context, AppContext, FuncContext

--- a/dragonfly/grammar/elements.py
+++ b/dragonfly/grammar/elements.py
@@ -55,6 +55,7 @@ DictListRef     = basic_.DictListRef
 DictList        = basic_.DictListRef    # For backwards compatibility.
 Empty           = basic_.Empty
 Dictation       = basic_.Dictation
+Modifier        = basic_.Modifier
 Impossible      = basic_.Impossible
 RuleWrap        = basic_.RuleWrap
 

--- a/dragonfly/grammar/elements_basic.py
+++ b/dragonfly/grammar/elements_basic.py
@@ -61,7 +61,7 @@ classes listed above:
 
 """
 
-
+import copy
 import logging
 from six import string_types
 
@@ -949,6 +949,9 @@ class Dictation(ElementBase):
             return "%s()" % (self.__class__.__name__)
 
     def __getattr__(self, name):
+        if isinstance(name, str) and name[:2] == name[-2:] == '__':
+            # skip non-existing dunder method lookups
+            raise AttributeError(name)
         def call(*args, **kwargs):
             self._string_methods.append((name, args, kwargs))
             return self

--- a/dragonfly/grammar/elements_compound.py
+++ b/dragonfly/grammar/elements_compound.py
@@ -317,9 +317,40 @@ class Compound(elements_.Alternative):
 # The Choice class which maps multiple Compound instances to values.
 
 class Choice(elements_.Alternative):
+    """
+        Element allowing a dictionary of phrases to be recognised to be mapped to objects to be used in an action.
 
+        Constructor arguments:
+            - *name* (*str*) -- the name of this element
+            - *choices* (*dict*) -- dictionary mapping recognised phrases to returned values
+            - *extras* (*list*, default: *None*) -- a list of included extras
+            - *default* (default: *None*) -- the default value of this element
+
+        Example:
+
+        .. code:: python
+
+            # Tab switching command e.g. 'third tab'
+            mapping = {
+                "<nth> tab": Key("c-%(nth)s"),
+            }
+            extras = [
+                Choice("nth", {
+                    "first"         : "1",
+                    "second"        : "2",
+                    "third"         : "3",
+                    "fourth"        : "4",
+                    "fifth"         : "5",
+                    "sixth"         : "6",
+                    "seventh"       : "7",
+                    "eighth"        : "8",
+                    "(last | ninth)": "9",
+                    "next"          : "pgdown",
+                    "previous"      : "pgup",
+                }),
+            ]
+    """
     def __init__(self, name, choices, extras=None, default=None):
-
         # Argument type checking.
         assert isinstance(name, string_types) or name is None
         assert isinstance(choices, dict)

--- a/dragonfly/test/test_dictation.py
+++ b/dragonfly/test/test_dictation.py
@@ -19,8 +19,9 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-
+import copy
 import unittest
+
 from six import string_types, text_type
 
 from dragonfly.engines.base.dictation   import DictationContainerBase
@@ -143,6 +144,16 @@ class ApplyDictationTestCase(ElementTestCase):
                     ("test some random dictation", "some_random_DICTATION"),
                     ("test touché jalapeño",       "touché_JALAPEÑO"),
                    ]
+
+
+class DictationCopyTestCase(unittest.TestCase):
+
+    def test_copy(self):
+        """ Test that Dictation elements can be copied. """
+        element = Dictation("text")
+        self.assertIsNot(element, copy.copy(element))
+        element = Dictation("text").camel()
+        self.assertIsNot(element, copy.copy(element))
 
 #===========================================================================
 

--- a/dragonfly/test/test_engine_text_dictation.py
+++ b/dragonfly/test/test_engine_text_dictation.py
@@ -20,7 +20,9 @@
 #
 
 
+import copy
 import unittest
+
 from six import string_types, text_type
 
 from dragonfly.engines.base.dictation   import DictationContainerBase
@@ -92,6 +94,16 @@ class NonAsciiStrDictationTestCase(ElementTestCase):
                     ("test TOUCHÉ",        "touché"),
                     ("test JALAPEÑO",      "jalapeño"),
                    ]
+
+
+class DictationCopyTestCase(unittest.TestCase):
+
+    def test_copy(self):
+        """ Test that Dictation elements can be copied. """
+        element = Dictation("text")
+        self.assertIsNot(element, copy.copy(element))
+        element = Dictation("text").camel()
+        self.assertIsNot(element, copy.copy(element))
 
 
 # ==========================================================================


### PR DESCRIPTION
Following the suggestion from @wolfmanstout in #96 I have implemented a new element which allows the output of any other element to be modified according to some function.

I was originally planning to do this using a method on `ElementBase` but this gets complicated quickly when you have a tree of elements and you only want to apply the function to one of them, so I think this is the simplest and clearest way.

@Danesprite it would be good to get your input on what to do about the issues with methods like `deepcopy` on `Dictation` objects. The modifier class provides similar functionality to calling methods on dictation objects, but is perhaps more verbose. We could either decide that the complexities of overriding `__getattr__` are not worth the gains and I can revert the modifications to `Dictation`, or I can try to fix the issues with making copies. I don't know whether there are other similar bugs lurking though.

I've done some testing in a notebook and it looks like adding something like the following would fix the issues, making magic methods behave as normal:
```
def __getattr__(self, name):
        if isinstance(name, str) and name[:2] == name[-2:] == '__':
            # skip non-existing dunder method lookups
            raise AttributeError(name)
        def call(*args, **kwargs):
            self._string_methods.append((name, args, kwargs))
            return self
        return call
```