### PR TITLE
Fix dragon dictation of "numeral"

### DIFF
--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -135,6 +135,8 @@ class WordFlags(FlagContainer):
         # Miscellaneous flags
         "no_format",           # Don't apply formatting (like Cap)
         "not_after_period",    # Suppress this word after a word ending in period (like full-stop after etc.)
+
+        "use_spoken_form",     # Treat this as a normal word
     )
 
 
@@ -341,9 +343,10 @@ class WordParserDns11(WordParserBase):
         "left-*":           WordFlags("no_cap_reset", "no_space_after"),
         "right-*":          WordFlags("no_cap_reset", "no_space_before", "no_space_reset"),
         "open paren":       WordFlags("no_space_after"),
-        "close paren":       WordFlags("no_space_before"),
+        "close paren":      WordFlags("no_space_before"),
         "slash":            WordFlags("no_space_after", "no_space_before"),
 
+        "numeral":          WordFlags("use_spoken_form"),
         # below are two examples of Dragon custom vocabulary with formatting
         # these would have to be added to the Dragon vocabulary for users to use them
         # "len":              WordFlags("no_space_after"), # shorter name for (
@@ -408,7 +411,7 @@ class WordParserDns11(WordParserBase):
 
         word = Word(written, spoken, word_flags)
         self._log.debug("Parsed input {0!r} -> {1}".format(input, word))
-#        print ("Parsed input {0!r} -> {1}".format(input, word))
+        # print ("Parsed input {0!r} -> {1}".format(input, word))
         return word
 
 
@@ -515,7 +518,8 @@ class WordFormatter(object):
         else:                                  prefix = " "
 
         # Determine formatted written form.
-        if   word.flags.no_format:         written = word.written
+        if   word.flags.use_spoken_form:   written = word.spoken
+        elif word.flags.no_format:         written = word.written
         elif state.cap_mode and not word.flags.no_title_cap:
                                            written = self.capitalize_all(word.written)
         elif state.upper_mode:             written = self.upper_all(word.written)


### PR DESCRIPTION
Fixes a bug whereby "numeral" does not show up in dragon dictation.

The problem seems to be that the Dragon representation for numeral is `\\numeral\\numeral`. This is split into three parts by `dictation_format.WordParserDns11.parse_input` - an empty written form and numeral for both the property and spoken parts.
```
        elif len(parts) == 3:
            # Format: "written \ property \ spoken"
            written, property, spoken = parts
```

When this gets formatted the written form is used and so we get an empty string instead of the word.

I've fixed this by having the formatter fall back on the spoken form if there is no written form. I don't think this will cause any other issues but I'm not intimately familiar with the way Dragon pronunciations work. 

An alternative way to do it would be to simply strip `\\` from the front of the input to `parse_input` if it's present, so that we only split `\\numeral\\numeral` into two parts - "numeral" for both the written and spoken forms. I don't have strong opinions so let me know if you think this would be a better approach.