### PR TITLE
Remove duplicate dependency adding code

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -122,7 +122,6 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
         self._log.info("Loading grammar %s..." % grammar.name)
         if not self._decoder:
             self.connect()
-        grammar.engine = self
 
         kaldi_rule_by_rule_dict = self._compiler.compile_grammar(grammar, self)
         wrapper = GrammarWrapper(grammar, kaldi_rule_by_rule_dict, self)

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -124,8 +124,6 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
             self.connect()
         grammar.engine = self
 
-        grammar.add_all_dependencies()
-
         kaldi_rule_by_rule_dict = self._compiler.compile_grammar(grammar, self)
         wrapper = GrammarWrapper(grammar, kaldi_rule_by_rule_dict, self)
         for kaldi_rule in kaldi_rule_by_rule_dict.values():

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -124,11 +124,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
             self.connect()
         grammar.engine = self
 
-        # Dependency checking.
-        memo = []
-        for r in grammar._rules:
-            for d in r.dependencies(memo):
-                grammar.add_dependency(d)
+        grammar.add_all_dependencies()
 
         kaldi_rule_by_rule_dict = self._compiler.compile_grammar(grammar, self)
         wrapper = GrammarWrapper(grammar, kaldi_rule_by_rule_dict, self)

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -95,7 +95,6 @@ class NatlinkEngine(EngineBase):
         self._log.debug("Engine %s: loading grammar %s."
                         % (self, grammar.name))
 
-        grammar.engine = self
         grammar_object = self.natlink.GramObj()
         wrapper = GrammarWrapper(grammar, grammar_object, self)
         grammar_object.setBeginCallback(wrapper.begin_callback)

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -102,8 +102,6 @@ class NatlinkEngine(EngineBase):
         grammar_object.setResultsCallback(wrapper.results_callback)
         grammar_object.setHypothesisCallback(None)
 
-        grammar.add_all_dependencies()
-
         c = NatlinkCompiler()
         (compiled_grammar, rule_names) = c.compile_grammar(grammar)
         grammar._rule_names = rule_names

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -102,11 +102,7 @@ class NatlinkEngine(EngineBase):
         grammar_object.setResultsCallback(wrapper.results_callback)
         grammar_object.setHypothesisCallback(None)
 
-        # Dependency checking.
-        memo = []
-        for r in grammar._rules:
-            for d in r.dependencies(memo):
-                grammar.add_dependency(d)
+        grammar.add_all_dependencies()
 
         c = NatlinkCompiler()
         (compiled_grammar, rule_names) = c.compile_grammar(grammar)

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -136,8 +136,6 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
 
         grammar.engine = self
 
-        grammar.add_all_dependencies()
-
         # Create recognition context, compile grammar, and create
         #  the grammar wrapper object for managing this grammar.
         context = self._recognizer.CreateRecoContext()

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -134,8 +134,6 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
         if not self._recognizer:
             self.connect()
 
-        grammar.engine = self
-
         # Create recognition context, compile grammar, and create
         #  the grammar wrapper object for managing this grammar.
         context = self._recognizer.CreateRecoContext()

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -136,11 +136,7 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
 
         grammar.engine = self
 
-        # Dependency checking.
-        memo = []
-        for r in grammar._rules:
-            for d in r.dependencies(memo):
-                grammar.add_dependency(d)
+        grammar.add_all_dependencies()
 
         # Create recognition context, compile grammar, and create
         #  the grammar wrapper object for managing this grammar.

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -465,7 +465,6 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
                         % (self, grammar.name))
 
         grammar.engine = self
-        grammar.add_all_dependencies()
 
         wrapper = self._build_grammar_wrapper(grammar)
 

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -465,11 +465,7 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
                         % (self, grammar.name))
 
         grammar.engine = self
-        # Dependency checking.
-        memo = []
-        for r in grammar.rules:
-            for d in r.dependencies(memo):
-                grammar.add_dependency(d)
+        grammar.add_all_dependencies()
 
         wrapper = self._build_grammar_wrapper(grammar)
 

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -463,9 +463,6 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         """ Load the given *grammar* and return a wrapper. """
         self._log.debug("Engine %s: loading grammar %s."
                         % (self, grammar.name))
-
-        grammar.engine = self
-
         wrapper = self._build_grammar_wrapper(grammar)
 
         # Check that the engine doesn't already have a grammar with the same

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -88,7 +88,6 @@ class TextInputEngine(EngineBase):
                         % (self, grammar.name))
 
         grammar.engine = self
-        grammar.add_all_dependencies()
 
         return self._build_grammar_wrapper(grammar)
 

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -86,9 +86,6 @@ class TextInputEngine(EngineBase):
         """ Load the given *grammar* and return a wrapper. """
         self._log.debug("Engine %s: loading grammar %s."
                         % (self, grammar.name))
-
-        grammar.engine = self
-
         return self._build_grammar_wrapper(grammar)
 
     def _unload_grammar(self, grammar, wrapper):

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -88,11 +88,7 @@ class TextInputEngine(EngineBase):
                         % (self, grammar.name))
 
         grammar.engine = self
-        # Dependency checking.
-        memo = []
-        for r in grammar.rules:
-            for d in r.dependencies(memo):
-                grammar.add_dependency(d)
+        grammar.add_all_dependencies()
 
         return self._build_grammar_wrapper(grammar)
 

--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -245,6 +245,17 @@ class Grammar(object):
         else:
             raise GrammarError("Unknown dependency type %s." % dep)
 
+    def add_all_dependencies(self):
+        """
+            Iterate through the grammar's rules and add all the necessary dependencies.
+
+            **Internal** This method is called by the engine when the grammar is loaded.
+        """
+        memo = []
+        for r in self._rules:
+            for d in r.dependencies(memo):
+                self.add_dependency(d)
+
     # ----------------------------------------------------------------------
     # Methods for runtime modification of a grammar's contents.
 

--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -346,6 +346,7 @@ class Grammar(object):
         if self._loaded:
             return
 
+        self.add_all_dependencies()
         self._engine.load_grammar(self)
         self._loaded = True
         self._in_context = False

--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -249,7 +249,7 @@ class Grammar(object):
         """
             Iterate through the grammar's rules and add all the necessary dependencies.
 
-            **Internal** This method is called by the engine when the grammar is loaded.
+            **Internal** This method is called when the grammar is loaded.
         """
         memo = []
         for r in self._rules:


### PR DESCRIPTION
Before being compiled grammars need to loop through the rules the user has added and add their dependencies. Previously this was done manually in the engines but makes much more sense as a method on the grammar class.

Tagging @daanzu.

Edit: Also, in every engine's `_load_grammar` method there is the line:
```
grammar.engine = self
```

this seems redundant since in order to get to that stage the grammar had to have called:
```
self._engine.load_grammar(self)
```
so it must have the engine set already. Am I missing something?