### PR TITLE
Add Window class for Mac OS using AppleScript

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -44,7 +44,7 @@ mock_modules = {
     "win32clipboard", "win32com", "win32com.client", "numpy",
     "win32com.client.gencache", "win32com.gen_py",  "win32com.shell",
     "win32con", "win32event", "win32file", "win32gui", "winsound",
-    "winxpgui", "psutil",
+    "winxpgui", "psutil", "applescript",
 }
 
 for module_name in mock_modules:

--- a/documentation/window_classes.txt
+++ b/documentation/window_classes.txt
@@ -19,3 +19,6 @@ The :class:`FakeWindow` class will be used on unsupported platforms.
 
 .. automodule:: dragonfly.windows.x11_window
    :members:
+
+.. automodule:: dragonfly.windows.darwin_window
+   :members:

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -1,0 +1,171 @@
+#
+# This file is part of Aenea
+#
+# Aenea is free software: you can redistribute it and/or modify it under
+# the terms of version 3 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# Aenea is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with Aenea.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright (2014) Alex Roper
+# Alex Roper <alex@aroper.net>
+#
+# Modified from Aenea's server_osx.py file.
+
+import locale
+
+from six import binary_type, string_types
+import applescript
+
+from .base_window import BaseWindow
+from .rectangle import Rectangle
+
+
+class DarwinWindow(BaseWindow):
+    """
+        The Window class is an interface to the macOS window control and
+        placement.
+
+    """
+
+    #-----------------------------------------------------------------------
+    # Class methods to create new Window objects.
+
+    @classmethod
+    def get_foreground(cls):
+        script = '''
+        global frontApp, frontAppName
+        tell application "System Events"
+            set frontApp to first application process whose frontmost is true
+            set frontAppName to name of frontApp
+            tell process frontAppName
+                set mainWindow to missing value
+                repeat with win in windows
+                    if attribute "AXMain" of win is true then
+                        set mainWindow to win
+                        exit repeat
+                    end if
+                end repeat
+            end tell
+        end tell
+        return frontAppName
+        '''
+
+        # window_id isn't really a unique id, instead it's just the app name
+        # -- but still useful for automating through applescript
+        window_id = applescript.AppleScript(script).run()
+        if isinstance(window_id, binary_type):
+            window_id = window_id.decode(locale.getpreferredencoding())
+
+        return cls.get_window(id=window_id)
+
+    @classmethod
+    def get_all_windows(cls):
+        # FIXME
+        return []
+
+    #-----------------------------------------------------------------------
+    # Methods for initialization and introspection.
+
+    def __init__(self, id):
+        BaseWindow.__init__(self, id)
+        self._names.add(id)
+
+    #-----------------------------------------------------------------------
+    # Methods that control attribute access.
+
+    def _set_id(self, id):
+        if not isinstance(id, string_types):
+            raise TypeError("Window id/handle must be a string,"
+                            " but received {0!r}".format(id))
+        self._id = id
+        self._windows_by_id[id] = self
+
+    #-----------------------------------------------------------------------
+    # Methods and properties for window attributes.
+
+    def _get_window_properties(self):
+        cmd = '''
+        tell application "System Events" to tell application process "%s"
+            try
+                get properties of window 1
+            on error errmess
+                log errmess
+            end try
+        end tell
+        ''' % self._id
+        script = applescript.AppleScript(cmd)
+        properties = script.run()
+
+        result = {}
+        encoding = locale.getpreferredencoding()
+        for key, value in properties.items():
+            key = key.code
+            if isinstance(key, binary_type):
+                key = key.decode(encoding)
+            if isinstance(value, applescript.AEType):
+                value = value.code
+                if isinstance(value, binary_type):
+                    value = value.decode(encoding)
+            result[key] = value
+        return result
+
+    def _get_window_text(self):
+        return self._get_window_properties()['pnam']
+
+    def _get_class_name(self):
+        return self._get_window_properties()['pcls']
+
+    def _get_window_module(self):
+        return self._id  # The window ID is the app name on macOS.
+
+    def _get_window_pid(self):
+        raise NotImplementedError()
+
+    @property
+    def is_minimized(self):
+        raise NotImplementedError()
+
+    @property
+    def is_maximized(self):
+        raise NotImplementedError()
+
+    @property
+    def is_visible(self):
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+    # Methods related to window geometry.
+
+    def get_position(self):
+        props = self._get_window_properties()
+        return Rectangle(props['posn'][0], props['posn'][1],
+                         props['ptsz'][0], props['ptsz'][1])
+
+    def set_position(self, rectangle):
+        assert isinstance(rectangle, Rectangle)
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+    # Methods for miscellaneous window control.
+
+    def minimize(self):
+        raise NotImplementedError()
+
+    def maximize(self):
+        raise NotImplementedError()
+
+    def restore(self):
+        raise NotImplementedError()
+
+    def close(self):
+        raise NotImplementedError()
+
+    def set_foreground(self):
+        raise NotImplementedError()

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -67,8 +67,20 @@ class DarwinWindow(BaseWindow):
 
     @classmethod
     def get_all_windows(cls):
