### PR TITLE
Add keywords argument handling to AppContext class

### DIFF
--- a/dragonfly/grammar/context.py
+++ b/dragonfly/grammar/context.py
@@ -61,6 +61,25 @@ Firefox is in the foreground, but only if Google Reader is
    firefox_but_not_reader_context = firefox_context & ~reader_context
 
 
+Matching other window attributes
+----------------------------------------------------------------------------
+
+The :class:`AppContext` class can be used to match window attributes and
+properties other than the title and executable. To do this, pass extra
+keyword arguments to the constructor::
+
+   # Context for a maximized Firefox window.
+   maximized_firefox = AppContext(executable="firefox", is_maximized=True)
+
+   # Context for a browser in fullscreen mode.
+   # 'role' and 'is_fullscreen' are X11 only.
+   fullscreen_browser = AppContext(role="browser", is_fullscreen=True)
+
+   # Context for Android Studio or PyCharm using the X11 'cls' property.
+   AppContext(cls=["jetbrains-studio", "jetbrains-pycharm-ce"])
+
+
+
 Class reference
 ----------------------------------------------------------------------------
 

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -133,7 +133,12 @@ class Win32Window(BaseWindow):
     is_enabled      = _win32gui_test("IsWindowEnabled")
     is_visible      = _win32gui_test("IsWindowVisible")
     is_minimized    = _win32gui_test("IsIconic")
-#   is_maximized    = _win32gui_test("IsZoomed")  # IsZoomed is unavailable
+
+    @property
+    def is_maximized(self):
+        # IsZoomed() is not available from win32gui for some reason.
+        # So we use the function directly.
+        return bool(windll.user32.IsZoomed(self._handle))
 
     def _win32gui_show_window(state):
         return lambda self: win32gui.ShowWindow(self._handle, state)


### PR DESCRIPTION
This allows using `AppContext` to match window attributes other than the title and executable. For example, matching `cls` or `cls_name` on X11, similar to what Aenea's `ProxyAppContext` function allows. This will work with any existing window property or attribute.

It works by getting a window using the `handle` parameter.

@mrob95 I've also made this work with your list additions added by #82. This is especially useful on X11/Linux where the `cls` and/or `cls_name` properties are more meaningful than the executable.

Some examples:

```Python
# Context for maximized Firefox
AppContext(executable="firefox", is_maximized=True)

# X11 context for a browser in fullscreen mode.
AppContext(role="browser", is_fullscreen=True)

# X11 context for Android Studio or PyCharm
AppContext(cls=["jetbrains-studio", "jetbrains-pycharm-ce"])

```

I've implemented the missing `Win32Window.is_maximized` property in this PR too. Just realised the `IsZoomed()` function can just be called directly with `ctypes`.