### PR TITLE
Add note about requiring the `xdotool` to be installed in kaldi example.

### DIFF
--- a/documentation/kaldi_engine.txt
+++ b/documentation/kaldi_engine.txt
@@ -99,6 +99,10 @@ Once the dependencies and model are installed, you're ready to go!
 script. Simply run it from the directory containing the above model (or
 modify the configuration paths in the file) using::
 
+**Note for Linux:** Before proceeding, you'll need ``xdotool``. Under ``apt``-based
+distributions, you can get them by running ``sudo apt install
+xdotool``
+
   python path/to/kaldi_demo.py
 
 For more structured and long-term use, you'll want to use a **module


### PR DESCRIPTION
The example errors if the `xdotool` is not installed when you try to run this.

The error I got on ubuntu is as follows:
```
window (ERROR): Failed to execute command 'xdotool getactivewindow': [Errno 2] No such file or directory
Traceback (most recent call last):
  File "./dragonfly/examples/kaldi_demo.py", line 60, in <module>
    engine.do_recognition()
  File "/home/jasoons/.local/share/virtualenvs/dragonfly-zX3FzRWY/local/lib/python2.7/site-packages/dragonfly/engines/backend_kaldi/engine.py", line 233, in do_recognition
    kaldi_rules_activity = self._compute_kaldi_rules_activity()
  File "/home/jasoons/.local/share/virtualenvs/dragonfly-zX3FzRWY/local/lib/python2.7/site-packages/dragonfly/engines/backend_kaldi/engine.py", line 286, in _compute_kaldi_rules_activity
    fg_window = Window.get_foreground()
  File "/home/jasoons/.local/share/virtualenvs/dragonfly-zX3FzRWY/local/lib/python2.7/site-packages/dragonfly/windows/x11_window.py", line 104, in get_foreground
    window_id, _, _ = cls._run_xdotool_command(["getactivewindow"])
TypeError: 'NoneType' object is not iterable
```

Installing the package fixed it for me.