### PR TITLE
Implement mouse and monitor functionality for X11 & Mac OS

### DIFF
--- a/documentation/monitor_classes.txt
+++ b/documentation/monitor_classes.txt
@@ -5,8 +5,6 @@ Monitor classes
 The monitor classes are how Dragonfly gets information on the available
 monitors (a.k.a. screens, displays) for the current platform.
 
-The :class:`BaseMonitor` class will be used on unsupported platforms.
-
 .. automodule:: dragonfly.windows.base_monitor
    :members:
 
@@ -14,4 +12,7 @@ The :class:`BaseMonitor` class will be used on unsupported platforms.
    :members:
 
 .. automodule:: dragonfly.windows.x11_monitor
+   :members:
+
+.. automodule:: dragonfly.windows.monitor
    :members:

--- a/documentation/monitor_classes.txt
+++ b/documentation/monitor_classes.txt
@@ -1,0 +1,17 @@
+
+Monitor classes
+============================================================================
+
+The monitor classes are how Dragonfly gets information on the available
+monitors (a.k.a. screens, displays) for the current platform.
+
+The :class:`BaseMonitor` class will be used on unsupported platforms.
+
+.. automodule:: dragonfly.windows.base_monitor
+   :members:
+
+.. automodule:: dragonfly.windows.win32_monitor
+   :members:
+
+.. automodule:: dragonfly.windows.x11_monitor
+   :members:

--- a/documentation/windows.txt
+++ b/documentation/windows.txt
@@ -12,4 +12,5 @@ Contents of Dragonfly's windows sub-package:
    :maxdepth: 2
 
    clipboard
+   monitor_classes
    window_classes

--- a/dragonfly/actions/__init__.py
+++ b/dragonfly/actions/__init__.py
@@ -34,18 +34,17 @@ from .typeables           import typeables
 from .action_key          import Key
 from .action_text         import Text
 from .action_paste        import Paste
+from .action_mouse        import Mouse
 from .action_waitwindow   import WaitWindow
 from .action_focuswindow  import FocusWindow
 from .action_startapp     import StartApp, BringApp
 
 if sys.platform.startswith("win"):
     # Import Windows only classes and functions.
-    from .action_mouse        import Mouse
     from .action_playsound    import PlaySound
     from .sendinput           import (KeyboardInput, MouseInput,
                                       HardwareInput, make_input_array,
                                       send_input_array)
 else:
     # Import mocked classes and functions for other platforms.
-    from ..os_dependent_mock import Mouse
     from ..os_dependent_mock import PlaySound

--- a/dragonfly/actions/actions.py
+++ b/dragonfly/actions/actions.py
@@ -36,15 +36,14 @@ from .keyboard            import Keyboard, Typeable
 from .action_key          import Key
 from .action_text         import Text
 from .action_paste        import Paste
+from .action_mouse        import Mouse
 from .action_waitwindow   import WaitWindow
 from .action_focuswindow  import FocusWindow
 from .action_startapp     import StartApp, BringApp
 
 if sys.platform.startswith("win"):
     # Import Windows only classes and functions.
-    from .action_mouse        import Mouse
     from .action_playsound    import PlaySound
 else:
     # Import mocked classes and functions for other platforms.
-    from ..os_dependent_mock import Mouse
     from ..os_dependent_mock import PlaySound

--- a/dragonfly/actions/mouse/__init__.py
+++ b/dragonfly/actions/mouse/__init__.py
@@ -1,0 +1,68 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+
+"""
+This module initializes the mouse interface for the current platform.
+"""
+
+import os
+import sys
+
+# Import mouse events common to each platform.
+from ._base import (EventBase, PauseEvent, MoveEvent, MoveRelativeEvent,
+                    MoveScreenEvent, MoveWindowEvent)
+
+
+# Import the mouse functions and classes for the current platform.
+# Always use the base classes for building documentation.
+DOC_BUILD = bool(os.environ.get("SPHINX_BUILD_RUNNING"))
+if sys.platform.startswith("win") and not DOC_BUILD:
+    from ._win32 import (
+        ButtonEvent, get_cursor_position, set_cursor_position,
+        PLATFORM_BUTTON_FLAGS, PLATFORM_WHEEL_FLAGS
+    )
+
+elif ((os.environ.get("XDG_SESSION_TYPE") == "x11" or
+       sys.platform == "darwin") and not DOC_BUILD):
+    from ._pynput import (
+        ButtonEvent, get_cursor_position, set_cursor_position,
+        PLATFORM_BUTTON_FLAGS, PLATFORM_WHEEL_FLAGS
+    )
+
+else:
+    # No mouse interface is available. Dragonfly can function
+    # without this functionality, so don't raise an error or log any
+    # messages. Errors/messages will occur later if the mouse is used.
+    from ._base import (
+        BaseButtonEvent as ButtonEvent, get_cursor_position,
+        set_cursor_position, PLATFORM_BUTTON_FLAGS, PLATFORM_WHEEL_FLAGS
+    )
+
+
+# Ensure all button and wheel flag names are accounted for.
+# Used for debugging. Uncomment if adding new buttons or aliases.
+# _BUTTON_NAMES = ["left", "right", "middle", "four", "five"]
+# _WHEEL_NAMES = ["wheelup", "stepup", "wheeldown", "stepdown",
+#                 "wheelright", "stepright", "wheelleft", "stepleft"]
+# assert sorted(PLATFORM_BUTTON_FLAGS.keys()) == sorted(_BUTTON_NAMES),\
+#     "Mouse implementation is missing button flags"
+# assert sorted(PLATFORM_WHEEL_FLAGS.keys()) == sorted(_WHEEL_NAMES),\
+#     "Mouse implementation is missing wheel flags"

