### PR TITLE
Add support for special specifiers to Compound specs

### DIFF
--- a/dragonfly/parsing/grammar.lark
+++ b/dragonfly/parsing/grammar.lark
@@ -3,6 +3,7 @@
 // ? means that the rule will be inlined iff there is a single child
 ?alternative: sequence ("|" sequence)*
 ?sequence: single*
+         | sequence "{" WORD "}"  -> special
 
 ?single: WORD+               -> literal
       | "<" WORD ">"         -> reference
@@ -11,7 +12,7 @@
 
 // Match anything which is not whitespace or a control character,
 // we will let the engine handle invalid words
-WORD: /[^\s\[\]<>|()]+/
+WORD: /[^\s\[\]<>|(){}]+/
 
 %import common.WS_INLINE
 %ignore WS_INLINE

--- a/dragonfly/parsing/parse.py
+++ b/dragonfly/parsing/parse.py
@@ -41,3 +41,18 @@ class CompoundTransformer(Transformer):
         except KeyError:
             raise Exception("Unknown reference name %r" % (str(ref)))
 
+    def special(self, args):
+        child, specifier = args
+        if '=' in specifier:
+            name, value = specifier.split('=')
+        else:
+            name = specifier
+
+        if name in ['weight', 'w']:
+            child.weight = float(value)
+        elif name in ['test_special']:
+            child.test_special = True
+        else:
+            raise ParseError("Unrecognized special specifier: {%s}" % str(specifier))
+
+        return child

--- a/dragonfly/parsing/parse.py
+++ b/dragonfly/parsing/parse.py
@@ -45,6 +45,18 @@ class CompoundTransformer(Transformer):
         child, specifier = args
         if '=' in specifier:
             name, value = specifier.split('=')
+
+            # Try to convert the value to a bool, None or a float.
+            if value in ['True', 'False']:
+                value = bool(value)
+            elif value == 'None':
+                value = None
+            else:
+                try:
+                    value = float(value)
+                except ValueError:
+                    # Conversion failed, value is just a string.
+                    pass
         else:
             name, value = specifier, True
 

--- a/dragonfly/parsing/parse.py
+++ b/dragonfly/parsing/parse.py
@@ -46,13 +46,11 @@ class CompoundTransformer(Transformer):
         if '=' in specifier:
             name, value = specifier.split('=')
         else:
-            name = specifier
+            name, value = specifier, True
 
         if name in ['weight', 'w']:
             child.weight = float(value)
-        elif name in ['test_special']:
-            child.test_special = True
         else:
-            raise ParseError("Unrecognized special specifier: {%s}" % str(specifier))
+            setattr(child, name, value)
 
         return child

--- a/dragonfly/parsing/parse.py
+++ b/dragonfly/parsing/parse.py
@@ -62,7 +62,10 @@ class CompoundTransformer(Transformer):
 
         if name in ['weight', 'w']:
             child.weight = float(value)
+        elif name in ['test_special']:
+            child.test_special = value
         else:
-            setattr(child, name, value)
+            raise ParseError("Unrecognized special specifier: {%s}" %
+                             specifier)
 
         return child

--- a/dragonfly/test/test_lark_parser.py
+++ b/dragonfly/test/test_lark_parser.py
@@ -70,7 +70,7 @@ class TestLarkParser(unittest.TestCase):
     def test_unicode(self):
         check_parse_tree(u"touché", Literal(u"touché"))
 
-    def test_special_in_sequence(self):
+    def test_bool_special_in_sequence(self):
         output = check_parse_tree(
             " test <an_extra> [op] {test_special}",
             Sequence([Literal(u"test"), extras["an_extra"], Optional(Literal(u"op"))]),
@@ -78,7 +78,15 @@ class TestLarkParser(unittest.TestCase):
         assert output.test_special == True
         assert all(getattr(child, 'test_special', None) == None for child in output.children)
 
-    def test_special_in_alternative(self):
+    def test_other_special_in_sequence(self):
+        output = check_parse_tree(
+            " test <an_extra> [op] {test_special=4}",
+            Sequence([Literal(u"test"), extras["an_extra"], Optional(Literal(u"op"))]),
+        )
+        assert output.test_special == 4
+        assert all(getattr(child, 'test_special', None) == None for child in output.children)
+
+    def test_bool_special_in_alternative(self):
         output = check_parse_tree(
             "foo | bar {test_special} | baz",
             Alternative([
@@ -89,6 +97,19 @@ class TestLarkParser(unittest.TestCase):
         )
         assert getattr(output.children[0], 'test_special', None) == None
         assert output.children[1].test_special == True
+        assert getattr(output.children[2], 'test_special', None) == None
+
+    def test_other_special_in_alternative(self):
+        output = check_parse_tree(
+            "foo | bar {test_special=4} | baz",
+            Alternative([
+                Literal(u"foo"),
+                Literal(u"bar"),
+                Literal(u"baz"),
+            ]),
+        )
+        assert getattr(output.children[0], 'test_special', None) == None
+        assert output.children[1].test_special == 4
         assert getattr(output.children[2], 'test_special', None) == None
 
 


### PR DESCRIPTION
Allows for adding attributes, either a specific value or just True. Must come at the end of a `Sequence`, and applies to that whole `Sequence` (or whatever more specific `Element`). The main impetus for this is easily specifying weights for Kaldi, but trying to making it flexible for future/other additions.

Examples:
* "alpha {weight=2}"
* "test <an_extra> [op] {test_special}"
* "foo | bar {test_special} | baz"

I am open to suggestions for the best implementation.