### PR TITLE
Make improvements to recognition observers and documentation

### DIFF
--- a/documentation/object_model.txt
+++ b/documentation/object_model.txt
@@ -13,6 +13,7 @@ object model.
     rules
     elements
     context
+    recobs
 
 
 Grammars

--- a/documentation/recobs.txt
+++ b/documentation/recobs.txt
@@ -1,0 +1,26 @@
+.. _Recobs:
+
+Recognition observers
+============================================================================
+
+This section describes classes and functions for observing Dragonfly's
+recognition state events:
+
+ * ``on_begin()`` -- called when speech start is detected.
+ * ``on_recognition()`` -- called when speech successfully decoded to a
+   grammar rule or to dictation. This is called *before* grammar rule
+   processing (i.e. ``Rule.process_recognition()``).
+ * ``on_failure()`` -- called when speech failed to decode to a grammar rule
+   or to dictation.
+
+.. automodule:: dragonfly.grammar.recobs
+   :members:
+
+.. automodule:: dragonfly.grammar.recobs_callbacks
+   :members:
+
+Doctest usage examples
+----------------------------------------------------------------------------
+
+See Dragonfly's :ref:`doctests for recognition observers<Recobs Doc Tests>`
+for some usage examples.

--- a/documentation/test_recobs_doctest.txt
+++ b/documentation/test_recobs_doctest.txt
@@ -1,6 +1,10 @@
-﻿
+.. _Recobs Doc Tests:
+
 RecognitionObserver base class
 ==========================================================================
+
+If you're looking for the class and function reference for recognition
+observers, you want :ref:`this page <Recobs>`.
 
 .. note:: :class:`RecognitionObserver` instances can be used for both
    the DNS and the WSR backend engines.  However, WSR will sometimes call

--- a/documentation/test_recobs_doctest.txt
+++ b/documentation/test_recobs_doctest.txt
@@ -152,3 +152,42 @@ Minimum length is 1::
     ...     assert test_int.recognize(word) == i + 1
     >>> history
     [(u'five',)]
+
+
+Recognition callback functions
+==========================================================================
+
+Register recognition callback functions::
+
+    >>> # Define and register functions for each recognition state event.
+    >>> def on_begin():
+    ...     print("on_begin()")
+    ...
+    >>> def on_recognition(words):
+    ...     print("on_recognition(): %s" % (words,))
+    ...
+    >>> def on_failure():
+    ...     print("on_failure()")
+    ...
+    >>> on_begin_obs = register_beginning_callback(on_begin)
+    >>> on_success_obs = register_recognition_callback(on_recognition)
+    >>> on_failure_obs = register_failure_callback(on_failure)
+
+Callback functions are called during recognitions::
+
+    >>> test_lit = ElementTester(Literal("hello world"))
+    >>> test_lit.recognize("hello world")
+    on_begin()
+    on_recognition(): (u'hello', u'world')
+    u'hello world'
+    >>> test_lit.recognize("hello universe")
+    on_begin()
+    on_failure()
+    RecognitionFailure
+
+Callback functions are unregistered using the observer objects returned by
+each function::
+
+    >>> on_begin_obs.unregister()
+    >>> on_success_obs.unregister()
+    >>> on_failure_obs.unregister()

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -42,6 +42,10 @@ from .grammar.context   import Context, AppContext, FuncContext
 from .grammar.list      import ListBase, List, DictList
 from .grammar.recobs    import (RecognitionObserver, RecognitionHistory,
                                 PlaybackHistory)
+from .grammar.recobs_callbacks   import (CallbackRecognitionObserver,
+                                         register_beginning_callback,
+                                         register_recognition_callback,
+                                         register_failure_callback)
 
 # --------------------------------------------------------------------------
 

--- a/dragonfly/grammar/recobs.py
+++ b/dragonfly/grammar/recobs.py
@@ -19,7 +19,7 @@
 #
 
 """
-Recognition observer base class
+Recognition observer classes
 ============================================================================
 
 """
@@ -36,6 +36,11 @@ from ..engines          import get_engine
 #---------------------------------------------------------------------------
 
 class RecognitionObserver(object):
+    """
+    Recognition observer base class.
+
+    Sub-classes should override one or more of the event methods.
+    """
 
     _log = logging.getLogger("grammar")
 
@@ -49,20 +54,44 @@ class RecognitionObserver(object):
             pass
 
     def register(self):
+        """
+        Register the observer for recognition state events.
+        """
         engine = get_engine()
         engine.register_recognition_observer(self)
 
     def unregister(self):
+        """
+        Unregister the observer for recognition state events.
+        """
         engine = get_engine()
         engine.unregister_recognition_observer(self)
 
     def on_begin(self):
+        """
+        Method called when the observer is registered and speech start is
+        detected.
+        """
         pass
 
     def on_recognition(self, words):
