### PR TITLE
Change engine recognition loop method names to 'do_recognition'

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -242,7 +242,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
         """ Can be called optionally before ``do_recognition()`` to speed up its starting of active recognition. """
         self._compiler.prepare_for_recognition()
 
-    def do_recognition(self, timeout=None, single=False):
+    def recognize_forever(self, timeout=None, single=False):
         """
             Loops performing recognition, by default forever, or for *timeout* seconds, or for a single recognition if *single=True*.
             Returns ``False`` if timeout occurred without a recognition.
@@ -317,6 +317,9 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
             self.audio_store.save_all()
 
         return not timed_out
+
+    #: Alias of :meth:`recognize_forever` left in for backwards-compatibility
+    do_recognition = recognize_forever
 
     in_phrase = property(lambda self: self._in_phrase,
         doc="Whether or not the engine is currently in the middle of hearing a phrase from the user.")

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -242,7 +242,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
         """ Can be called optionally before ``do_recognition()`` to speed up its starting of active recognition. """
         self._compiler.prepare_for_recognition()
 
-    def recognize_forever(self, timeout=None, single=False):
+    def _do_recognition(self, timeout=None, single=False):
         """
             Loops performing recognition, by default forever, or for *timeout* seconds, or for a single recognition if *single=True*.
             Returns ``False`` if timeout occurred without a recognition.
@@ -317,9 +317,6 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
             self.audio_store.save_all()
 
         return not timed_out
-
-    #: Alias of :meth:`recognize_forever` left in for backwards-compatibility
-    do_recognition = recognize_forever
 
     in_phrase = property(lambda self: self._in_phrase,
         doc="Whether or not the engine is currently in the middle of hearing a phrase from the user.")

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -264,7 +264,8 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
         next(self._audio_iter)
 
         try:
-            while (not timeout) or (time.time() < end_time):
+            # Loop until timeout (if set) or until disconnect() is called.
+            while self._decoder and ((not timeout) or (time.time() < end_time)):
                 self.prepare_for_recognition()
                 block = self._audio_iter.send(in_complex)
 
@@ -313,8 +314,10 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
                 self.call_timer_callback()
 
         finally:
-            self._audio.stop()
-            self.audio_store.save_all()
+            if self._audio:
+                self._audio.stop()
+            if self.audio_store:
+                self.audio_store.save_all()
 
         return not timed_out
 

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -205,7 +205,7 @@ class NatlinkEngine(EngineBase):
     #-----------------------------------------------------------------------
     # Miscellaneous methods.
 
-    def recognize_forever(self):
+    def _do_recognition(self):
         self.natlink.waitForSpeech()
 
     def mimic(self, words):

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -28,8 +28,10 @@ Detecting sleep mode
  - http://blogs.msdn.com/b/tsfaware/archive/2010/03/22/detecting-sleep-mode-in-sapi.aspx
 
 """
+
 import os.path
 import sys
+import pywintypes
 from datetime import datetime
 from locale import getpreferredencoding
 from six import text_type, binary_type, string_types
@@ -94,6 +96,23 @@ class NatlinkEngine(EngineBase):
 
     def disconnect(self):
         """ Disconnect from natlink. """
+        # Unload all grammars from the engine so that Dragon doesn't keep
+        # recognizing them.
+        for grammar in self.grammars:
+            grammar.unload()
+
+        # Close the the waitForSpeech() dialog box if it is active.
+        from dragonfly import Window
+        target_title = "Natlink / Python Subsystem"
+        for window in Window.get_matching_windows(title=target_title):
+            if window.is_visible:
+                try:
+                    window.close()
+                except pywintypes.error:
+                    pass
+                break
+
+        # Finally disconnect from natlink.
         self.natlink.natDisconnect()
 
     # -----------------------------------------------------------------------

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -205,6 +205,9 @@ class NatlinkEngine(EngineBase):
     #-----------------------------------------------------------------------
     # Miscellaneous methods.
 
+    def recognize_forever(self):
+        self.natlink.waitForSpeech()
+
     def mimic(self, words):
         """ Mimic a recognition of the given *words*. """
         try:

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -345,9 +345,9 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
           win32con.EVENT_OBJECT_NAMECHANGE, }]
 
         # Recognize speech, call timer functions and handle window change
-        # events in a loop.
+        # events in a loop. Stop on disconnect().
         self.speak('beginning loop!')
-        while 1:
+        while self._recognizer is not None:
             pythoncom.PumpWaitingMessages()
             self.call_timer_callback()
             time.sleep(0.005)

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -305,7 +305,7 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
             grammar.process_begin(window.executable, window.title,
                                   window.handle)
 
-    def recognize_forever(self):
+    def _do_recognition(self):
         """
             Recognize speech in a loop.
 

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -981,7 +981,7 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
             self._log.warning("Or maybe '-vad_startspeech' or "
                               "'-vad_postspeech' should be lower?")
 