--- a/dragonfly/actions/mouse/_base.py
+++ b/dragonfly/actions/mouse/_base.py
@@ -1,0 +1,183 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+import time
+
+from dragonfly.actions.action_base import ActionError
+from dragonfly.windows import monitors
+
+
+#---------------------------------------------------------------------------
+# Functions and event delegate for getting and setting the cursor position.
+
+def get_cursor_position():
+    message = ("Getting the cursor position is not implemented on this "
+               "platform!")
+    raise NotImplementedError(message)
+
+
+def set_cursor_position(x, y):
+    message = ("Setting the cursor position is not implemented on this "
+               "platform!")
+    raise NotImplementedError(message)
+
+
+class MoveEventDelegate(object):
+
+    @classmethod
+    def get_position(cls):
+        return get_cursor_position()
+
+    @classmethod
+    def set_position(cls, x, y):
+        return set_cursor_position(x, y)
+
+
+#---------------------------------------------------------------------------
+# Mouse button and wheel up/down flags.
+# These flags should be overridden for each supported platform.
+
+PLATFORM_BUTTON_FLAGS = {
+    "left":   ((1, 1),   # down
+               (1, 0)),  # up
+    "right":  ((2, 1),
+               (2, 0)),
+    "middle": ((3, 1),
+               (3, 0)),
+    "four":   ((4, 1),
+               (4, 0)),
+    "five":   ((5, 1),
+               (5, 0)),
+}
+
+
+PLATFORM_WHEEL_FLAGS = {
+    "wheelup": (1, 120),
+    "stepup": (1, 40),
+    "wheeldown": (1, -120),
+    "stepdown": (1, -40),
+    "wheelright": (2, 120),
+    "stepright": (2, 40),
+    "wheelleft": (2, -120),
+    "stepleft": (2, -40),
+}
+
+
+#---------------------------------------------------------------------------
+# Event classes.
+
+
+class EventBase(object):
+
+    def execute(self, window):
+        pass
+
+
+class MoveEvent(EventBase):
+
+    # Set the event delegate. This allows us to set platform-specific
+    # functions for getting and setting the cursor position without having
+    # to do a lot of sub-classing for no good reason.
+    delegate = MoveEventDelegate()
+
+    def __init__(self, from_left, horizontal, from_top, vertical):
+        self.from_left = from_left
+        self.horizontal = horizontal
+        self.from_top = from_top
+        self.vertical = vertical
+        EventBase.__init__(self)
+
+    def _move_relative(self, rectangle):
+        if self.from_left:  horizontal = rectangle.x1
+        else:               horizontal = rectangle.x2
+        if isinstance(self.horizontal, float):
+            distance = self.horizontal * rectangle.dx
+        else:
+            distance = self.horizontal
+        horizontal += distance
+
+        if self.from_top:   vertical = rectangle.y1
+        else:               vertical = rectangle.y2
+        if isinstance(self.vertical, float):
+            distance = self.vertical * rectangle.dy
+        else:
+            distance = self.vertical
+        vertical += distance
+
+        self._move_mouse(horizontal, vertical)
+
+    def _get_position(self):
+        return self.delegate.get_position()
+
+    def _move_mouse(self, horizontal, vertical):
+        self.delegate.set_position(horizontal, vertical)
+
+
+class MoveWindowEvent(MoveEvent):
+
+    def execute(self, window):
+        self._move_relative(window.get_position())
+
+
+class MoveScreenEvent(MoveEvent):
+
+    def execute(self, window):
+        # Move the mouse relative to the first monitor's rectangle.
+        # Do nothing if there are no monitors in the list.
+        if monitors:
+            self._move_relative(monitors[0].rectangle)
+
+
+class BaseButtonEvent(EventBase):
+
+    def __init__(self, *flags):
+        EventBase.__init__(self)
+        self._flags = flags
+
+    def execute(self, window):
+        message = ("Mouse button events are not implemented for this "
+                   "platform!")
+        raise NotImplementedError(message)
+
+
+class MoveRelativeEvent(MoveEvent):
+
+    def __init__(self, horizontal, vertical):
+        MoveEvent.__init__(self, None, None, None, None)
+        self.horizontal = horizontal
+        self.vertical = vertical
+
+    def execute(self, window):
+        position = self._get_position()
+        if not position:
+            raise ActionError("Failed to retrieve cursor position.")
+        horizontal = position[0] + self.horizontal
+        vertical   = position[1] + self.vertical
+        self._move_mouse(horizontal, vertical)
+
+
+class PauseEvent(EventBase):
+
+    def __init__(self, interval):
+        EventBase.__init__(self)
+        self._interval = interval
+
+    def execute(self, window):
+        time.sleep(self._interval)

--- a/dragonfly/actions/mouse/_pynput.py
+++ b/dragonfly/actions/mouse/_pynput.py
@@ -1,0 +1,120 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+from pynput.mouse import Controller, Button
+
+from ._base import BaseButtonEvent, MoveEvent
+
+
+# Initialise a pynput mouse controller.
+_controller = Controller()
+
+
+#---------------------------------------------------------------------------
+# Functions and event delegate for getting and setting the cursor position.
+
+def get_cursor_position():
+    return _controller.position
+
+
+def set_cursor_position(x, y):
+    _controller.position = (x, y)
+    return True
+
+
+class MoveEventDelegate(object):
+
+    @classmethod
+    def get_position(cls):
+        return get_cursor_position()
+
+    @classmethod
+    def set_position(cls, x, y):
+        return set_cursor_position(x, y)
+
+
+# Set MoveEvent's delegate. This allows us to set platform-specific
+# functions for getting and setting the cursor position without having
+# to do a lot of sub-classing for no good reason.
+MoveEvent.delegate = MoveEventDelegate()
+
+#---------------------------------------------------------------------------
+# Pynput mouse button and wheel up/down flags.
+
+
+def get_button(name):
+    # If possible, get a Button from the name.
+    # This allows button and wheel flags to work, at least partially, on
+    # multiple platforms.
+    return getattr(Button, name, None)
+
+
+PLATFORM_BUTTON_FLAGS = {
+    # ((button, event_type), down)
+    # The inner pair is used here and below to be compatible with the
+    # original Windows flags.
+    "left":   (((get_button("left"), 0), 1),  # down
+               ((get_button("left"), 0), 0)),  # up
+    "right":  (((get_button("right"), 0), 1),
+               ((get_button("right"), 0), 0)),
+    "middle": (((get_button("middle"), 0), 1),
+               ((get_button("middle"), 0), 0)),
+
+    # We call these "four" and "five" because Windows calls them that.
+    # These buttons typically behave as browser back and forward media keys.
+    "four": (((get_button("button8"), 0), 1),
+             ((get_button("button8"), 0), 0)),
+    "five": (((get_button("button9"), 0), 1),
+             ((get_button("button9"), 0), 0)),
+}
+
+PLATFORM_WHEEL_FLAGS = {
+    # ((button, event_type), scroll_count)
+    "wheelup": ((get_button("scroll_up"), 1), 3),
+    "stepup": ((get_button("scroll_up"), 1), 1),
+    "wheeldown": ((get_button("scroll_down"), 1), 3),
+    "stepdown": ((get_button("scroll_down"), 1), 1),
+    "wheelright": ((get_button("scroll_right"), 1), 3),
+    "stepright": ((get_button("scroll_right"), 1), 1),
+    "wheelleft": ((get_button("scroll_left"), 1), 3),
+    "stepleft": ((get_button("scroll_left"), 1), 1),
+}
+
+
+#---------------------------------------------------------------------------
+# pynput event classes.
+
+
+class ButtonEvent(BaseButtonEvent):
+
+    def execute(self, window):
+        for ((button, event_type), flag) in self._flags:
+            # Check if the button is unknown.
+            if button is None:
+                event_type_s = "button" if event_type == 0 else "scroll"
+                raise ValueError("Unsupported %s event" % event_type_s)
+
+            if event_type == 0:  # Button press event
+                if flag:
+                    _controller.press(button)
+                else:
+                    _controller.release(button)
+            elif event_type == 1:  # Scroll event
+                _controller.click(button, flag)

