### PR TITLE
Fix empty key action

### DIFF
--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -336,7 +336,7 @@ class Key(BaseKeyboardAction):
         # Remove leading and trailing whitespace.
         spec = spec.strip()
         if not spec:
-            return []
+            return [], None
 
         # Parse modifier prefix.
         index = spec.find(self._modifier_prefix_delimiter)


### PR DESCRIPTION
Bug got introduced somewhere recently, `Key("")` currently raises an unpacking error.