### PR TITLE
Add check to avoid unnecessarily preparing expensive debug log messages

### DIFF
--- a/dragonfly/grammar/state.py
+++ b/dragonfly/grammar/state.py
@@ -172,7 +172,7 @@ class State(object):
         return None
 
     def _log_step(self, parser, message):
-        if not self._log_decode:
+        if not self._log_decode or not self._log_decode.isEnabledFor(logging.DEBUG):
             return
         indent = u"   " * self._depth
         output = u"%s%s: %s" % (indent, message, parser)


### PR DESCRIPTION
This is surprisingly dominant in CPU profiling, based on yappi. Seems like a pretty simple and safe improvement.