### PR TITLE
Fix missing file error for "grammar.lark"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,4 @@
 recursive-include dragonfly/examples *.py
 include documentation/*
 exclude .git*
+include dragonfly/parsing/grammar.lark

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,7 @@ setup(
       url              = "https://github.com/dictation-toolbox/dragonfly",
       zip_safe         = False,  # To unzip documentation files.
       long_description = read("README.rst"),
-
-      package_data={
-                    "": ["*.txt", "*.rst"]
-                   },
-
+      include_package_data=True,
       install_requires=[
                         "setuptools >= 0.6c7",
                         "six",


### PR DESCRIPTION
I've included "grammar.lark" in Dragonfly's `MANIFEST.in` file, which closes #169.

@LexiconCode Thanks for the suggestion :+1: 