### PR TITLE
Change time.clock() to time.time() in Kaldi debug_timer() func

### DIFF
--- a/dragonfly/engines/backend_kaldi/testing.py
+++ b/dragonfly/engines/backend_kaldi/testing.py
@@ -30,13 +30,13 @@ _debug_timer_stack = []
 
 @contextmanager
 def debug_timer(log, desc, enabled=True, independent=False):
-    start_time = time.clock()
+    start_time = time.time()
     if not independent: _debug_timer_stack.append(start_time)
-    spent_time_func = lambda: time.clock() - start_time
+    spent_time_func = lambda: time.time() - start_time
     yield spent_time_func
     start_time_adjusted = _debug_timer_stack.pop() if not independent else 0
     if enabled:
         if debug_timer_enabled:
-            log("%s %d ms" % (desc, (time.clock() - start_time_adjusted) * 1000))
+            log("%s %d ms" % (desc, (time.time() - start_time_adjusted) * 1000))
         if _debug_timer_stack and not independent:
             _debug_timer_stack[-1] += spent_time_func()


### PR DESCRIPTION
@daanzu Just letting you know I'm changing this because the behaviour of `time.clock()` varies between platforms. It counts wall clock time on Windows and CPU time on Linux. The function will also be removed in Python 3.8.

It's not a big problem, but you might want to fix it in [kaldi_active_grammar/utils.py](https://github.com/daanzu/kaldi-active-grammar/blob/master/kaldi_active_grammar/utils.py#L31) too.

Only noticed these things because I got some warnings when running the Kaldi tests in Python 3.7 ;-)