--- a/dragonfly/actions/mouse/_win32.py
+++ b/dragonfly/actions/mouse/_win32.py
@@ -1,0 +1,111 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+import win32con
+
+from ctypes import windll, pointer, c_long, c_ulong, Structure
+
+from dragonfly.actions.sendinput import (MouseInput, make_input_array,
+                                         send_input_array)
+from ._base import BaseButtonEvent, MoveEvent
+
+
+#---------------------------------------------------------------------------
+# Functions and event delegate for getting and setting the cursor position.
+
+class Point(Structure):
+    _fields_ = [
+                ('x',  c_long),
+                ('y',  c_long),
+               ]
+
+
+def get_cursor_position():
+    point = Point()
+    result = windll.user32.GetCursorPos(pointer(point))
+    if result:
+        return point.x, point.y
+    else:
+        return None
+
+
+def set_cursor_position(x, y):
+    result = windll.user32.SetCursorPos(c_long(int(x)), c_long(int(y)))
+    return not result
+
+
+class MoveEventDelegate(object):
+
+    @classmethod
+    def get_position(cls):
+        return get_cursor_position()
+
+    @classmethod
+    def set_position(cls, x, y):
+        return set_cursor_position(x, y)
+
+
+# Set MoveEvent's delegate. This allows us to set platform-specific
+# functions for getting and setting the cursor position without having
+# to do a lot of sub-classing for no good reason.
+MoveEvent.delegate = MoveEventDelegate()
+
+#---------------------------------------------------------------------------
+# Win32 mouse button and wheel up/down flags.
+
+# Taken from https://msdn.microsoft.com/en-us/library/windows/desktop/ms646273(v=vs.85).aspx
+MOUSEEVENTF_HWHEEL = 0x1000
+
+PLATFORM_BUTTON_FLAGS = {
+    "left":   ((win32con.MOUSEEVENTF_LEFTDOWN, 0),
+               (win32con.MOUSEEVENTF_LEFTUP, 0)),
+    "right":  ((win32con.MOUSEEVENTF_RIGHTDOWN, 0),
+               (win32con.MOUSEEVENTF_RIGHTUP, 0)),
+    "middle": ((win32con.MOUSEEVENTF_MIDDLEDOWN, 0),
+               (win32con.MOUSEEVENTF_MIDDLEUP, 0)),
+    "four": ((win32con.MOUSEEVENTF_XDOWN, 1),
+             (win32con.MOUSEEVENTF_XUP, 1)),
+    "five": ((win32con.MOUSEEVENTF_XDOWN, 2),
+             (win32con.MOUSEEVENTF_XUP, 2)),
+}
+
+PLATFORM_WHEEL_FLAGS = {
+    "wheelup": (win32con.MOUSEEVENTF_WHEEL, 120),
+    "stepup": (win32con.MOUSEEVENTF_WHEEL, 40),
+    "wheeldown": (win32con.MOUSEEVENTF_WHEEL, -120),
+    "stepdown": (win32con.MOUSEEVENTF_WHEEL, -40),
+    "wheelright": (MOUSEEVENTF_HWHEEL, 120),
+    "stepright": (MOUSEEVENTF_HWHEEL, 40),
+    "wheelleft": (MOUSEEVENTF_HWHEEL, -120),
+    "stepleft": (MOUSEEVENTF_HWHEEL, -40),
+}
+
+
+#---------------------------------------------------------------------------
+# Win32 event classes.
+
+class ButtonEvent(BaseButtonEvent):
+
+    def execute(self, window):
+        zero = pointer(c_ulong(0))
+        inputs = [MouseInput(0, 0, flag[1], flag[0], 0, zero)
+                  for flag in self._flags]
+        array = make_input_array(inputs)
+        send_input_array(array)

--- a/dragonfly/os_dependent_mock.py
+++ b/dragonfly/os_dependent_mock.py
@@ -38,10 +38,3 @@ class MockAction(ActionBase):
 class PlaySound(ActionBase):
     def __init__(self, name=None, file=None):
         ActionBase.__init__(self)
-
-
-monitors = []
-
-
-class Monitor(MockBase):
-    pass

