### PR TITLE
Fix on_recognition() observer callback for the natlink engine

### DIFF
--- a/dragonfly/engines/backend_natlink/recobs.py
+++ b/dragonfly/engines/backend_natlink/recobs.py
@@ -38,6 +38,24 @@ class NatlinkRecObsManager(RecObsManagerBase):
         RecObsManagerBase.__init__(self, engine)
         self._grammar = None
 
+        # Define a flag for limiting the number of notify_recognition()
+        # calls to one per utterance / mimic call. This is necessary to
+        # guarantee that observers are notified *before* rule processing and
+        # are still notified about dictation and other grammar recognitions
+        # via the special NatlinkRecObsGrammar grammar.
+        self._complete_flag = False
+
+    def notify_begin(self):
+        super(NatlinkRecObsManager, self).notify_begin()
+        self._complete_flag = False
+
+    def notify_recognition(self, words):
+        if self._complete_flag:
+            return
+
+        super(NatlinkRecObsManager, self).notify_recognition(words)
+        self._complete_flag = True
+
     def _activate(self):
         if not self._grammar:
             self._grammar = NatlinkRecObsGrammar(self)


### PR DESCRIPTION
The `on_recognition()` callback is now called *before* rule processing, as it is for other engines.

CC @lettersandnumbersgithub