### PR TITLE
Retain even the last dictation in Kaldi backend

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -314,6 +314,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
 
         finally:
             self._audio.stop()
+            self.audio_store.save_all()
 
         return not timed_out
 


### PR DESCRIPTION
After interrupting the engine, last dictation was not being saved. I do not understand using the deque as opposed to saving directly, so this just saves remaining items on exit. Great feature by the way