--- a/dragonfly/os_dependent_mock.py
+++ b/dragonfly/os_dependent_mock.py
@@ -21,7 +21,7 @@ Heavily modified to allow more dragonfly functionality to work
 regardless of operating system.
 """
 
-from .actions import ActionBase, DynStrActionBase
+from .actions import ActionBase
 
 
 class MockBase(object):
@@ -33,12 +33,6 @@ class MockAction(ActionBase):
     """ Mock class for dragonfly actions. """
     def __init__(self, *args, **kwargs):
         ActionBase.__init__(self)
-
-
-class Mouse(DynStrActionBase):
-    """ Mock Mouse action class. """
-    def __init__(self, spec=None, static=False):
-        DynStrActionBase.__init__(self, spec, static)
 
 
 class PlaySound(ActionBase):

--- a/dragonfly/windows/__init__.py
+++ b/dragonfly/windows/__init__.py
@@ -25,12 +25,8 @@ from .rectangle   import Rectangle, unit
 from .point       import Point
 from .window      import Window
 from .fake_window import FakeWindow
+from .monitor     import Monitor, monitors
 
 # Windows-specific
 if sys.platform.startswith("win"):
-    from .monitor      import Monitor, monitors
     from .clipboard    import Clipboard
-
-# Import mock classes.
-else:
-    from ..os_dependent_mock import Monitor, monitors

--- a/dragonfly/windows/base_monitor.py
+++ b/dragonfly/windows/base_monitor.py
@@ -1,0 +1,94 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+    This file offers an interface to the system's information about
+    available monitors (a.k.a. screens, displays).
+"""
+
+import logging
+
+from six import integer_types
+
+from .rectangle import Rectangle
+
+
+#---------------------------------------------------------------------------
+# List of monitors that will be filled when this module is loaded and
+# updated on calls to `Monitor.update_monitors_list`.
+
+monitors = []
+
+
+#===========================================================================
+# Monitor classes for storing info about single display monitor.
+
+class BaseMonitor(object):
+
+    _log = logging.getLogger("monitor.init")
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    def __init__(self, handle, rectangle):
+        assert isinstance(handle, integer_types)
+        self._handle = handle
+        assert isinstance(rectangle, Rectangle)
+        self._rectangle = rectangle
+
+    def __str__(self):
+        return "%s(%d)" % (self.__class__.__name__, self._handle)
+
+    @classmethod
+    def update_monitors_list(cls):
+        """
+        Update dragonfly's monitors list with new monitors, delete monitors
+        that aren't found and replace rectangles of monitors that have
+        changed.
+        """
+        pass
+
+    #-----------------------------------------------------------------------
+    # Methods that control attribute access.
+
+    def _set_handle(self, handle):
+        assert isinstance(handle, integer_types)
+        self._handle = handle
+
+    handle = property(fget=lambda self: self._handle,
+                      fset=_set_handle,
+                      doc="Protected access to handle attribute.")
+
+    def _get_updated_rectangle(self):
+        self.update_monitors_list()
+        return self._rectangle
+
+    def _set_rectangle(self, rectangle):
+        assert isinstance(rectangle, Rectangle)
+        self._rectangle = rectangle  # Should make a copy??
+
+    rectangle = property(fget=_get_updated_rectangle,
+                         fset=_set_rectangle,
+                         doc="Protected access to rectangle attribute.")
+
+
+# Enumerate monitors and build Dragonfly's monitor list when this
+# module is loaded.
+BaseMonitor.update_monitors_list()

--- a/dragonfly/windows/base_monitor.py
+++ b/dragonfly/windows/base_monitor.py
@@ -18,11 +18,6 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-"""
-    This file offers an interface to the system's information about
-    available monitors (a.k.a. screens, displays).
-"""
-
 import logging
 
 from six import integer_types
@@ -41,6 +36,9 @@ monitors = []
 # Monitor classes for storing info about single display monitor.
 
 class BaseMonitor(object):
+    """
+    The base monitor class.
+    """
 
     _log = logging.getLogger("monitor.init")
 

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -24,9 +24,12 @@ Base Window class
 
 """
 
-from six import string_types, integer_types, binary_type
 from locale import getpreferredencoding
 
+from six import string_types, integer_types, binary_type
+
+from .monitor import monitors
+from .rectangle import unit
 from .window_movers import window_movers
 
 #===========================================================================
@@ -239,6 +242,53 @@ class BaseWindow(object):
         :type rectangle: Rectangle
         """
         raise NotImplementedError()
+
+    def get_containing_monitor(self):
+        """
+        Method to get the :class:`Monitor` containing the window.
+
+        This checks which monitor contains the center of the window.
+
+        :returns: containing monitor
+        :rtype: Monitor
+        """
+        center = self.get_position().center
+        for monitor in monitors:
+            if monitor.rectangle.contains(center):
+                return monitor
+        # Fall through, return first monitor.
+        return monitors[0]
+
+    def get_normalized_position(self):
+        """
+        Method to get the window's normalized position.
+
+        This is useful when working with multiple monitors.
+
+        :returns: normalized position
+        :rtype: Rectangle
+        """
+        monitor = self.get_containing_monitor()
+        rectangle = self.get_position()
+        rectangle.renormalize(monitor.rectangle, unit)
+        return rectangle
+
+    def set_normalized_position(self, rectangle, monitor=None):
+        """
+        Method to get the window's normalized position.
+
+        This is useful when working with multiple monitors.
+
+        :param rectangle: window position
+        :type rectangle: Rectangle
+        :param monitor: monitor to normalize to (default: the first one).
+        :type monitor: Monitor
+        """
+        if not monitor:
+            monitor = self.get_containing_monitor()
+
+        rectangle.renormalize(unit, monitor.rectangle)
+        self.set_position(rectangle)
 
     #-----------------------------------------------------------------------
     # Methods for miscellaneous window control.

--- a/dragonfly/windows/darwin_monitor.py
+++ b/dragonfly/windows/darwin_monitor.py
@@ -1,0 +1,87 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+from AppKit import NSScreen
+
+from .base_monitor import BaseMonitor
+from .rectangle import Rectangle
+
+
+#---------------------------------------------------------------------------
+# List of monitors that will be filled when this module is loaded and
+# updated on calls to `Monitor.update_monitors_list`.
+
+monitors = []
+
+
+#===========================================================================
+# Monitor class for storing info about single display monitor.
+
+class DarwinMonitor(BaseMonitor):
+    """
+    The monitor class used on Mac OS (Darwin).
+
+    Monitors for Mac OS are **not** automatically updated because ``AppKit``
+    doesn't update monitor information after it is retrieved. A simple
+    workaround for this is to restart the Python interpreter after a monitor
+    change.
+
+    """
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    @classmethod
+    def update_monitors_list(cls):
+        # Get a list of the current monitor handles.
+        monitor_handles = [m.handle for m in monitors]
+
+        # Get monitor information from AppKit.
+        new_monitor_handles = []
+        for screen in NSScreen.screens():
+            handle = screen.deviceDescription()['NSScreenNumber']
+            frame = screen.frame()
+            dx = frame.size.width - frame.origin.x
+            dy = frame.size.height - frame.origin.y
+            rectangle = Rectangle(frame.origin.x, frame.origin.y, dx, dy)
+
+            # Check if this monitor is already in the list.
+            if handle in monitor_handles:
+                # Replace the monitor's rectangle if it has changed.
+                index = monitor_handles.index(handle)
+                monitor = monitors[index]
+                if rectangle != monitor._rectangle:
+                    monitor.rectangle = rectangle
+            else:
+                # Add a new monitor object to the list.
+                monitors.append(cls(handle, rectangle))
+
+            # Keep track of each monitor handle.
+            new_monitor_handles.append(handle)
+
+        # Remove any monitors whose handles weren't found.
+        for monitor in tuple(monitors):
+            if monitor.handle not in new_monitor_handles:
+                monitors.remove(monitor)
+
+
+# Enumerate monitors and build Dragonfly's monitor list when this
+# module is loaded.
+DarwinMonitor.update_monitors_list()

