### PR TITLE
New parser!

### DIFF
--- a/dragonfly/grammar/elements.py
+++ b/dragonfly/grammar/elements.py
@@ -29,7 +29,6 @@
 import dragonfly.grammar.elements_basic as basic_
 import dragonfly.grammar.elements_compound as compound_
 
-
 #===========================================================================
 # Element classes.
 

--- a/dragonfly/language/base/integer_internal.py
+++ b/dragonfly/language/base/integer_internal.py
@@ -41,22 +41,25 @@ class IntBuilderBase(object):
         raise NotImplementedError("Call to virtual method build_element()"
                                   " in base class IntBuilderBase")
 
-
 class MapIntBuilder(IntBuilderBase):
 
     def __init__(self, mapping):
         self._mapping = mapping
 
-    def build_element(self, min, max):
-        elements = [(spec, value)
-                    for spec, value in self._mapping.items()
-                    if min <= value < max]
-        if len(elements) > 1:
-            children = [Compound(spec=spec, value=value)
-                        for spec, value in elements]
+    def build_element(self, min, max, memo={}):
+        children = []
+        for spec, value in self._mapping.items():
+            if min <= value < max:
+                if spec in memo:
+                    children.append(memo[spec])
+                else:
+                    element = Compound(spec=spec, value=value)
+                    children.append(element)
+                    memo[spec] = element
+        if len(children) > 1:
             return Alternative(children)
-        elif len(elements) == 1:
-            return Compound(spec=elements[0][0], value=elements[0][1])
+        elif len(children) == 1:
+            return children[0]
         else:
             return None
 

--- a/dragonfly/parsing/__init__.py
+++ b/dragonfly/parsing/__init__.py
@@ -1,0 +1,1 @@
+from .parse import spec_parser, CompoundTransformer

--- a/dragonfly/parsing/grammar.lark
+++ b/dragonfly/parsing/grammar.lark
@@ -1,0 +1,17 @@
+?start: alternative
+
+// ? means that the rule will be inlined iff there is a single child
+?alternative: sequence ("|" sequence)*
+?sequence: single*
+
+?single: WORD+               -> literal
+      | "<" WORD ">"         -> reference
+      | "[" alternative "]"  -> optional
+      | "(" alternative ")"
+
+// Match anything which is not whitespace or a control character,
+// we will let the engine handle invalid words
+WORD: /[^\s\[\]<>|()]+/
+
+%import common.WS_INLINE
+%ignore WS_INLINE

--- a/dragonfly/parsing/parse.py
+++ b/dragonfly/parsing/parse.py
@@ -1,0 +1,43 @@
+from lark import Lark, Transformer
+from ..grammar.elements_basic import Literal, Optional, Sequence, Alternative, Empty
+import os
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+spec_parser = Lark.open(os.path.join(dir_path, "grammar.lark"),
+    parser="lalr"
+)
+
+class ParseError(Exception):
+    pass
+
+class CompoundTransformer(Transformer):
+    """
+        Visits each node of the parse tree starting with the leaves
+        and working up, replacing lark Tree objects with the
+        appropriate dragonfly classes.
+    """
+
+    def __init__(self, extras=None, *args, **kwargs):
+        self.extras = extras or {}
+        Transformer.__init__(self, *args, **kwargs)
+
+    def optional(self, args):
+        return Optional(args[0])
+
+    def literal(self, args):
+        return Literal(" ".join(args))
+
+    def sequence(self, args):
+        return Sequence(args)
+
+    def alternative(self, args):
+        return Alternative(args)
+
+    def reference(self, args):
+        ref = args[0]
+        try:
+            return self.extras[ref]
+        except KeyError:
+            raise Exception("Unknown reference name %r" % (str(ref)))
+

--- a/dragonfly/test/suites.py
+++ b/dragonfly/test/suites.py
@@ -39,6 +39,7 @@ common_names = [
     "test_engine_nonexistent",
     "test_log",
     "test_parser",
+    "test_lark_parser",
     "test_rpc",
     "test_timer",
     "test_window",

--- a/dragonfly/test/test_lark_parser.py
+++ b/dragonfly/test/test_lark_parser.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+
+import unittest
+import string
+
+from dragonfly.parsing.parse import spec_parser, CompoundTransformer
+from dragonfly import Compound, Literal, Sequence, Optional, Empty, Alternative
+
+# ===========================================================================
+
+extras = {"an_extra": Alternative([Literal(u"1"), Literal(u"2")])}
+
+
+def check_parse_tree(spec, expected):
+    tree = spec_parser.parse(spec)
+    output = CompoundTransformer(extras).transform(tree)
+    assert output.element_tree_string() == expected.element_tree_string()
+
+
+class TestLarkParser(unittest.TestCase):
+    def test_literal(self):
+        check_parse_tree("test   ", Literal(u"test"))
+
+    def test_multiple_literals(self):
+        check_parse_tree("test  hello world ", Literal(u"test hello world"))
+
+    def test_parens(self):
+        check_parse_tree("(test )   ", Literal(u"test"))
+
+    def test_punctuation(self):
+        check_parse_tree(",", Literal(u","))
+        check_parse_tree("test's   ", Literal(u"test's"))
+        check_parse_tree("cul-de-sac   ", Literal(u"cul-de-sac"))
+
+    def test_sequence(self):
+        check_parse_tree(
+            " test <an_extra> [op]",
+            Sequence([Literal(u"test"), extras["an_extra"], Optional(Literal(u"op"))]),
+        )
+
+    def test_alternative_no_parens(self):
+        check_parse_tree(
+            " test |[op] <an_extra>",
+            Alternative(
+                [
+                    Literal(u"test"),
+                    Sequence([Optional(Literal(u"op")), extras["an_extra"]]),
+                ]
+            ),
+        )
+
+    def test_alternative_parens(self):
+        check_parse_tree(
+            "( test |[op] <an_extra>)",
+            Alternative(
+                [
+                    Literal(u"test"),
+                    Sequence([Optional(Literal(u"op")), extras["an_extra"]]),
+                ]
+            ),
+        )
+
+    def test_optional_alternative(self):
+        check_parse_tree("[test|test's]", Optional(Alternative([Literal(u"test"), Literal(u"test's")])))
+
+    def test_digit_in_word(self):
+        check_parse_tree("F2", Literal(u"F2"))
+
+    def test_unicode(self):
+        check_parse_tree(u"touché", Literal(u"touché"))
+
+
+# ===========================================================================
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
                         "enum34;python_version<'3.4'",
                         "regex",
                         "decorator",
+                        "lark-parser",
 
                         # Windows-only dependencies.
                         "comtypes;platform_system=='Windows'",


### PR DESCRIPTION
This has been bugging me all week so I finally took another look at it. Turns out I was using the slow, forgiving lark parser (Earley) rather than the fast, extremely uncooperative parser (LALR).

Headlines:
* Tests down from 6s to 3s
* Breathe start-up down from ~3s to <1s
* Caster start-up down from ~20s to <10s
* Major simplification

This is still a work in progress, although I *think* I have caught at least most of the potential edge cases. The only thing remaining that it doesn't like in caster is `"((meth|method)|(meth|method)s)"` in `ide_shared.py`. I don't think this should actually be valid syntax, but am willing to be persuaded.

As I said, LALR is quite unforgiving and the error messages are not brilliant so modify this at your peril :-). I tried a lot of things which I thought should have worked but didn't.

TODO:
* ~~Proper error messages~~
* clean up directory structure, delete old parser and tests
* ~~more tests?~~

Questions:
* What happens in `apps/family/loader_parser.py`? It appears to rely on the old parser but I have no idea what any of that stuff does