### PR TITLE
Minor speed optimizations.

### DIFF
--- a/dragonfly/actions/action_paste.py
+++ b/dragonfly/actions/action_paste.py
@@ -93,6 +93,7 @@ class Paste(DynStrActionBase):
             self.contents = contents
         self.format = format
         self.paste = paste
+        self._on_windows = sys.platform.startswith("win")
         DynStrActionBase.__init__(self, spec, static=static)
 
     def _parse_spec(self, spec):
@@ -112,8 +113,7 @@ class Paste(DynStrActionBase):
         # Convert the string to the appropriate type. Only use a binary
         # string if on Windows and using the CF_TEXT clipboard format.
         binary_string = isinstance(events, binary_type)
-        on_windows = sys.platform.startswith("win")
-        text_format = on_windows and self.format == CF_TEXT
+        text_format = self._on_windows and self.format == CF_TEXT
         if text_format and not binary_string:
             events = events.encode(getpreferredencoding())
 

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -162,7 +162,7 @@ class Text(BaseKeyboardAction):
         "\n": typeables["enter"],
         "\t": typeables["tab"],
     }
-
+    
     def __init__(self, spec=None, static=False, pause=None,
                  autofmt=False, use_hardware=False):
         # Use the default pause time if pause in None.
@@ -172,6 +172,7 @@ class Text(BaseKeyboardAction):
 
         # Set other members and call the super constructor.
         self._autofmt = autofmt
+        self._on_windows = sys.platform.startswith("win")
 
         if isinstance(spec, binary_type):
             spec = spec.decode(getpreferredencoding())
@@ -202,7 +203,7 @@ class Text(BaseKeyboardAction):
                                               % (character, spec))
 
                 # Calculate and add Unicode events only if necessary.
-                if not sys.platform.startswith("win"):
+                if not self._on_windows or self._use_hardware:
                     continue
 
                 try:

--- a/dragonfly/actions/sendinput.py
+++ b/dragonfly/actions/sendinput.py
@@ -55,7 +55,7 @@ class KeyboardInput(Structure):
                 ("dwFlags", c_ulong),
                 ("time", c_ulong),
                 ("dwExtraInfo", POINTER(c_ulong))]
-    soft_keys = tuple(SOFT_KEYS)
+    soft_keys = set(SOFT_KEYS)
 
     # pylint: disable=line-too-long
 
@@ -69,7 +69,7 @@ class KeyboardInput(Structure):
     #
     #  It's unclear if the Windows keys are also "extended", so they
     #  have been included for historical reasons.
-    extended_keys = (
+    extended_keys = set((
         win32con.VK_UP,
         win32con.VK_DOWN,
         win32con.VK_LEFT,
@@ -88,7 +88,7 @@ class KeyboardInput(Structure):
         win32con.VK_DIVIDE,
         win32con.VK_LWIN,
         win32con.VK_RWIN,
-    )
+    ))
 
     def __init__(self, virtual_keycode, down, scancode=-1, layout=None):
         """Initialize structure based on key type."""
@@ -103,12 +103,14 @@ class KeyboardInput(Structure):
         flags = 0
         if virtual_keycode == 0:
             flags |= 4  # KEYEVENTF_UNICODE
-        elif virtual_keycode not in self.soft_keys:
-            flags |= 8  # KEYEVENTF_SCANCODE
+        else:
+            if virtual_keycode not in self.soft_keys:
+                flags |= 8  # KEYEVENTF_SCANCODE
+            if virtual_keycode in self.extended_keys:
+                flags |= win32con.KEYEVENTF_EXTENDEDKEY
         if not down:
             flags |= win32con.KEYEVENTF_KEYUP
-        if virtual_keycode in self.extended_keys:
-            flags |= win32con.KEYEVENTF_EXTENDEDKEY
+        
 
         extra = pointer(c_ulong(0))
         # print(virtual_keycode, scancode, flags, 0, extra)


### PR DESCRIPTION
I made a few minor adjustments just because they were relatively straightforward and I need some momentum. At some point, the platform check should probably be done in the configuration module I never got around to properly implementing.

>The platform check in `Paste` and `Text` is now done once upon class instantiation.
Additionally, `Text` no longer generates Windows Unicode keyboard events unless it's necessary.
In `KeyboardInput` from `actions/sendinput.py`, the lists `self.extended_keys` and `self.soft_keys` have been turned into sets to improve membership test times and the test against `self.extended_keys' now only happens for non-Unicode key events.