### PR TITLE
Fix problems relating to exported and non-exported rules

### DIFF
--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -319,7 +319,7 @@ class GrammarWrapper(object):
         #  method for processing the recognition and return.
         s = state_.State(words_rules, self.grammar._rule_names, self.engine)
         for r in self.grammar._rules:
-            if not r.active: continue
+            if not (r.active and r.exported): continue
             s.initialize_decoding()
             for result in r.decode(s):
                 if s.finished():

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -601,7 +601,7 @@ class GrammarWrapper(object):
 
             s = State(results, rule_set, self.engine)
             for r in self.grammar.rules:
-                if not r.active:
+                if not (r.active and r.exported):
                     continue
 
                 s.initialize_decoding()

--- a/dragonfly/engines/backend_sphinx/grammar_wrapper.py
+++ b/dragonfly/engines/backend_sphinx/grammar_wrapper.py
@@ -148,7 +148,7 @@ class GrammarWrapper(object):
         # recognition and return.
         s = state_.State(words, self.grammar.rule_names, self.engine)
         for r in self.grammar.rules:
-            if not r.active:
+            if not (r.active and r.exported):
                 continue
             s.initialize_decoding()
             for _ in r.decode(s):

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -246,7 +246,7 @@ class GrammarWrapper(object):
         # recognition and return.
         s = state_.State(words, self.grammar.rule_names, self.engine)
         for r in self.grammar.rules:
-            if not r.active:
+            if not (r.active and r.exported):
                 continue
             s.initialize_decoding()
             for _ in r.decode(s):

--- a/dragonfly/grammar/rule_compound.py
+++ b/dragonfly/grammar/rule_compound.py
@@ -92,8 +92,8 @@ class CompoundRule(Rule):
     spec     = None
     extras   = ()
     defaults = ()
-    exported = True
     context  = None
+    _default_exported = True
 
     #-----------------------------------------------------------------------
 
@@ -103,8 +103,17 @@ class CompoundRule(Rule):
         if spec     is None: spec     = self.spec
         if extras   is None: extras   = self.extras
         if defaults is None: defaults = self.defaults
-        if exported is None: exported = self.exported
         if context  is None: context  = self.context
+
+        # Complex handling of exported, because of clashing use of the
+        #  exported name at the class level: property & class-value.
+        if exported is not None:
+            pass
+        elif (hasattr(self.__class__, "exported")
+            and not isinstance(self.__class__.exported, property)):
+            exported = self.__class__.exported
+        else:
+            exported = self._default_exported
 
         assert isinstance(name, string_types)
         assert isinstance(spec, string_types)


### PR DESCRIPTION
I've come across two confusing issues related to exported and non-exported rules today:

1. `CompoundRule` sometimes refuses to be used as a non-exported rule. If `exported=False` is passed to the constructor without overriding the class-level `exported` definition, then the rule will actually be an exported rule.
  I've fixed this by re-using the logic from `MappingRule` and removing the `exported = True` line which was overriding the base class's `exported` property.

2. Non-exported rules can sometimes be mimicked.
  This is obviously undesirable, as `mimic()` should work like normal speech does, with only top-level rules being recognisable.
  The Natlink and SAPI5 engines seem to disallow this internally anyway. I noticed the problem when testing with the Sphinx and text engines and have modified the code in the other engines for consistency.

@daanzu Issue 2 does not seem to effect your Kaldi engine, just FYI :)