### PR TITLE
Various optimisations

### DIFF
--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -251,7 +251,7 @@ class Grammar(object):
 
             **Internal** This method is called when the grammar is loaded.
         """
-        memo = []
+        memo = set()
         for r in self._rules:
             for d in r.dependencies(memo):
                 self.add_dependency(d)

--- a/dragonfly/grammar/rule_base.py
+++ b/dragonfly/grammar/rule_base.py
@@ -230,9 +230,9 @@ class Rule(object):
         return s
 
     def dependencies(self, memo):
-        if self in memo:
+        if self._name in memo:
             return []
-        memo.append(self)
+        memo.add(self._name)
         if self._element:
             return self._element.dependencies(memo)
         else:

--- a/dragonfly/parser.py
+++ b/dragonfly/parser.py
@@ -98,7 +98,7 @@ class State(object):
         self._data = data
         self._index = index
         self._log = log
-        self._log_debug = False if not self._log else self._log.isEnabledFor(logging.DEBUG)
+        self._log_debug = self._log.isEnabledFor(logging.DEBUG) if self._log else False
         self._stack = []
         self._depth = 0
         self._previous_index = None
@@ -213,13 +213,15 @@ class State(object):
         # assert isinstance(element, ParserElementBase)
         self._depth += 1
         self._stack.append(State._Frame(self._depth, element, self._index))
-        self._log_step(element, "attempt")
+        if self._log_debug:
+            self._log_step(element, "attempt")
 
     def decode_retry(self, element):
         # assert isinstance(element, ParserElementBase)
         frame = self._get_frame_from_actor(element)
         self._depth = frame.depth
-        self._log_step(element, "retry")
+        if self._log_debug:
+            self._log_step(element, "retry")
 
     def decode_rollback(self, element):
         # assert isinstance(element, ParserElementBase)
@@ -231,11 +233,13 @@ class State(object):
             self._index = frame.begin
         else:
             raise ParserError("Parser decoding stack broken")
-        self._log_step(element, "rollback")
+        if self._log_debug:
+            self._log_step(element, "rollback")
 
     def decode_success(self, element, value=None):
         # assert isinstance(element, ParserElementBase)
-        self._log_step(element, "success")
+        if self._log_debug:
+            self._log_step(element, "success")
         frame = self._get_frame_from_depth()
         if not frame or frame.actor != element:
             raise ParserError("Parser decoding stack broken.")
@@ -248,7 +252,8 @@ class State(object):
         frame = self._stack.pop()
         self._index = frame.begin
         self._depth = frame.depth
-        self._log_step(element, "failure")
+        if self._log_debug:
+            self._log_step(element, "failure")
         self._depth -= 1
 
     def _get_frame_from_depth(self):
@@ -264,8 +269,6 @@ class State(object):
         return None
 
     def _log_step(self, parser, message):
-        if not self._log_debug:
-            return
         indent = "   " * self._depth
         output = "%s%s: %s" % (indent, message, parser)
         self._log.debug(output)
@@ -409,7 +412,7 @@ class Sequence(ParserElementBase):
         state.decode_attempt(self)
 
         # Special case for an empty sequence.
-        if len(self._children) == 0:
+        if not self._children:
             state.decode_success(self)
             yield state
             state.decode_retry(self)

--- a/dragonfly/parser.py
+++ b/dragonfly/parser.py
@@ -252,21 +252,18 @@ class State(object):
         self._depth -= 1
 
     def _get_frame_from_depth(self):
-        for i in range(len(self._stack)-1, -1, -1):
-            frame = self._stack[i]
+        for frame in reversed(self._stack):
             if frame.depth == self._depth:
                 return frame
         return None
 
     def _get_frame_from_actor(self, actor):
-        for i in range(len(self._stack)-1, -1, -1):
-            frame = self._stack[i]
+        for frame in reversed(self._stack):
             if frame.actor is actor:
                 return frame
         return None
 
     def _log_step(self, parser, message):
-        # if not self._log or not self._log.isEnabledFor(logging.DEBUG):
         if not self._log_debug:
             return
         indent = "   " * self._depth

--- a/dragonfly/parser.py
+++ b/dragonfly/parser.py
@@ -98,6 +98,7 @@ class State(object):
         self._data = data
         self._index = index
         self._log = log
+        self._log_debug = False if not self._log else self._log.isEnabledFor(logging.DEBUG)
         self._stack = []
         self._depth = 0
         self._previous_index = None
@@ -265,7 +266,8 @@ class State(object):
         return None
 
     def _log_step(self, parser, message):
-        if not self._log or not self._log.isEnabledFor(logging.DEBUG):
+        # if not self._log or not self._log.isEnabledFor(logging.DEBUG):
+        if not self._log_debug:
             return
         indent = "   " * self._depth
         output = "%s%s: %s" % (indent, message, parser)
@@ -547,7 +549,8 @@ class Alternative(ParserElementBase):
         state.decode_attempt(self)
 
         # Special case for an empty list of alternatives.
-        if len(self._children) == 0:
+        # if len(self._children) == 0:
+        if not self._children:
             state.decode_success(self)
             yield state
             state.decode_retry(self)

--- a/dragonfly/parser.py
+++ b/dragonfly/parser.py
@@ -549,7 +549,6 @@ class Alternative(ParserElementBase):
         state.decode_attempt(self)
 
         # Special case for an empty list of alternatives.
-        # if len(self._children) == 0:
         if not self._children:
             state.decode_success(self)
             yield state


### PR DESCRIPTION
Profiling caster's start-up produces this:
```
         34793638 function calls (32510155 primitive calls) in 24.034 seconds

   Ordered by: internal time
   List reduced from 4160 to 1248 due to restriction <0.3>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      106    2.953    0.028    2.953    0.028 {method 'acquire' of 'thread.lock' objects}
646083/163188    1.797    0.000   14.751    0.000 parser.py:409(parse)
  1296417    1.586    0.000    3.657    0.000 parser.py:211(decode_attempt)
  2997654    1.414    0.000    3.485    0.000 parser.py:267(_log_step)
  2997878    1.219    0.000    2.071    0.000 __init__.py:1367(isEnabledFor)
492119/29710    0.999    0.000    1.677    0.000 parser.py:187(_build_parse_node)
   806866    0.929    0.000    1.414    0.000 parser.py:253(_get_frame_from_depth)
  2997878    0.852    0.000    0.852    0.000 __init__.py:1353(getEffectiveLevel)
   538329    0.805    0.000    4.427    0.000 parser.py:725(parse)
   804298    0.713    0.000    1.789    0.000 parser.py:245(decode_failure)
   582192    0.580    0.000    2.353    0.000 parser.py:235(decode_success)
6442396/6441593    0.476    0.000    0.476    0.000 {len}
   900706    0.470    0.000    0.470    0.000 {range}
128370/96772    0.454    0.000    9.549    0.000 parser.py:546(parse)
1102854/74197    0.444    0.000   14.351    0.000 {next}
   492119    0.433    0.000    0.433    0.000 parser.py:286(__init__)
  1296417    0.421    0.000    0.421    0.000 parser.py:207(__init__)
  7596/18    0.412    0.000    0.815    0.045 elements_basic.py:476(dependencies)
     6872    0.346    0.000    0.349    0.000 elements_basic.py:141(dependencies)
```

~~I don't fancy getting deep into the parser code~~I am almost certainly going to spend tomorrow going through this line by line, but there are a couple of easy gains to be had. 

1. Firstly, the call to `_log_step` looks like this:
```
    def _log_step(self, parser, message):
        if not self._log or not self._log.isEnabledFor(logging.DEBUG):
            return
	...
```
This is called for every decode attempt, and each time calls `isEnabledFor`, which as you can see takes up a fair bit of time. We only need to check the logging level once and store it, and since this is only used in a couple of places we can avoid the unnecessary function calls (and presumably string allocations) completely with:
```
        self._log_debug = self._log.isEnabledFor(logging.DEBUG) if self._log else False
```
and
```
        if self._log_debug:
            self._log_step(element, "attempt")
```

2. The calls to `range` look like this:
```
    def _get_frame_from_depth(self):
        for i in range(len(self._stack)-1, -1, -1):
            frame = self._stack[i]
            if frame.depth == self._depth:
                return frame
        return None
```
I am almost certain that this is more efficient:
```
        for frame in reversed(self._stack):
            if frame.depth == self._depth:
                return frame
        return None
```

3. We can reduce the number of `len` calls by doing:
```
if not self._children:
```
Instead of
```
if len(self._children) == 0:
```
I'm not actually sure this is faster but it is cleaner at any rate.

4. The calls to `dependencies` look like this:
```
    def dependencies(self, memo):
        if self in memo:
            return []
        memo.append(self)
        return self._child.dependencies(memo)
```
list lookup is O(n), and we are doing it for every item in at least the first dependency tree encountered, for a complex mapping rule this gets expensive. I've added an auto generated ID to every element, and we can then use a set to track dependencies we've seen before, with constant time look up. 

After all that, the profile looks like this:
```
         23527029 function calls (21243456 primitive calls) in 20.222 seconds

   Ordered by: internal time
   List reduced from 4160 to 1248 due to restriction <0.3>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      106    2.963    0.028    2.963    0.028 {method 'acquire' of 'thread.lock' objects}
646083/163188    1.972    0.000   10.812    0.000 parser.py:411(parse)
  1296417    1.453    0.000    2.072    0.000 parser.py:212(decode_attempt)
492119/29710    1.205    0.000    1.997    0.000 parser.py:188(_build_parse_node)
   538329    0.973    0.000    3.385    0.000 parser.py:728(parse)
   804298    0.604    0.000    0.784    0.000 parser.py:250(decode_failure)
   806866    0.594    0.000    0.594    0.000 parser.py:259(_get_frame_from_depth)
1180523/151866    0.536    0.000   10.538    0.000 {next}
   582192    0.511    0.000    0.992    0.000 parser.py:239(decode_success)
4948511/4947708    0.507    0.000    0.507    0.000 {len}
128370/96772    0.487    0.000    7.129    0.000 parser.py:548(parse)
   492119    0.461    0.000    0.461    0.000 parser.py:288(__init__)
  1296417    0.461    0.000    0.461    0.000 parser.py:208(__init__)
   477797    0.380    0.000    0.459    0.000 parser.py:176(next)
220848/169844    0.378    0.000   10.483    0.000 parser.py:479(parse)
   256921    0.372    0.000    1.195    0.000 parser.py:683(parse)
  1388419    0.351    0.000    0.351    0.000 {method 'pop' of 'list' objects}
```

Number of function calls reduced by ~30%, time reduced by 20%. I am seeing similar speedups in breathe and somehow the dragonfly tests have gone from ~30s to 6, I think due to the dependency changes.

If someone can explain to me why so many parser calls are necessary, or rewrite the parser to do things more efficiently, that would be great :-).