### PR TITLE
Fix Win32Window.get_matching_windows() for recent Dragon versions

### DIFF
--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -24,7 +24,6 @@ Window class for Windows
 
 """
 
-import os
 from ctypes          import windll, pointer, c_wchar, c_ulong
 
 import win32gui
@@ -43,6 +42,8 @@ class Win32Window(BaseWindow):
         and placement.
 
     """
+
+    _results_box_class_names = ["#32770", "DgnResultsBoxWindow"]
 
     #-----------------------------------------------------------------------
     # Class methods to create new Window objects.
@@ -75,9 +76,16 @@ class Win32Window(BaseWindow):
         for window in cls.get_all_windows():
             if not window.is_visible:
                 continue
-            if (os.name == 'nt'
-                    and window.executable.endswith("natspeak.exe")
-                    and window.classname == "#32770"
+
+            if executable:
+                if window.executable.lower().find(executable) == -1:
+                    continue
+            if title:
+                if window.title.lower().find(title) == -1:
+                    continue
+
+            if (window.executable.endswith("natspeak.exe")
+                    and window.classname in cls._results_box_class_names
                     and window.get_position().dy < 50):
                 # If a window matches the above, it is very probably
                 #  the results-box of DNS.  We ignore this because
@@ -86,12 +94,6 @@ class Win32Window(BaseWindow):
                 #  a window with a spoken title.
                 continue
 
-            if executable:
-                if window.executable.lower().find(executable) == -1:
-                    continue
-            if title:
-                if window.title.lower().find(title) == -1:
-                    continue
             matching.append(window)
 
         return matching


### PR DESCRIPTION
This stops `get_matching_windows()` from returning windows with a class name of "#32770" or "DgnResultsBoxWindow". The second name is used in more recent Dragon versions.

This indirectly fixes the `FocusWindow` action.

Thanks for bringing this to my attention @lettersandnumbersgithub and @mrob95!