-    def recognise_forever(self):
+    def recognize_forever(self):
         """
         Start recognising from the default recording device until
         :meth:`disconnect` is called.
@@ -1006,6 +1006,9 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
 
         # Free engine resources after recognition has stopped.
         self._free_engine_resources()
+
+    #: Alias of :meth:`recognize_forever` left in for backwards-compatibility
+    recognise_forever = recognize_forever
 
     def mimic(self, words):
         """ Mimic a recognition of the given *words* """

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -981,7 +981,7 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
             self._log.warning("Or maybe '-vad_startspeech' or "
                               "'-vad_postspeech' should be lower?")
 
-    def recognize_forever(self):
+    def _do_recognition(self):
         """
         Start recognising from the default recording device until
         :meth:`disconnect` is called.
@@ -1006,9 +1006,6 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
 
         # Free engine resources after recognition has stopped.
         self._free_engine_resources()
-
-    #: Alias of :meth:`recognize_forever` left in for backwards-compatibility
-    recognise_forever = recognize_forever
 
     def mimic(self, words):
         """ Mimic a recognition of the given *words* """

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -130,6 +130,13 @@ class TextInputEngine(EngineBase):
         # Minor note: this won't work for languages without capitalisation.
         return tuple(map(_map_word, words))
 
+    def recognize_forever(self):
+        """
+        Recognize words from standard input (stdin) in a loop until
+        interrupted or :meth:`disconnect` is called.
+        """
+        # TODO Implement using code from dragonfly/__main__.py
+
     def mimic(self, words, **kwargs):
         """ Mimic a recognition of the given *words*. """
         # Handle string input.

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -54,15 +54,17 @@ class TextInputEngine(EngineBase):
     def __init__(self):
         EngineBase.__init__(self)
         self._language = "en"
+        self._connected = False
         self._recognition_observer_manager = TextRecobsManager(self)
         self._timer_manager = ThreadedTimerManager(0.02, self)
 
     def connect(self):
-        pass
+        self._connected = True
 
     def disconnect(self):
         # Clear grammar wrappers on disconnect()
         self._grammar_wrappers.clear()
+        self._connected = False
 
     # -----------------------------------------------------------------------
     # Methods for administrating timers.
@@ -140,6 +142,7 @@ class TextInputEngine(EngineBase):
         :param delay: time in seconds to delay before mimicking each
             command. This is useful for testing contexts.
         """
+        self.connect()
         try:
             # Use iter to avoid a bug in Python 2.x:
             # https://bugs.python.org/issue3907
@@ -156,6 +159,10 @@ class TextInputEngine(EngineBase):
                     self.mimic(line.split())
                 except MimicFailure:
                     self._log.error("Mimic failure for words: %s", line)
+
+                # Finish early if disconnect() was called.
+                if self._connected is False:
+                    break
         except KeyboardInterrupt:
             pass
 

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -130,7 +130,7 @@ class TextInputEngine(EngineBase):
         # Minor note: this won't work for languages without capitalisation.
         return tuple(map(_map_word, words))
 
-    def recognize_forever(self):
+    def _do_recognition(self):
         """
         Recognize words from standard input (stdin) in a loop until
         interrupted or :meth:`disconnect` is called.

--- a/dragonfly/engines/base/engine.py
+++ b/dragonfly/engines/base/engine.py
@@ -204,6 +204,13 @@ class EngineBase(object):
     #-----------------------------------------------------------------------
     #  Miscellaneous methods.
 
+    def recognize_forever(self):
+        """
+        Recognize speech in a loop until interrupted or :meth:`disconnect`
+        is called.
+        """
+        raise NotImplementedError("Engine %s not implemented." % self)
+
     def mimic(self, words):
         """ Mimic a recognition of the given *words*. """
         raise NotImplementedError("Engine %s not implemented." % self)