--- a/dragonfly/windows/darwin_monitor.py
+++ b/dragonfly/windows/darwin_monitor.py
@@ -24,15 +24,8 @@ from .base_monitor import BaseMonitor
 from .rectangle import Rectangle
 
 
-#---------------------------------------------------------------------------
-# List of monitors that will be filled when this module is loaded and
-# updated on calls to `Monitor.update_monitors_list`.
-
-monitors = []
-
-
 #===========================================================================
-# Monitor class for storing info about single display monitor.
+# Monitor class for storing info about a single display monitor.
 
 class DarwinMonitor(BaseMonitor):
     """
@@ -46,42 +39,24 @@ class DarwinMonitor(BaseMonitor):
     """
 
     #-----------------------------------------------------------------------
-    # Methods for initialization and introspection.
+    # Class methods to create new Monitor objects.
 
     @classmethod
-    def update_monitors_list(cls):
-        # Get a list of the current monitor handles.
-        monitor_handles = [m.handle for m in monitors]
-
+    def get_all_monitors(cls):
         # Get monitor information from AppKit.
-        new_monitor_handles = []
+        monitors = []
         for screen in NSScreen.screens():
+            # Get the monitor handle.
             handle = screen.deviceDescription()['NSScreenNumber']
+
+            # Create a rectangle object representing the monitor's
+            # dimensions and relative position.
             frame = screen.frame()
             dx = frame.size.width - frame.origin.x
             dy = frame.size.height - frame.origin.y
             rectangle = Rectangle(frame.origin.x, frame.origin.y, dx, dy)
 
-            # Check if this monitor is already in the list.
-            if handle in monitor_handles:
-                # Replace the monitor's rectangle if it has changed.
-                index = monitor_handles.index(handle)
-                monitor = monitors[index]
-                if rectangle != monitor._rectangle:
-                    monitor.rectangle = rectangle
-            else:
-                # Add a new monitor object to the list.
-                monitors.append(cls(handle, rectangle))
+            # Get a new or updated monitor object and add it to the list.
+            monitors.append(cls.get_monitor(handle, rectangle))
 
-            # Keep track of each monitor handle.
-            new_monitor_handles.append(handle)
-
-        # Remove any monitors whose handles weren't found.
-        for monitor in tuple(monitors):
-            if monitor.handle not in new_monitor_handles:
-                monitors.remove(monitor)
-
-
-# Enumerate monitors and build Dragonfly's monitor list when this
-# module is loaded.
-DarwinMonitor.update_monitors_list()
+        return monitors

--- a/dragonfly/windows/monitor.py
+++ b/dragonfly/windows/monitor.py
@@ -21,9 +21,13 @@
 import sys
 import os
 
-# Windows-specific
+# Windows
 if sys.platform.startswith("win"):
     from .win32_monitor import Win32Monitor as Monitor, monitors
+
+# Mac OS
+elif sys.platform == "darwin":
+    from .darwin_monitor import DarwinMonitor as Monitor, monitors
 
 # Linux/X11
 elif os.environ.get("XDG_SESSION_TYPE") == "x11":

--- a/dragonfly/windows/monitor.py
+++ b/dragonfly/windows/monitor.py
@@ -18,108 +18,17 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-"""
-    This file offers an interface to the Win32 information about
-    available monitors (a.k.a. screens, displays).
-"""
-from six import integer_types
+import sys
+import os
 
-import win32api
-import logging
+# Windows-specific
+if sys.platform.startswith("win"):
+    from .win32_monitor import Win32Monitor as Monitor, monitors
 
-from .rectangle import Rectangle
+# Linux/X11
+elif os.environ.get("XDG_SESSION_TYPE") == "x11":
+    from .x11_monitor import X11Monitor as Monitor, monitors
 
-
-#---------------------------------------------------------------------------
-# List of monitors that will be filled when this module is loaded and
-# updated on calls to `Monitor.update_monitors_list`.
-
-monitors = []
-
-
-#===========================================================================
-# Monitor class for storing info about single display monitor.
-
-class Monitor(object):
-
-    _log = logging.getLogger("monitor.init")
-
-    #-----------------------------------------------------------------------
-    # Methods for initialization and introspection.
-
-    def __init__(self, handle, rectangle):
-        assert isinstance(handle, integer_types)
-        self._handle = handle
-        assert isinstance(rectangle, Rectangle)
-        self._rectangle = rectangle
-
-    def __str__(self):
-        return "%s(%d)" % (self.__class__.__name__, self._handle)
-
-    @staticmethod
-    def update_monitors_list():
-        """
-        Update dragonfly's monitors list with new monitors, delete monitors
-        that aren't found and replace rectangles of monitors that have
-        changed.
-        """
-        # Get an updated list of monitor information and the handles of
-        # monitors in the list at the moment.
-        updated_monitors = win32api.EnumDisplayMonitors()
-        monitor_handles = [m.handle for m in monitors]
-
-        # Update the list with any new or changed monitors.
-        for h1, _, rectangle in updated_monitors:
-            handle = h1.handle
-            top_left_x, top_left_y, bottom_right_x, bottom_right_y = rectangle
-            dx = bottom_right_x - top_left_x
-            dy = bottom_right_y - top_left_y
-
-            # Check if the monitors list already contains this monitor.
-            if handle in monitor_handles:
-                # Replace the rectangle for the monitor if it has changed.
-                i = monitor_handles.index(handle)
-                m = monitors[i]
-                r = Rectangle(top_left_x, top_left_y, dx, dy)
-                if r != m._rectangle:
-                    Monitor._log.debug("Setting %s.rectangle to %s"
-                                       % (m, r))
-                    m.rectangle = r
-            else:
-                # Add the new monitor to the list.
-                m = Monitor(handle, Rectangle(top_left_x, top_left_y, dx, dy))
-                Monitor._log.debug("Adding %s to monitors list" % m)
-                monitors.append(m)
-
-        # Remove any monitors that aren't in the updated list.
-        monitor_handles = [h1.handle for h1, _, _ in updated_monitors]
-        for m in list(monitors):
-            if m.handle not in monitor_handles:
-                Monitor._log.debug("Removing %s from monitors list" % m)
-                monitors.remove(m)
-
-    #-----------------------------------------------------------------------
-    # Methods that control attribute access.
-
-    def _set_handle(self, handle):
-        assert isinstance(handle, integer_types)
-        self._handle = handle
-    handle = property(fget=lambda self: self._handle,
-                      fset=_set_handle,
-                      doc="Protected access to handle attribute.")
-
-    def _get_updated_rectangle(self):
-        Monitor.update_monitors_list()
-        return self._rectangle
-
-    def _set_rectangle(self, rectangle):
-        assert isinstance(rectangle, Rectangle)
-        self._rectangle = rectangle  # Should make a copy??
-    rectangle = property(fget=_get_updated_rectangle,
-                         fset=_set_rectangle,
-                         doc="Protected access to rectangle attribute.")
-
-
-# Enumerate monitors and build Dragonfly's monitor list when this
-# module is loaded.
-Monitor.update_monitors_list()
+# Unsupported
+else:
+    from .base_monitor import BaseMonitor as Monitor, monitors

