### PR TITLE
Allow using StartApp and BringApp actions with lists/tuples

### DIFF
--- a/dragonfly/actions/action_startapp.py
+++ b/dragonfly/actions/action_startapp.py
@@ -82,8 +82,14 @@ class StartApp(ActionBase):
                if not *None*, then start the application in this
                directory
 
+            A single *list* or *tuple* argument can be used instead of
+            variable arguments.
+
         """
         ActionBase.__init__(self)
+        if len(args) == 1 and isinstance(args, (list, tuple)):
+            args = args[0]  # use the sub-list instead
+
         self._args = args
 
         if "cwd" in kwargs:  self._cwd = kwargs.pop("cwd")


### PR DESCRIPTION
This allows passing a single list or tuple argument to the `StartApp` / `BringApp` constructor, instead of using variable arguments.

This is more in-line with the main argument for `Popen()`.

@kendonB This should fix the problem you were having with `BringApp`.