### PR TITLE
Change/fix bugs with StartApp & BringApp action classes

### DIFF
--- a/dragonfly/actions/action_startapp.py
+++ b/dragonfly/actions/action_startapp.py
@@ -57,6 +57,9 @@ Class reference
 
 import os.path
 from subprocess           import Popen
+
+from six import string_types
+
 from .action_base         import ActionBase, ActionError
 from .action_focuswindow  import FocusWindow
 
@@ -82,12 +85,12 @@ class StartApp(ActionBase):
                if not *None*, then start the application in this
                directory
 
-            A single *list* argument can be used instead of
+            A single *list* or *tuple* argument can be used instead of
             variable arguments.
 
         """
         ActionBase.__init__(self)
-        if len(args) == 1 and isinstance(args, list):
+        if len(args) == 1 and isinstance(args[0], (tuple, list)):
             args = args[0]  # use the sub-list instead
 
         self._args = args
@@ -105,6 +108,10 @@ class StartApp(ActionBase):
         self._str = str(", ".join(repr(a) for a in self._args))
 
     def _interpret(self, path):
+        if not isinstance(path, string_types):
+            raise TypeError("expected string argument for path, but got "
+                            "%s" % path)
+
         return os.path.expanduser(os.path.expandvars(path))
 
     def _execute(self, data=None):

--- a/dragonfly/actions/action_startapp.py
+++ b/dragonfly/actions/action_startapp.py
@@ -149,14 +149,19 @@ class BringApp(StartApp):
              - *cwd* (*str*, default *None*) --
                if not *None*, then start the application in this
                directory
+             - *title* (*str*, default *None*) --
+               if not *None*, then matching existing windows using this
+               title.
 
         """
+        self._title = kwargs.pop("title", None)
         StartApp.__init__(self, *args, **kwargs)
 
     def _execute(self, data=None):
         self._log.debug("Bringing app: %r" % (self._args,))
         target = self._args[0].lower()
-        focus_action = FocusWindow(executable=target)
+        title = self._title
+        focus_action = FocusWindow(executable=target, title=title)
         # Attempt to focus on an existing window.
         if not focus_action.execute():
             # Failed to focus on an existing window, so start

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -179,6 +179,10 @@ class BaseWindow(object):
         # Method to get the window executable.
         raise NotImplementedError()
 
+    def _get_window_pid(self):
+        # Method to get the window process ID.
+        raise NotImplementedError()
+
     @property
     def title(self):
         """ Read-only access to the window's title. """
@@ -201,6 +205,21 @@ class BaseWindow(object):
     def executable(self):
         """ Read-only access to the window's executable. """
         return self._get_window_module()
+
+    @property
+    def pid(self):
+        """
+        Read-only access to the window's process ID.
+
+        This will be the PID of the window's process, not any subprocess.
+
+        If the window has no associated process id, this will return
+        ``None``.
+
+        :returns: pid
+        :rtype: int | None
+        """
+        return self._get_window_pid()
 
     @property
     def is_minimized(self):

--- a/dragonfly/windows/fake_window.py
+++ b/dragonfly/windows/fake_window.py
@@ -28,6 +28,7 @@ class FakeWindow(BaseWindow):
     fake_title = ''
     fake_classname = ''
     fake_executable = ''
+    fake_pid = 0
 
     @classmethod
     def get_foreground(cls):
@@ -52,6 +53,9 @@ class FakeWindow(BaseWindow):
 
     def _get_window_module(self):
         return self.fake_executable
+
+    def _get_window_pid(self):
+        return self.fake_pid
 
     @property
     def is_minimized(self):

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -157,10 +157,15 @@ class Win32Window(BaseWindow):
 
     close = _win32gui_post(win32con.WM_CLOSE)
 
-    def _get_window_module(self):
+    def _get_window_pid(self):
         # Get this window's process ID.
         pid = c_ulong()
         windll.user32.GetWindowThreadProcessId(self._handle, pointer(pid))
+        return pid.value
+
+    def _get_window_module(self):
+        # Get this window's process ID.
+        pid = self._get_window_pid()
 
         # Get the process handle of this window's process ID.
         #  Access permission flags:

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -248,25 +248,7 @@ class X11Window(BaseWindow):
         return (self._get_properties_from_xprop("WM_CLASS")
                 .get('cls_name', ''))
 
-    @property
-    def cls(self):
-        """ Read-only access to the window's class. """
-        return (self._get_properties_from_xprop("WM_CLASS")
-                .get('cls', ''))
-
-    @property
-    def pid(self):
-        """
-        Read-only access to the window's process ID.
-
-        This will be the PID of the window's process, not any subprocess.
-
-        If the window has no associated process id, this will return
-        ``None``.
-
-        :returns: pid
-        :rtype: int | None
-        """
+    def _get_window_pid(self):
         # Set the pid once when it is needed.
         if self._pid == -1:
             p = '_NET_WM_PID'
@@ -276,6 +258,12 @@ class X11Window(BaseWindow):
             self._pid = pid
 
         return self._pid
+
+    @property
+    def cls(self):
+        """ Read-only access to the window's class. """
+        return (self._get_properties_from_xprop("WM_CLASS")
+                .get('cls', ''))
 
     @property
     def role(self):


### PR DESCRIPTION
Re: #158.

- Handle single list and tuple arguments correctly.
- Raise an intelligible TypeError for other non-string arguments.
- Add Window.pid property and backing _get_window_pid() method.
- Add optional 'title' constructor argument to BringApp action.
- Add optional 'focus_after_start' argument to StartApp action.
  This also applies to BringApp if the application isn't running yet.