### PR TITLE
Fix a Windows bug where the wrong mouse buttons may be pressed

### DIFF
--- a/dragonfly/actions/mouse/_win32.py
+++ b/dragonfly/actions/mouse/_win32.py
@@ -107,8 +107,18 @@ PLATFORM_WHEEL_FLAGS = {
 class ButtonEvent(BaseButtonEvent):
 
     def execute(self, window):
+        # Ensure that the primary mouse button is the *left* button before
+        # sending events.
+        primary_changed = windll.user32.SwapMouseButton(0)
+
+        # Prepare and send the mouse events.
         zero = pointer(c_ulong(0))
         inputs = [MouseInput(0, 0, flag[1], flag[0], 0, zero)
                   for flag in self._flags]
         array = make_input_array(inputs)
         send_input_array(array)
+
+        # Swap the primary mouse button back if it was previously set to
+        # *right*.
+        if primary_changed:
+            windll.user32.SwapMouseButton(1)


### PR DESCRIPTION
Closes #185.

This fixes a bug that occurs when the primary and secondary mouse buttons are inverted using the Windows control panel. Dragonfly's Mouse action would press the wrong buttons: left instead of right
and vice versa.

This bug has been fixed by restoring the normal left/right primary and secondary buttons and swapping back afterwards if necessary.