### PR TITLE
Fix problems with the RunCommand action

### DIFF
--- a/dragonfly/actions/action_cmd.py
+++ b/dragonfly/actions/action_cmd.py
@@ -102,12 +102,15 @@ Class reference
 
 """
 
+from __future__ import print_function
+
+import locale
 import os
 import shlex
 import subprocess
 import threading
 
-from six import string_types
+from six import string_types, binary_type
 
 from .action_base import ActionBase
 from ..engines import get_engine
@@ -186,8 +189,12 @@ class RunCommand(ActionBase):
             By default this method prints lines from the subprocess until it
             exits.
         """
+        encoding = locale.getpreferredencoding()
         for line in iter(proc.stdout.readline, b''):
-            print(line)
+            if isinstance(line, binary_type):
+                line = line.decode(encoding)
+
+            print(line, end='')
 
     def _execute(self, data=None):
         self._log.info("Executing: %s" % self.command)

--- a/dragonfly/actions/action_cmd.py
+++ b/dragonfly/actions/action_cmd.py
@@ -53,12 +53,18 @@ Example using a command list instead of a string::
 
 Example using the optional function parameter::
 
+    from __future__ import print_function
+    from locale import getpreferredencoding
+    from six import binary_type
     from dragonfly import RunCommand
 
     def func(proc):
         # Read lines from the process.
+        encoding = getpreferredencoding()
         for line in iter(proc.stdout.readline, b''):
-            print(line)
+            if isinstance(line, binary_type):
+                line = line.decode(encoding)
+            print(line, end='')
 
     RunCommand('ping -w 4 localhost', func).execute()
 
@@ -68,6 +74,14 @@ Example using the optional synchronous parameter::
     from dragonfly import RunCommand
 
     RunCommand('ping -w 4 localhost', synchronous=True).execute()
+
+
+Example using the optional hide_window parameter::
+
+    from dragonfly import RunCommand
+
+    # Use hide_window=False for running GUI applications via RunCommand.
+    RunCommand('notepad.exe', hide_window=False).execute()
 
 
 Example using the subprocess's :class:`Popen` object::
@@ -84,6 +98,9 @@ Example using the subprocess's :class:`Popen` object::
 
 Example using a subclass::
 
+    from __future__ import print_function
+    from locale import getpreferredencoding
+    from six import binary_type
     from dragonfly import RunCommand
 
     class Ping(RunCommand):
@@ -91,8 +108,11 @@ Example using a subclass::
         synchronous = True
         def process_command(self, proc):
             # Read lines from the process.
+            encoding = getpreferredencoding()
             for line in iter(proc.stdout.readline, b''):
-                print(line)
+                if isinstance(line, binary_type):
+                    line = line.decode(encoding)
+                print(line, end='')
 
     Ping().execute()
 

--- a/dragonfly/actions/action_cmd.py
+++ b/dragonfly/actions/action_cmd.py
@@ -131,7 +131,7 @@ class RunCommand(ActionBase):
     synchronous = False
 
     def __init__(self, command=None, process_command=None,
-                 synchronous=False):
+                 synchronous=False, hide_window=True):
         """
             Constructor arguments:
              - *command* (str or list) -- the command to run when this
@@ -145,6 +145,10 @@ class RunCommand(ActionBase):
              - *synchronous* (bool, default *False*) -- whether to wait
                until :meth:`process_command` has finished executing before
                continuing.
+             - *hide_window* (bool, default *True*) -- whether to hide the
+               application window. Set to *False* if using this action with
+               GUI programs. This argument only applies to Windows. It has
+               no effect on other platforms.
 
         """
         ActionBase.__init__(self)
@@ -166,6 +170,7 @@ class RunCommand(ActionBase):
                             "None")
 
         self._process_command = process_command
+        self._hide_window = hide_window
 
         # Set the string used for representing actions.
         if isinstance(self.command, list):
@@ -201,7 +206,7 @@ class RunCommand(ActionBase):
 
         # Suppress showing the new CMD.exe window on Windows.
         startupinfo = None
-        if os.name == 'nt':
+        if os.name == 'nt' and self._hide_window:
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 


### PR DESCRIPTION
- Fix threading issue with the RunCommand action under natlink.
  Natlink doesn't really allow other threads to work, so use an engine timer to workaround that. This only applies when the action is used asynchronously.

- Fix the RunCommand action's handling of subprocess output.
  Properly decode output using the preferred system charset and stop printing extra new lines for each line in the output.

- Add optional 'hide_window' argument to RunCommand action.
  This argument is useful if using RunCommand to start a GUI application on Windows. The argument is False by default to avoid showing cmd.exe windows unnecessarily.

CC @lettersandnumbersgithub 