--- a/dragonfly/windows/monitor.py
+++ b/dragonfly/windows/monitor.py
@@ -23,16 +23,42 @@ import os
 
 # Windows
 if sys.platform.startswith("win"):
-    from .win32_monitor import Win32Monitor as Monitor, monitors
+    from .win32_monitor import Win32Monitor as Monitor
 
 # Mac OS
 elif sys.platform == "darwin":
-    from .darwin_monitor import DarwinMonitor as Monitor, monitors
+    from .darwin_monitor import DarwinMonitor as Monitor
 
 # Linux/X11
 elif os.environ.get("XDG_SESSION_TYPE") == "x11":
-    from .x11_monitor import X11Monitor as Monitor, monitors
+    from .x11_monitor import X11Monitor as Monitor
 
 # Unsupported
 else:
-    from .base_monitor import BaseMonitor as Monitor, monitors
+    from .base_monitor import FakeMonitor as Monitor
+
+
+class MonitorList(object):
+    """
+    Special read-only, self-updating monitors list class.
+
+    Supports indexing and iteration.
+    """
+
+    def __init__(self):
+        self._list = None  # lazily initialised
+
+    def _update(self):
+        self._list = Monitor.get_all_monitors()
+
+    def __getitem__(self, index):
+        self._update()
+        return self._list[index]
+
+    def __iter__(self):
+        self._update()
+        return iter(self._list)
+
+
+#: :class:`MonitorsList` instance
+monitors = MonitorList()

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -1,0 +1,86 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+    This file offers an interface to Win32 information about
+    available monitors (a.k.a. screens, displays).
+"""
+
+import win32api
+
+from .base_monitor import BaseMonitor
+from .rectangle import Rectangle
+
+
+#---------------------------------------------------------------------------
+# List of monitors that will be filled when this module is loaded and
+# updated on calls to `Monitor.update_monitors_list`.
+
+monitors = []
+
+
+#===========================================================================
+# Monitor class for storing info about single display monitor.
+
+class Win32Monitor(BaseMonitor):
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    @classmethod
+    def update_monitors_list(cls):
+        # Get an updated list of monitor information and the handles of
+        # monitors in the list at the moment.
+        updated_monitors = win32api.EnumDisplayMonitors()
+        monitor_handles = [m.handle for m in monitors]
+
+        # Update the list with any new or changed monitors.
+        for h1, _, rectangle in updated_monitors:
+            handle = h1.handle
+            top_left_x, top_left_y, bottom_right_x, bottom_right_y = rectangle
+            dx = bottom_right_x - top_left_x
+            dy = bottom_right_y - top_left_y
+
+            # Check if the monitors list already contains this monitor.
+            if handle in monitor_handles:
+                # Replace the rectangle for the monitor if it has changed.
+                i = monitor_handles.index(handle)
+                m = monitors[i]
+                r = Rectangle(top_left_x, top_left_y, dx, dy)
+                if r != m._rectangle:
+                    cls._log.debug("Setting %s.rectangle to %s"
+                                       % (m, r))
+                    m.rectangle = r
+            else:
+                # Add the new monitor to the list.
+                m = cls(handle, Rectangle(top_left_x, top_left_y, dx, dy))
+                cls._log.debug("Adding %s to monitors list" % m)
+                monitors.append(m)
+
+        # Remove any monitors that aren't in the updated list.
+        monitor_handles = [h1.handle for h1, _, _ in updated_monitors]
+        for m in list(monitors):
+            if m.handle not in monitor_handles:
+                cls._log.debug("Removing %s from monitors list" % m)
+                monitors.remove(m)
+
+# Enumerate monitors and build Dragonfly's monitor list when this
+# module is loaded. This should be done for concrete Monitor classes.
+Win32Monitor.update_monitors_list()

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -18,11 +18,6 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-"""
-    This file offers an interface to Win32 information about
-    available monitors (a.k.a. screens, displays).
-"""
-
 import win32api
 
 from .base_monitor import BaseMonitor
@@ -40,6 +35,9 @@ monitors = []
 # Monitor class for storing info about single display monitor.
 
 class Win32Monitor(BaseMonitor):
+    """
+    The monitor class used on Win32.
+    """
 
     #-----------------------------------------------------------------------
     # Methods for initialization and introspection.

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -31,8 +31,7 @@ import win32gui
 import win32con
 
 from .base_window    import BaseWindow
-from .rectangle      import Rectangle, unit
-from .monitor        import monitors
+from .rectangle      import Rectangle
 from ..actions.action_key import Key
 
 
@@ -208,25 +207,6 @@ class Win32Window(BaseWindow):
         assert isinstance(rectangle, Rectangle)
         l, t, w, h = rectangle.ltwh
         win32gui.MoveWindow(self._handle, l, t, w, h, 1)
-
-    def get_containing_monitor(self):
-        center = self.get_position().center
-        for monitor in monitors:
-            if monitor.rectangle.contains(center):
-                return monitor
-        # Fall through, return first monitor.
-        return monitors[0]
-
-    def get_normalized_position(self):
-        monitor = self.get_containing_monitor()
-        rectangle = self.get_position()
-        rectangle.renormalize(monitor.rectangle, unit)
-        return rectangle
-
-    def set_normalized_position(self, rectangle, monitor=None):
-        if not monitor: monitor = self.get_containing_monitor()
-        rectangle.renormalize(unit, monitor.rectangle)
-        self.set_position(rectangle)
 
     #-----------------------------------------------------------------------
     # Methods for miscellaneous window control.

--- a/dragonfly/windows/x11_monitor.py
+++ b/dragonfly/windows/x11_monitor.py
@@ -18,7 +18,10 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-from six import integer_types, string_types
+import locale
+from subprocess import Popen, PIPE
+
+from six import string_types, binary_type
 
 from .base_monitor import BaseMonitor
 from .rectangle import Rectangle
@@ -37,6 +40,9 @@ monitors = []
 class X11Monitor(BaseMonitor):
     """
     The monitor class used on X11 (Linux).
