### PR TITLE
Make changes to the PlaySound action

### DIFF
--- a/documentation/actions.txt
+++ b/documentation/actions.txt
@@ -134,3 +134,6 @@ Action class reference
 
 .. automodule:: dragonfly.actions.action_pause
    :members:
+
+.. automodule:: dragonfly.actions.action_playsound
+   :members:

--- a/dragonfly/actions/__init__.py
+++ b/dragonfly/actions/__init__.py
@@ -38,13 +38,13 @@ from .action_mouse        import Mouse
 from .action_waitwindow   import WaitWindow
 from .action_focuswindow  import FocusWindow
 from .action_startapp     import StartApp, BringApp
+from .action_playsound    import PlaySound
 
 if sys.platform.startswith("win"):
     # Import Windows only classes and functions.
-    from .action_playsound    import PlaySound
     from .sendinput           import (KeyboardInput, MouseInput,
                                       HardwareInput, make_input_array,
                                       send_input_array)
 else:
     # Import mocked classes and functions for other platforms.
-    from ..os_dependent_mock import PlaySound
+    pass

--- a/dragonfly/actions/action_playsound.py
+++ b/dragonfly/actions/action_playsound.py
@@ -22,26 +22,172 @@
 PlaySound action
 ============================================================================
 
+The :class:`PlaySound` action class is used to play wave files.
+
+
+Example usage
+----------------------------------------------------------------------------
+
+The following example shows how to play a wave file using the
+:class:`PlaySound` action class::
+
+    PlaySound(file="tada.wav").execute()
+
+
+Windows
+----------------------------------------------------------------------------
+
+On Windows, :class:`PlaySound` uses the `PlaySound Windows API function
+<https://docs.microsoft.com/en-us/windows/win32/multimedia/the-playsound-function>`__.
+
+The action can be used to play Windows system sounds. For example::
+
+    # Play the system shutdown sound.
+    PlaySound("SystemExit").execute()
+
+    # Play the logout sound.
+    PlaySound("WindowsLogout").execute()
+
+
+System sound names are matched against registry keys.
+
+Invalid file paths or unknown system sounds will result in the default error
+sound being played. ``RuntimeErrors`` will be raised if Windows fails to
+play a known system sound.
+
+
+Other platforms
+----------------------------------------------------------------------------
+
+On other platforms, the :class:`PlaySound` class will use `PyAudio
+<http://people.csail.mit.edu/hubert/pyaudio>`__ to play specified wave
+files.
+
+Invalid file paths will result in errors on other platforms.
+
+
+Class reference
+----------------------------------------------------------------------------
+
 """
 
-import winsound
-from .action_base         import ActionBase, ActionError
+from ctypes import CFUNCTYPE, c_char_p, c_int, cdll
+
+import os
+import wave
+
+if os.name == 'nt':
+    import winsound
+
+try:
+    import pyaudio
+except ImportError:
+    pyaudio = None
+
+from .action_base         import ActionBase
 
 
 #---------------------------------------------------------------------------
 
-class PlaySound(ActionBase):
+ERROR_HANDLER_FUNC = CFUNCTYPE(None, c_char_p, c_int, c_char_p, c_int,
+                               c_char_p)
 
-    def __init__(self, name=None, file=None):
+
+def _get_pa_instance():
+    # Suppress initial ALSA messages if using ALSA.
+    # Got this from: https://stackoverflow.com/a/17673011/12157649
+    try:
+        asound = cdll.LoadLibrary('libasound.so')
+        c_error_handler = ERROR_HANDLER_FUNC(
+            lambda filename, line, function, err, fmt: None
+        )
+        asound.snd_lib_error_set_handler(c_error_handler)
+    except:
+        # We'll most likely get here if the Port Audio host API isn't ALSA.
+        asound = None
+
+    # Create the pa instance.
+    pa = pyaudio.PyAudio()
+
+    # If necessary, restore the original error handler.
+    if asound:
+        asound.snd_lib_error_set_handler(None)
+    return pa
+
+
+def _pyaudio_play(name):
+    if not name:
+        return
+
+    if pyaudio is None:
+        # Raise an error because pyaudio isn't installed.
+        raise RuntimeError("pyaudio must be installed to use PlaySound "
+                           "on this platform")
+
+    # Play the wave file.
+    pa = _get_pa_instance()
+    chunk = 1024
+    wf = wave.open(name, 'rb')
+    stream = pa.open(format=pa.get_format_from_width(wf.getsampwidth()),
+                     channels=wf.getnchannels(), rate=wf.getframerate(),
+                     output=True)
+    data = wf.readframes(chunk)
+    while data:
+        stream.write(data)
+        data = wf.readframes(chunk)
+
+    stream.stop_stream()
+    stream.close()
+    pa.terminate()
+
+
+class PlaySound(ActionBase):
+    """
+        Start playing a wave file or system sound.
+
+        When this action is executed, the specified wave file or named
+        system sound is played.
+
+        Playing named system sounds is only supported on Windows.
+
+    """
+
+    def __init__(self, name='', file=None):
+        """
+            Constructor arguments:
+             - *name* (*str*, default *empty string*) --
+               name of the Windows system sound to play. This argument is
+               effectively an alias for *file* on other platforms.
+             - *file* (*str*, default *None*) --
+               path of wave file to play when the action is executed.
+
+            If *name* and *file* are both *None*, then waveform playback
+            will be silenced on Windows when the action is executed. Nothing
+            will happen on other platforms.
+
+        """
         ActionBase.__init__(self)
-        if name is not None:
-            self._name = name
-            self._flags = winsound.SND_ASYNC | winsound.SND_ALIAS
-        elif file is not None:
+        self._flags = 0
+        if file is not None:
             self._name = file
-            self._flags = winsound.SND_ASYNC | winsound.SND_FILENAME
+            if os.name == 'nt':
+                self._flags = winsound.SND_FILENAME
+        else:
+            self._name = name
+            if os.name == 'nt':
+                self._flags = winsound.SND_ALIAS
+
+        # Expand ~ constructions and shell variables in the file path if
+        # necessary.
+        if file is not None or os.name != 'nt':
+            self._name = os.path.expanduser(os.path.expandvars(self._name))
 
         self._str = str(self._name)
 
     def _execute(self, data=None):
-        winsound.PlaySound(self._name, self._flags)
+        if os.name == 'nt':
+            # Play the file or sound using the Windows API.
+            winsound.PlaySound(self._name, self._flags)
+        else:
+            # Play the file with pyaudio.
+            _pyaudio_play(self._name)

--- a/dragonfly/actions/actions.py
+++ b/dragonfly/actions/actions.py
@@ -22,7 +22,6 @@
 This file offers access to various action classes.
 
 """