--- a/dragonfly/engines/base/engine.py
+++ b/dragonfly/engines/base/engine.py
@@ -204,12 +204,57 @@ class EngineBase(object):
     #-----------------------------------------------------------------------
     #  Miscellaneous methods.
 
-    def recognize_forever(self):
+    def do_recognition(self, begin_callback=None, recognition_callback=None,
+                       failure_callback=None, *args, **kwargs):
         """
         Recognize speech in a loop until interrupted or :meth:`disconnect`
         is called.
+
+        Recognition callback functions can optionally be registered.
+
+        Extra positional and key word arguments are passed to
+        :meth:`_do_recognition`.
+
+        :param begin_callback: optional function to be called when speech
+            starts.
+        :type begin_callback: callable | None
+        :param recognition_callback: optional function to be called on
+            recognition success.
+        :type recognition_callback: callable | None
+        :param failure_callback: optional function to be called on
+            recognition failure.
+        :type failure_callback: callable | None
+        """
+        # Import locally to avoid cycles.
+        from dragonfly.grammar.recobs_callbacks import (
+            register_beginning_callback, register_recognition_callback,
+            register_failure_callback
+        )
+
+        if begin_callback:
+            register_beginning_callback(begin_callback)
+        if recognition_callback:
+            register_recognition_callback(recognition_callback)
+        if failure_callback:
+            register_failure_callback(failure_callback)
+
+        # Call _do_recognition() to start recognizing.
+        self._do_recognition(*args, **kwargs)
+
+    def _do_recognition(self, *args, **kwargs):
+        """
+        Recognize speech in a loop until interrupted or :meth:`disconnect`
+        is called.
+
+        This method should be implemented by engine sub-classes.
         """
         raise NotImplementedError("Engine %s not implemented." % self)
+
+    #: Alias of :meth:`do_recognition` left in for backwards-compatibility
+    recognize_forever = do_recognition
+
+    #: Alias of :meth:`do_recognition` left in for backwards-compatibility
+    recognise_forever = do_recognition
 
     def mimic(self, words):
         """ Mimic a recognition of the given *words*. """

--- a/dragonfly/examples/dfly-loader-natlink.py
+++ b/dragonfly/examples/dfly-loader-natlink.py
@@ -86,11 +86,6 @@ def main():
     except KeyboardInterrupt:
         pass
 
-    # Unload all grammars from the engine so that Dragon doesn't keep
-    # recognizing them.
-    for grammar in engine.grammars:
-        grammar.unload()
-
     # Disconnect after the dialogue is closed.
     engine.disconnect()
 

--- a/dragonfly/examples/kaldi_module_loader.py
+++ b/dragonfly/examples/kaldi_module_loader.py
@@ -17,7 +17,7 @@ import os.path
 import logging
 
 
-from dragonfly import RecognitionObserver, get_engine
+from dragonfly import get_engine
 from dragonfly.loader import CommandModuleDirectory
 from dragonfly.log import setup_log
 
@@ -33,20 +33,6 @@ if False:
     logging.getLogger('kaldi.compiler').setLevel(10)
 else:
     setup_log()
-
-
-# --------------------------------------------------------------------------
-# Simple recognition observer class.
-
-class Observer(RecognitionObserver):
-    def on_begin(self):
-        print("Speech started.")
-
-    def on_recognition(self, words):
-        print(" ".join(words))
-
-    def on_failure(self):
-        print("Sorry, what was that?")
 
 
 # --------------------------------------------------------------------------
@@ -81,18 +67,24 @@ def main():
     # Call connect() now that the engine configuration is set.
     engine.connect()
 
-    # Register a recognition observer
-    observer = Observer()
-    observer.register()
-
+    # Load grammars.
     directory = CommandModuleDirectory(path, excludes=[__file__])
     directory.load()
+
+    # Define recognition callback functions.
+    def on_begin():
+        print("Speech start detected.")
+
+    def on_recognition(words):
+        print("Recognized: %s" % " ".join(words))
+
+    def on_failure():
+        print("Sorry, what was that?")
 
     # Start the engine's main recognition loop
     engine.prepare_for_recognition()
     try:
-        # Loop forever
-        engine.do_recognition()
+        engine.do_recognition(on_begin, on_recognition, on_failure)
     except KeyboardInterrupt:
         pass
 