+
+    This implementation parses monitor information from
+    ``xrandr``.
     """
 
     #-----------------------------------------------------------------------
@@ -51,11 +57,101 @@ class X11Monitor(BaseMonitor):
         super(X11Monitor, self).__init__(handle, rectangle)
 
     def __str__(self):
-        return "%s(%d)" % (self.__class__.__name__, self._name)
+        return "%s(%s)" % (self.__class__.__name__, self._name)
 
     @classmethod
     def update_monitors_list(cls):
-        pass
+        # Get monitor information from xrandr.
+        try:
+            p = Popen(["xrandr"], stdout=PIPE, stderr=PIPE)
+            stdout, stderr = p.communicate()
+
+            # Decode output if it is binary.
+            encoding = locale.getpreferredencoding()
+            if isinstance(stdout, binary_type):
+                stdout = stdout.decode(encoding)
+            if isinstance(stderr, binary_type):
+                stderr = stderr.decode(encoding)
+
+            # Handle non-zero return codes.
+            if p.wait() > 0:
+                print(stdout)
+                print(stderr)
+                raise RuntimeError("xrandr exited with non-zero return "
+                                   "code %d" % p.returncode)
+        except Exception as e:
+            cls._log.error("Failed to execute command: %s. Is "
+                           "xrandr installed?", e)
+            raise e
+
+        # Get a list of the current monitor names.
+        monitor_names = [m.name for m in monitors]
+        new_monitor_names = []
+
+        # Parse output from xrandr.
+        for line in stdout.split("\n")[1:]:  # skip the first line
+            # Skip disconnected monitors, output modes and empty lines.
+            if not line or "disconnected" in line or line.startswith("   "):
+                continue
+
+            # Get the information we need.
+            parts = line.split()
+            name = parts.pop(0)
+            primary = "primary" in parts
+            if primary:  # this monitor will be first in the list
+                parts.remove("primary")
+
+            # Find and remove info we don't need (e.g. 'connected' and
+            # orientation info).
+            for i, part in enumerate(parts):
+                if "(" in part:  # e.g. '(normal'
+                    break
+            parts = parts[1:i]
+
+            # Skip disabled monitors that haven't reported mode info.
+            if not parts:
+                continue
+
+            # Get resolution and position info.
+            res_info = parts[0].split("+")
+            width, height = res_info.pop(0).split("x")
+            origin_x, origin_y = res_info
+
+            # Convert values to integers and create a rectangle using them.
+            width, height = int(width), int(height)
+            origin_x, origin_y = int(origin_x), int(origin_y)
+            dx = width - origin_x
+            dy = height - origin_y
+            rectangle = Rectangle(origin_x, origin_y, dx, dy)
+
+            # Check if this monitor is already in the list.
+            if name in monitor_names:
+                # Replace the monitor's rectangle if it has changed.
+                index = monitor_names.index(name)
+                monitor = monitors[index]
+                if rectangle != monitor._rectangle:
+                    monitor.rectangle = rectangle
+
+                # Ensure that the primary monitor is first.
+                if primary:
+                    monitors.pop(index)
+                    monitors.insert(0, monitor)
+            else:
+                # Add a new monitor object to the list, ensuring that the
+                # primary monitor is first.
+                new_monitor = cls(name, rectangle)
+                if primary:
+                    monitors.insert(0, new_monitor)
+                else:
+                    monitors.append(new_monitor)
+
+            # Keep track of each monitor name.
+            new_monitor_names.append(name)
+
+        # Remove any monitors whose names weren't found.
+        for monitor in tuple(monitors):
+            if monitor.name not in new_monitor_names:
+                monitors.remove(monitor)
 
     #-----------------------------------------------------------------------
     # Methods that control attribute access.
@@ -68,8 +164,8 @@ class X11Monitor(BaseMonitor):
         self._set_handle(hash(name))
 
     name = property(fget=lambda self: self._name,
-                      fset=_set_name,
-                      doc="Protected access to name attribute.")
+                    fset=_set_name,
+                    doc="Protected access to name attribute.")
 
 
 # Enumerate monitors and build Dragonfly's monitor list when this

--- a/dragonfly/windows/x11_monitor.py
+++ b/dragonfly/windows/x11_monitor.py
@@ -1,0 +1,79 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+    This file offers an interface to X11 information about
+    available monitors (a.k.a. screens, displays).
+"""
+
+from six import integer_types, string_types
+
+from .base_monitor import BaseMonitor
+from .rectangle import Rectangle
+
+
+#---------------------------------------------------------------------------
+# List of monitors that will be filled when this module is loaded and
+# updated on calls to `Monitor.update_monitors_list`.
+
+monitors = []
+
+
+#===========================================================================
+# Monitor class for storing info about single display monitor.
+
+class X11Monitor(BaseMonitor):
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    def __init__(self, name, rectangle):
+        assert isinstance(name, string_types)
+        self._name = name
+
+        # Get a numeric value from the name that we can use as a handle.
+        handle = hash(name)
+        super(X11Monitor, self).__init__(handle, rectangle)
+
+    def __str__(self):
+        return "%s(%d)" % (self.__class__.__name__, self._name)
+
+    @classmethod
+    def update_monitors_list(cls):
+        pass
+
+    #-----------------------------------------------------------------------
+    # Methods that control attribute access.
+
+    def _set_name(self, name):
+        assert isinstance(name, string_types)
+        self._name = name
+
+        # Also set the handle, as it is derived from the name.
+        self._set_handle(hash(name))
+
+    name = property(fget=lambda self: self._name,
+                      fset=_set_name,
+                      doc="Protected access to name attribute.")
+
+
+# Enumerate monitors and build Dragonfly's monitor list when this
+# module is loaded.
+X11Monitor.update_monitors_list()

--- a/dragonfly/windows/x11_monitor.py
+++ b/dragonfly/windows/x11_monitor.py
@@ -18,11 +18,6 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-"""
-    This file offers an interface to X11 information about
-    available monitors (a.k.a. screens, displays).
-"""
-
 from six import integer_types, string_types
 
 from .base_monitor import BaseMonitor
@@ -40,6 +35,9 @@ monitors = []
 # Monitor class for storing info about single display monitor.
 
 class X11Monitor(BaseMonitor):
+    """
+    The monitor class used on X11 (Linux).
+    """
 
     #-----------------------------------------------------------------------
     # Methods for initialization and introspection.

--- a/dragonfly/windows/x11_monitor.py
+++ b/dragonfly/windows/x11_monitor.py
@@ -27,15 +27,8 @@ from .base_monitor import BaseMonitor
 from .rectangle import Rectangle
 
 
