### PR TITLE
More robust activity checking in kaldi engine

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -349,12 +349,13 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
     # Internal processing methods.
 
     def _compute_kaldi_rules_activity(self, phrase_start=True):
-        self._active_kaldi_rules = []
-        self._kaldi_rules_activity = [False] * self._compiler.num_kaldi_rules
         fg_window = Window.get_foreground()
-        for grammar_wrapper in self._grammar_wrappers.values():
+        for grammar_wrapper in self._grammar_wrappers.copy().values():
             if phrase_start:
                 grammar_wrapper.phrase_start_callback(fg_window)
+        self._active_kaldi_rules = []
+        self._kaldi_rules_activity = [False] * self._compiler.num_kaldi_rules
+        for grammar_wrapper in self._grammar_wrappers.copy().values():
             if grammar_wrapper.active and (not self._any_exclusive_grammars or (self._any_exclusive_grammars and grammar_wrapper.exclusive)):
                 for kaldi_rule in grammar_wrapper.kaldi_rule_by_rule_dict.values():
                     if kaldi_rule.active:


### PR DESCRIPTION
More or less the same fix as in #149, making sure that phrase begin callbacks can safely make changes to grammars.