### PR TITLE
Fix text engine bugs

### DIFF
--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -164,8 +164,9 @@ class TextInputEngine(EngineBase):
         # Call process_begin and process_words for all grammar wrappers,
         # stopping early if processing occurred.
         processing_occurred = False
-        for wrapper in self._grammar_wrappers.values():
+        for wrapper in self._grammar_wrappers.copy().values():
             wrapper.process_begin(**process_args)
+        for wrapper in self._grammar_wrappers.copy().values():
             processing_occurred = wrapper.process_words(words_rules)
             if processing_occurred:
                 break


### PR DESCRIPTION
At the moment, any `process_begin` call or any processed command (e.g. caster's "enable...") which loads a new grammar will cause a runtime error, because the _grammar_wrappers dict is mutated as it is being iterated over. This is fixed by using a copy of the dict.

New problem: if a new grammar is added during `process_begin` then this will not be available for processing immediately, because we are still iterating over the old grammar dict copy. This is fixed by splitting the `process_begin` step from the `process_words` step, as would happen in an actual engine.