-import sys
 
 from .action_pause        import Pause
 from .action_function     import Function
@@ -40,10 +39,4 @@ from .action_mouse        import Mouse
 from .action_waitwindow   import WaitWindow
 from .action_focuswindow  import FocusWindow
 from .action_startapp     import StartApp, BringApp
-
-if sys.platform.startswith("win"):
-    # Import Windows only classes and functions.
-    from .action_playsound    import PlaySound
-else:
-    # Import mocked classes and functions for other platforms.
-    from ..os_dependent_mock import PlaySound
+from .action_playsound    import PlaySound

--- a/dragonfly/os_dependent_mock.py
+++ b/dragonfly/os_dependent_mock.py
@@ -33,8 +33,3 @@ class MockAction(ActionBase):
     """ Mock class for dragonfly actions. """
     def __init__(self, *args, **kwargs):
         ActionBase.__init__(self)
-
-
-class PlaySound(ActionBase):
-    def __init__(self, name=None, file=None):
-        ActionBase.__init__(self)


### PR DESCRIPTION
- Add documentation and examples.
  Re: #77.

- Implement the action for other platforms using PyAudio.
  I've tested that the action works perfectly on Windows, Mac OS and Linux-based systems.
  `pyaudio` is effectively a soft-dependency on platforms other than Windows. `PlaySound` will raise an error when executed if `pyaudio` isn't installed.

- Make the action play sound synchronously instead because it avoids having to handle file queues and errors from other threads.

Although this PR removes the last internal use of `dragonfly/os_dependent_mock.py`, I'm leaving it in because Caster's tests make use of the file's `MockAction` class.