+        """
+        Method called when speech successfully decoded to a grammar rule or
+        to dictation.
+
+        This is called *before* grammar rule processing (i.e.
+        ``Rule.process_recognition()``).
+
+        :param words: recognized words
+        :type words: tuple
+        """
         pass
 
     def on_failure(self):
+        """
+        Method called when speech failed to decode to a grammar rule or to
+        dictation.
+        """
         pass
 
 
@@ -98,9 +127,11 @@ class RecognitionHistory(list, RecognitionObserver):
         return self._complete
 
     def on_begin(self):
+        """"""
         self._complete = False
 
     def on_recognition(self, words):
+        """"""
         self._complete = True
         self.append(self._recognition_to_item(words))
         if self._length:
@@ -108,12 +139,25 @@ class RecognitionHistory(list, RecognitionObserver):
                 self.pop(0)
 
     def _recognition_to_item(self, words):
+        """"""
         return words
 
 
 #---------------------------------------------------------------------------
 
 class PlaybackHistory(RecognitionHistory):
+    """
+        Storage class for playing back recent recognitions via the
+        :class:`Playback` action.
+
+        Instances of this class monitor recognitions and store them
+        internally.  This class derives from the built in *list* type
+        and can be accessed as if it were a normal *list* containing
+        :class:`Playback` actions for recent recognitions.  Note that an
+        instance's contents are updated automatically as recognitions are
+        received.
+
+    """
 
     def __init__(self, length=10):
         RecognitionHistory.__init__(self, length)

--- a/dragonfly/grammar/recobs_callbacks.py
+++ b/dragonfly/grammar/recobs_callbacks.py
@@ -1,0 +1,114 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+Recognition state change callbacks
+----------------------------------------------------------------------------
+
+"""
+
+from .recobs import RecognitionObserver
+
+
+class CallbackRecognitionObserver(RecognitionObserver):
+    """
+    Observer class for calling recognition state change callbacks.
+
+    This class is used by the ``register_*_callback`` functions and is
+    registered with the current engine on initialization.
+
+    Constructor arguments:
+     - *event* (*str*) -- the name of the recognition event to register for
+       (e.g. ``"on_begin"``).
+     - *function* (*callable*) -- function to call on the specified
+       recognition event.
+
+    """
+    def __init__(self, event, function):
+        RecognitionObserver.__init__(self)
+        if not hasattr(self, event):
+            raise ValueError("'%s' is not a valid recognition event"
+                             % event)
+        if not callable(function):
+            raise TypeError("callback function for event '%s' is not "
+                            "callable" % event)
+        self._function = function
+        self._event = event
+        self.register()
+
+    def on_begin(self):
+        """"""
+        if self._event == "on_begin" and callable(self._function):
+            self._function()
+
+    def on_recognition(self, words):
+        """"""
+        if self._event == "on_recognition" and callable(self._function):
+            self._function(words)
+
+    def on_failure(self):
+        """"""
+        if self._event == "on_failure" and callable(self._function):
+            self._function()
+
+
+def register_beginning_callback(function):
+    """
+    Register a callback function to be called when speech starts.
+
+    The :class:`CallbackRecognitionObserver` object returned from this
+    function can be used to unregister the callback function.
+
+    :param function: callback function
+    :type function: callable
+    :returns: recognition observer
+    :rtype: CallbackRecognitionObserver
+    """
+    return CallbackRecognitionObserver("on_begin", function)
+
+
+def register_recognition_callback(function):
+    """
+    Register a callback function to be called on recognition success.
+
+    The :class:`CallbackRecognitionObserver` object returned from this
+    function can be used to unregister the callback function.
+
+    :param function: callback function
+    :type function: callable
+    :returns: recognition observer
+    :rtype: CallbackRecognitionObserver
+    """
+    return CallbackRecognitionObserver("on_recognition", function)
+
+
+def register_failure_callback(function):
+    """
+    Register a callback function to be called on recognition failures.
+
+    The :class:`CallbackRecognitionObserver` object returned from this
+    function can be used to unregister the callback function.
+
+    :param function: callback function
+    :type function: callable
+    :returns: recognition observer
+    :rtype: CallbackRecognitionObserver
+    """
+    return CallbackRecognitionObserver("on_failure", function)


### PR DESCRIPTION
This adds new functions for recognition state change callbacks and should close #124. The following is a simple usage example:

```Python
from dragonfly import *

# Define and register functions for each recognition state event.
def on_begin():
    print("on_begin()")

def on_recognition(words):
    print("on_recognition(): %s" % (words,))

def on_failure():
    print("on_failure()")

register_beginning_callback(on_begin)
register_recognition_callback(on_recognition)
register_failure_callback(on_failure)

```

I decided against adding the `unregister` functions mentioned in #124 because each register function returns a recognition observer that can be unregistered with `observer.unregister()`.

I've also added doctests for these new functions and a separate documentation page for recognition observers under the [object model](https://dragonfly2.readthedocs.io/en/latest/object_model.html) section.