-#---------------------------------------------------------------------------
-# List of monitors that will be filled when this module is loaded and
-# updated on calls to `Monitor.update_monitors_list`.
-
-monitors = []
-
-
 #===========================================================================
-# Monitor class for storing info about single display monitor.
+# Monitor class for storing info about a single display monitor.
 
 class X11Monitor(BaseMonitor):
     """
@@ -59,19 +52,20 @@ class X11Monitor(BaseMonitor):
     def __str__(self):
         return "%s(%s)" % (self.__class__.__name__, self._name)
 
+    #-----------------------------------------------------------------------
+    # Class methods to create new Monitor objects.
+
     @classmethod
-    def update_monitors_list(cls):
-        # Get monitor information from xrandr.
+    def get_all_monitors(cls):
+        # Get updated monitor information from xrandr.
         try:
-            p = Popen(["xrandr"], stdout=PIPE, stderr=PIPE)
-            stdout, stderr = p.communicate()
+            p = Popen(["xrandr"], stdout=PIPE)
+            stdout, _ = p.communicate()
 
             # Decode output if it is binary.
             encoding = locale.getpreferredencoding()
             if isinstance(stdout, binary_type):
                 stdout = stdout.decode(encoding)
-            if isinstance(stderr, binary_type):
-                stderr = stderr.decode(encoding)
 
             # Handle non-zero return codes.
             if p.wait() > 0:
@@ -84,11 +78,8 @@ class X11Monitor(BaseMonitor):
                            "xrandr installed?", e)
             raise e
 
-        # Get a list of the current monitor names.
-        monitor_names = [m.name for m in monitors]
-        new_monitor_names = []
-
         # Parse output from xrandr.
+        monitors = []
         for line in stdout.split("\n")[1:]:  # skip the first line
             # Skip disconnected monitors, output modes and empty lines.
             if not line or "disconnected" in line or line.startswith("   "):
@@ -103,12 +94,13 @@ class X11Monitor(BaseMonitor):
 
             # Find and remove info we don't need (e.g. 'connected' and
             # orientation info).
+            i = 1
             for i, part in enumerate(parts):
                 if "(" in part:  # e.g. '(normal'
                     break
             parts = parts[1:i]
 
-            # Skip disabled monitors that haven't reported mode info.
+            # Skip disabled monitors (no reported mode info).
             if not parts:
                 continue
 
@@ -117,41 +109,23 @@ class X11Monitor(BaseMonitor):
             width, height = res_info.pop(0).split("x")
             origin_x, origin_y = res_info
 
-            # Convert values to integers and create a rectangle using them.
+            # Convert values to integers and create a rectangle object
+            # representing the monitor's dimensions and relative position.
             width, height = int(width), int(height)
             origin_x, origin_y = int(origin_x), int(origin_y)
             dx = width - origin_x
             dy = height - origin_y
             rectangle = Rectangle(origin_x, origin_y, dx, dy)
 
-            # Check if this monitor is already in the list.
-            if name in monitor_names:
-                # Replace the monitor's rectangle if it has changed.
-                index = monitor_names.index(name)
-                monitor = monitors[index]
-                if rectangle != monitor._rectangle:
-                    monitor.rectangle = rectangle
-
-                # Ensure that the primary monitor is first.
-                if primary:
-                    monitors.pop(index)
-                    monitors.insert(0, monitor)
+            # Get a new or updated monitor object and add it to the list.
+            monitor = cls.get_monitor(name, rectangle)
+            if primary:
+                monitors.insert(0, monitor)
             else:
-                # Add a new monitor object to the list, ensuring that the
-                # primary monitor is first.
-                new_monitor = cls(name, rectangle)
-                if primary:
-                    monitors.insert(0, new_monitor)
-                else:
-                    monitors.append(new_monitor)
+                monitors.append(monitor)
 
-            # Keep track of each monitor name.
-            new_monitor_names.append(name)
-
-        # Remove any monitors whose names weren't found.
-        for monitor in tuple(monitors):
-            if monitor.name not in new_monitor_names:
-                monitors.remove(monitor)
+        # Return the list of monitors.
+        return monitors
 
     #-----------------------------------------------------------------------
     # Methods that control attribute access.
@@ -166,8 +140,3 @@ class X11Monitor(BaseMonitor):
     name = property(fget=lambda self: self._name,
                     fset=_set_name,
                     doc="Protected access to name attribute.")
-
-
-# Enumerate monitors and build Dragonfly's monitor list when this
-# module is loaded.
-X11Monitor.update_monitors_list()

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,11 @@ setup(
                         # "python-libxdo;platform_system=='Linux'",
                         # "Xlib;platform_system=='Linux'",
                         "psutil >= 5.5.1;platform_system=='Linux'",
+                        "pynput >= 1.4.2;platform_system=='Linux'",
 
-                        # Linux and Mac OS dependencies.
-                        "pynput >= 1.4.2;platform_system!='Windows'",
+                        # Mac OS dependencies.
+                        "pynput >= 1.4.2;platform_system=='Darwin'",
+                        "pyobjc >= 5.2;platform_system=='Darwin'",
 
                         # RPC requirements
                         "json-rpc",

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,8 @@ setup(
                         # "Xlib;platform_system=='Linux'",
                         "psutil >= 5.5.1;platform_system=='Linux'",
 
-                        # Mac OS dependencies.
-                        "pynput >= 1.4.2;platform_system=='Darwin'",
+                        # Linux and Mac OS dependencies.
+                        "pynput >= 1.4.2;platform_system!='Windows'",
 
                         # RPC requirements
                         "json-rpc",


### PR DESCRIPTION
Re: #8.

This PR implements mouse support for Linux and Mac OS via [`pynput`](https://github.com/moses-palmer/pynput).

I've moved all internal mouse event classes, flags and functions into modules under a new `dragonfly/actions/mouse` sub-package, similar to the `keyboard` sub-package. Windows functionality should be completely unaffected by these changes. From my testing, it seems to work just as it did before.

Mouse button and scroll events all work in X11. `pynput` doesn't seem to support scrolling or the `"four"`/`"five"` buttons on Mac OS. The `"left"`, `"right"` and `"middle"` buttons seem to work properly though.

I won't merge this just yet because I want to get the `Monitor` class working on Linux so that relative mouse movements work correctly.

Mouse movements **do not yet work properly** on Mac OS because we don't have a `Window` class for that platform. A `Monitor` class will also be needed eventually, but these things can wait for another day because I'm not very familiar with the Mac OS APIs.