### PR TITLE
Fix minor Kaldi bug in AudioStore.save_all() method

### DIFF
--- a/dragonfly/engines/backend_kaldi/audio.py
+++ b/dragonfly/engines/backend_kaldi/audio.py
@@ -298,6 +298,9 @@ class AudioStore(object):
                 ]) + '\n')
 
     def save_all(self):
+        if self.deque is None:
+            return
+
         for i in reversed(range(len(self.deque))):
             self.save(i)
 


### PR DESCRIPTION
This stops `save_all()` raising an error if `deque` is `None`. Usually happens when I interrupt the Kaldi module loader with Ctrl+C.

@daanzu Just FYI :-)