### PR TITLE
Allow the passing of window attributes to text engine mimic

### DIFF
--- a/dragonfly/engines/backend_text/__init__.py
+++ b/dragonfly/engines/backend_text/__init__.py
@@ -36,6 +36,8 @@ recognition backends should be returned from the function by default.
 All dragonfly elements and rule classes should be supported. Use all
 uppercase words to mimic input for :class:`Dictation` elements, e.g.
 `"find SOME TEXT"` to match the dragonfly spec `"find <text>"`.
+`executable`, `title`, and `handle` keyword arguments may optionally be
+passed to :meth:`engine.mimic` to simulate a particular foreground window.
 
 Dragonfly's command-line interface can be used to test command modules with
 the text input engine. See the :ref:`CLI page <RefCLI>` for more details.

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -135,7 +135,7 @@ class TextInputEngine(EngineBase):
         # Minor note: this won't work for languages without capitalisation.
         return tuple(map(_map_word, words))
 
-    def mimic(self, words):
+    def mimic(self, words, **kwargs):
         """ Mimic a recognition of the given *words*. """
         # Handle string input.
         if isinstance(words, string_types):
@@ -154,10 +154,18 @@ class TextInputEngine(EngineBase):
 
         # Call process_begin and process_words for all grammar wrappers,
         # stopping early if processing occurred.
-        fg_window = Window.get_foreground()
+
+        w = Window.get_foreground()
+        process_args = {
+            "executable": w.executable,
+            "title": w.title,
+            "handle": w.handle,
+        }
+        process_args.update(kwargs)
+
         processing_occurred = False
         for wrapper in self._grammar_wrappers.values():
-            wrapper.process_begin(fg_window)
+            wrapper.process_begin(**process_args)
             processing_occurred = wrapper.process_words(words_rules)
             if processing_occurred:
                 break
@@ -203,9 +211,8 @@ class GrammarWrapper(object):
         self.engine = engine
         self._observer_manager = observer_manager
 
-    def process_begin(self, fg_window):
-        self.grammar.process_begin(fg_window.executable, fg_window.title,
-                                   fg_window.handle)
+    def process_begin(self, executable, title, handle):
+        self.grammar.process_begin(executable, title, handle)
 
     def process_words(self, words):
         # Return early if the grammar is disabled or if there are no active

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -152,17 +152,17 @@ class TextInputEngine(EngineBase):
         # Generate the input for process_words.
         words_rules = self.generate_words_rules(words)
 
-        # Call process_begin and process_words for all grammar wrappers,
-        # stopping early if processing occurred.
-
         w = Window.get_foreground()
         process_args = {
             "executable": w.executable,
             "title": w.title,
             "handle": w.handle,
         }
+        # Allows optional passing of window attributes to mimic
         process_args.update(kwargs)
 
+        # Call process_begin and process_words for all grammar wrappers,
+        # stopping early if processing occurred.
         processing_occurred = False
         for wrapper in self._grammar_wrappers.values():
             wrapper.process_begin(**process_args)


### PR DESCRIPTION
I'm finding the text engine extremely useful for debugging. This PR extends the functionality of `mimic` slightly by allowing e.g.

```
     engine.mimic(["new", "tab"], executable="firefox", title="google")
```

So that correct context switching behavior can be checked.