-        # FIXME
-        return []
+        script = '''
+        global appIds
+        tell application "System Events"
+            set appIds to {}
+            repeat with theProcess in (application processes)
+                if not background only of theProcess then
+                    set appIds to appIds & name of theProcess
+                end if
+            end repeat
+        end tell
+        return appIds
+        '''
+        return [cls.get_window(app_id) for app_id in
+                applescript.AppleScript(script).run()]
 
     #-----------------------------------------------------------------------
     # Methods for initialization and introspection.

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -20,7 +20,7 @@
 
 import locale
 
-from six import binary_type, string_types
+from six import binary_type, string_types, integer_types
 import applescript
 
 from .base_window import BaseWindow
@@ -81,8 +81,8 @@ class DarwinWindow(BaseWindow):
     # Methods that control attribute access.
 
     def _set_id(self, id):
-        if not isinstance(id, string_types):
-            raise TypeError("Window id/handle must be a string,"
+        if not isinstance(id, (string_types, integer_types)):
+            raise TypeError("Window id/handle must be an int or string,"
                             " but received {0!r}".format(id))
         self._id = id
         self._windows_by_id[id] = self

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -162,7 +162,15 @@ class DarwinWindow(BaseWindow):
 
     def set_position(self, rectangle):
         assert isinstance(rectangle, Rectangle)
-        raise NotImplementedError()
+        script = '''
+        tell application "System Events"
+            set firstWindow to first window of application process "%s"
+            set position of firstWindow to {%d, %d}
+            set size of firstWindow to {%d, %d}
+        end tell
+        ''' % (self._id, rectangle.x, rectangle.y, rectangle.dx,
+               rectangle.dy)
+        applescript.AppleScript(script).run()
 
     #-----------------------------------------------------------------------
     # Methods for miscellaneous window control.
@@ -180,4 +188,10 @@ class DarwinWindow(BaseWindow):
         raise NotImplementedError()
 
     def set_foreground(self):
-        raise NotImplementedError()
+        script = '''
+        tell application "%s"
+            set firstWindow to id of first window
+            activate firstWindow
+        end tell
+        ''' % self._id
+        applescript.AppleScript(script).run()

--- a/dragonfly/windows/window.py
+++ b/dragonfly/windows/window.py
@@ -29,6 +29,10 @@ if sys.platform.startswith("win"):
 elif os.environ.get("XDG_SESSION_TYPE") == "x11":
     from .x11_window import X11Window as Window
 
+# Mac OS
+elif sys.platform == "darwin":
+    from .darwin_window import DarwinWindow as Window
+
 # Unsupported
 else:
     from .fake_window import FakeWindow as Window

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
                         # Mac OS dependencies.
                         "pynput >= 1.4.2;platform_system=='Darwin'",
                         "pyobjc >= 5.2;platform_system=='Darwin'",
+                        "py-applescript == 1.0.0;platform_system=='Darwin'",
 
                         # RPC requirements
                         "json-rpc",

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
                         "pynput >= 1.4.2;platform_system=='Darwin'",
                         "pyobjc >= 5.2;platform_system=='Darwin'",
                         "py-applescript == 1.0.0;platform_system=='Darwin'",
+                        "psutil >= 5.5.1;platform_system=='Darwin'",
 
                         # RPC requirements
                         "json-rpc",


### PR DESCRIPTION
Re: #8, #35.

This is a work-in-progress `Window` class implementation for Mac OS using `py-applescript`. It is based on Aenea's Mac OS server implementation ([located here](https://github.com/dictation-toolbox/aenea/blob/master/server/osx/server_osx.py)).