--- a/dragonfly/examples/sphinx_module_loader.py
+++ b/dragonfly/examples/sphinx_module_loader.py
@@ -17,7 +17,7 @@ import os.path
 import logging
 
 
-from dragonfly import RecognitionObserver, get_engine
+from dragonfly import get_engine
 from dragonfly.loader import CommandModuleDirectory
 from dragonfly.log import setup_log
 
@@ -25,20 +25,6 @@ from dragonfly.log import setup_log
 # Set up basic logging.
 
 setup_log()
-
-
-# --------------------------------------------------------------------------
-# Simple recognition observer class.
-
-class Observer(RecognitionObserver):
-    def on_begin(self):
-        print("Speech started.")
-
-    def on_recognition(self, words):
-        print(" ".join(words))
-
-    def on_failure(self):
-        print("Sorry, what was that?")
 
 
 # --------------------------------------------------------------------------
@@ -54,6 +40,7 @@ def main():
         path = os.getcwd()
         __file__ = os.path.join(path, "sphinx_module_loader.py")
 
+    # Initialize the engine.
     engine = get_engine("sphinx")
 
     # Try to import the local engine configuration object first. If there isn't one,
@@ -77,16 +64,23 @@ def main():
     # Call connect() now that the engine configuration is set.
     engine.connect()
 
-    # Register a recognition observer
-    observer = Observer()
-    observer.register()
-
+    # Load grammars.
     directory = CommandModuleDirectory(path, excludes=[__file__])
     directory.load()
 
+    # Define recognition callback functions.
+    def on_begin():
+        print("Speech start detected.")
+
+    def on_recognition(words):
+        print("Recognized: %s" % " ".join(words))
+
+    def on_failure():
+        print("Sorry, what was that?")
+
     # Start the engine's main recognition loop
     try:
-        engine.recognise_forever()
+        engine.do_recognition(on_begin, on_recognition, on_failure)
     except KeyboardInterrupt:
         pass
 

--- a/dragonfly/examples/wsr_module_loader_plus.py
+++ b/dragonfly/examples/wsr_module_loader_plus.py
@@ -15,7 +15,7 @@ import os.path
 import logging
 import winsound
 
-from dragonfly import RecognitionObserver, get_engine
+from dragonfly import get_engine
 from dragonfly import Grammar, MappingRule, Function, Dictation, FuncContext
 from dragonfly.loader import CommandModuleDirectory
 from dragonfly.log import setup_log
@@ -105,20 +105,6 @@ def load_sleep_wake_grammar(initial_awake):
 
 
 # --------------------------------------------------------------------------
-# Simple recognition observer class.
-
-class Observer(RecognitionObserver):
-    def on_begin(self):
-        print("Speech started.")
-
-    def on_recognition(self, words):
-        print("Recognized:", " ".join(words))
-
-    def on_failure(self):
-        print("Sorry, what was that?")
-
-
-# --------------------------------------------------------------------------
 # Main event driving loop.
 
 def main():
@@ -133,26 +119,30 @@ def main():
         path = os.getcwd()
         __file__ = os.path.join(path, "wsr_module_loader_plus.py")
 
+    # Initialize and connect the engine.
     # Set any configuration options here as keyword arguments.
     engine = get_engine("sapi5inproc")
-
-    # Call connect() now that the engine configuration is set.
     engine.connect()
 
-    # Register a recognition observer
-    observer = Observer()
-    observer.register()
-
+    # Load grammars.
     load_sleep_wake_grammar(True)
-
     directory = CommandModuleDirectory(path, excludes=[__file__])
     directory.load()
 
+    # Define recognition callback functions.
+    def on_begin():
+        print("Speech start detected.")
+
+    def on_recognition(words):
+        print("Recognized: %s" % " ".join(words))
+
+    def on_failure():
+        print("Sorry, what was that?")
+
     # Start the engine's main recognition loop
     try:
-        # Recognize from WSR in a loop.
         print("Listening...")
-        engine.recognize_forever()
+        engine.do_recognition(on_begin, on_recognition, on_failure)
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
This is being done to unify the engine interface a bit. Aliases of renamed methods have been left in for backwards compatibility.

@daanzu @comodoro @jcaw This is the PR I mentioned on Gitter earlier.