### PR TITLE
Support running the test suites with different pytest options

### DIFF
--- a/dragonfly/test/suites.py
+++ b/dragonfly/test/suites.py
@@ -123,7 +123,7 @@ engine_tests_dict['sapi5shared'] = engine_tests_dict['sapi5']
 # ==========================================================================
 
 
-def run_pytest_suite(engine_name):
+def run_pytest_suite(engine_name, pytest_options):
     # Get test file paths.
     paths = []
     for name in engine_tests_dict[engine_name]:
@@ -143,10 +143,9 @@ def run_pytest_suite(engine_name):
     engine._timer_manager.disable()
     try:
         # Run doctests through pytest.main() now that the engine is set up.
-        # Use some doctest options for compatibility with both Python 2.7
-        # and 3.
-        args = [
-            # '-s',  # Uncomment this to have access to stdout/stdin
+        # Pass any specified pytest options, followed by doctest options for
+        # compatibility with both Python 2.7 and 3.
+        args = pytest_options + [
             '-o',
             'doctest_optionflags=ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL'
         ] + paths

--- a/dragonfly/test/suites.py
+++ b/dragonfly/test/suites.py
@@ -146,6 +146,7 @@ def run_pytest_suite(engine_name):
         # Use some doctest options for compatibility with both Python 2.7
         # and 3.
         args = [
+            # '-s',  # Uncomment this to have access to stdout/stdin
             '-o',
             'doctest_optionflags=ALLOW_UNICODE IGNORE_EXCEPTION_DETAIL'
         ] + paths

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ class test(Command):
         # (long option, short option, description)
         # '=' means an argument should be supplied.
         ('test-suite=', None, 'Dragonfly engine to test (default: "text")'),
-        ('pytest-options=', 'o', 'pytest options'),
+        ('pytest-options=', 'o',
+            'pytest options (ex: "-s" to expose stdout/stdin)'),
     ]
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,12 @@ class test(Command):
         # (long option, short option, description)
         # '=' means an argument should be supplied.
         ('test-suite=', None, 'Dragonfly engine to test (default: "text")'),
+        ('pytest-options=', 'o', 'pytest options'),
     ]
 
     def initialize_options(self):
         self.test_suite = 'text'
+        self.pytest_options = ''
 
     def finalize_options(self):
         # Check that 'test_suite' is an engine name.
@@ -55,10 +57,13 @@ class test(Command):
         assert suite in engine_tests_dict.keys(), \
             "the test suite value must be an engine name, not '%s'" % suite
 
+        # Split pytest options into a list.
+        self.pytest_options = self.pytest_options.split()
+
     def run(self):
         from dragonfly.test.suites import run_pytest_suite
         print("Test suite running for engine '%s'" % self.test_suite)
-        result = run_pytest_suite(self.test_suite)
+        result = run_pytest_suite(self.test_suite, self.pytest_options)
 
         # Exit using pytest's return code.
         exit(int(result))


### PR DESCRIPTION
It would be nice to have an CLI option to enable this, but I'm not sure how to add to it correctly/cleanly.