### PR TITLE
New load & load-directory CLI sub-commands + CLI code cleanup

### DIFF
--- a/documentation/cli.txt
+++ b/documentation/cli.txt
@@ -11,9 +11,11 @@ Command-line Interface (CLI)
 
 Usage Examples
 ----------------------------------------------------------------------------
-Below are some examples using the *test* sub-command. All of them should
-work in Bash.
+Below are some examples using each of the available sub-commands. All
+examples should work in Bash. Most should work in Windows PowerShell.
 
+:code:`test` examples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code:: shell
 
    # Load a command module and mimic two commands separately.
@@ -30,3 +32,62 @@ work in Bash.
    # Test loading two modules with the sphinx engine and exit without
    # checking input.
    python -m dragonfly test -e sphinx --no-input module1.py module2.py
+
+   # Load a command module with the text engine's language set to German.
+   python -m dragonfly test --language de module.py
+
+   # Use the --delay command to test context-dependent commands.
+   echo "save file" | python -m dragonfly test --delay 1 _notepad_example.py
+
+
+:code:`load` examples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code:: shell
+
+   # Load command modules and recognize speech in a loop using the default
+   # engine.
+   python -m dragonfly load _*.py
+
+   # Load command modules and exit afterwards.
+   python -m dragonfly load --no-input _*.py
+
+   # Load command modules and disable recognition state messages such as
+   # "Speech start detected".
+   python -m dragonfly load --no-recobs-messages _*.py
+
+   # Load one command module with the Sphinx engine.
+   python -m dragonfly load --engine sphinx sphinx_commands.py
+
+   # Initialize the Kaldi engine backend with custom arguments, then load
+   # command modules and recognize speech.
+   python -m dragonfly load _*.py --engine kaldi --engine-options " \
+       model_dir=kaldi_model_zamia \
+       vad_padding_end_ms=300"
+
+
+:code:`load-directory` examples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code:: shell
+
+   # Load command modules in the "command-modules" directory and recognize
+   # speech in a loop using the default engine.
+   python -m dragonfly load-directory command-modules
+
+   # Load command modules in the "command-modules" directory and any sub-
+   # directories, then recognize speech in a loop using the default engine.
+   python -m dragonfly load-directory -r command-modules
+   python -m dragonfly load-directory --recursive command-modules
+
+   # Load command modules in the "command-modules" directory and recognize
+   # speech without printing recognition state messages.
+   python -m dragonfly load-directory --no-recobs-messages command-modules
+
+   # Load command modules in the "wsr-modules" directory and recognize
+   # speech using the WSR/SAPI5 in-process engine backend.
+   python -m dragonfly load-directory -e sapi5inproc wsr-modules
+
+   # Initialize the Kaldi engine backend with some custom arguments, then
+   # load command modules in the current directory and recognize speech.
+   python -m dragonfly load-directory . --engine kaldi --engine-options " \
+       model_dir=kaldi_model_zamia \
+       vad_padding_end_ms=300"

--- a/dragonfly/__main__.py
+++ b/dragonfly/__main__.py
@@ -186,7 +186,7 @@ def cli_cmd_load_directory(args):
     with engine.connection():
         directory = CommandModuleDirectory(args.module_dir)
         directory.load()
-        return_code = 0 if directory.successfully_loaded else 1
+        return_code = 0 if directory.loaded else 1
 
         # Return early if --no-input was specified.
         if args.no_input:

--- a/dragonfly/__main__.py
+++ b/dragonfly/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import re
 import sys
 import time
 
@@ -221,8 +222,10 @@ def _engine_options_string(string):
         msg = "%r is not a valid option string" % string
         raise argparse.ArgumentTypeError(msg)
 
-    # Return any key/value arguments in a tuple.
-    return dict(sub_string.split('=') for sub_string in string.split(','))
+    # Return a dictionary off any key/value arguments separated by commas or
+    # spaces. Filter out empty strings.
+    return dict(sub_string.split('=')
+                for sub_string in re.split('[,\\s]', string) if sub_string)
 
 
 def _valid_directory_path(string):
@@ -252,7 +255,7 @@ def make_arg_parser():
         "-o", "--engine-options", default={}, type=_engine_options_string,
         help="One or more engine options to be passed to *get_engine()*. "
              "Each option should specify a key word argument and value. "
-             "Multiple options should be separated by commas (',')."
+             "Multiple options should be separated by spaces or commas."
     )
     language_argument = _build_argument(
         "--language", default="en",

--- a/dragonfly/__main__.py
+++ b/dragonfly/__main__.py
@@ -184,7 +184,11 @@ def cli_cmd_load_directory(args):
     # or a keyboard interrupt.
     LOG.debug("Recognizing with engine '%s'", args.engine)
     with engine.connection():
-        directory = CommandModuleDirectory(args.module_dir)
+        if args.recursive:
+            LOG.info("Loading command modules in sub-directories as "
+                     "specified (recursive mode).")
+        directory = CommandModuleDirectory(args.module_dir,
+                                           recursive=args.recursive)
         directory.load()
         return_code = 0 if directory.loaded else 1
 
@@ -239,6 +243,9 @@ def _valid_directory_path(string):
 # Main argparse functions.
 
 def make_arg_parser():
+    # pylint: disable=too-many-locals
+    # Suppress warnings about too many local variables in this function.
+
     parser = argparse.ArgumentParser(
         prog="python -m dragonfly",
         description="Command-line interface to the Dragonfly speech "
@@ -335,11 +342,16 @@ def make_arg_parser():
         "module_dir", type=_valid_directory_path,
         help="Directory with command module files."
     )
+    recursive_argument =  _build_argument(
+        "-r", "--recursive", default=False, action="store_true",
+        help="Whether to recursively load command modules in "
+             "sub-directories."
+    )
     _add_arguments(
         parser_load_directory,
-        module_dir_argument, engine_argument, engine_options_argument,
-        language_argument, no_input_argument, no_recobs_messages_argument,
-        log_level_argument, quiet_argument
+        module_dir_argument, recursive_argument, engine_argument,
+        engine_options_argument, language_argument, no_input_argument,
+        no_recobs_messages_argument, log_level_argument, quiet_argument
     )
 
     # Return the argument parser.

--- a/dragonfly/__main__.py
+++ b/dragonfly/__main__.py
@@ -245,6 +245,7 @@ def make_arg_parser():
                     "recognition framework"
     )
     subparsers = parser.add_subparsers(dest='command')
+    subparsers.required = True
 
     # Define common arguments.
     cmd_module_files_argument = _build_argument(

--- a/dragonfly/loader.py
+++ b/dragonfly/loader.py
@@ -81,12 +81,13 @@ class CommandModuleDirectory(object):
 
     _log = logging.getLogger("directory")
 
-    def __init__(self, path, excludes=None):
+    def __init__(self, path, excludes=None, recursive=False):
         if excludes is None:
             excludes = []
 
         self._path = os.path.abspath(path)
         self._excludes = excludes
+        self._recursive = recursive
         self._modules = {}
 
     def load(self):
@@ -101,7 +102,11 @@ class CommandModuleDirectory(object):
         # Add any new modules.
         for path in valid_paths:
             if path not in self._modules:
-                module_ = CommandModule(path)
+                if os.path.isfile(path):
+                    module_ = CommandModule(path)
+                elif os.path.isdir(path):
+                    module_ = CommandModuleDirectory(path, self._excludes,
+                                                     self._recursive)
                 module_.load()
                 self._modules[path] = module_
             else:
@@ -120,13 +125,25 @@ class CommandModuleDirectory(object):
         valid_paths = []
         for filename in os.listdir(self._path):
             path = os.path.abspath(os.path.join(self._path, filename))
-            if not os.path.isfile(path):
-                continue
-            if not (os.path.basename(path).startswith("_") and
-                    os.path.splitext(path)[1] == ".py"):
+            if not (self._recursive or os.path.isfile(path)):
                 continue
             if path in self._excludes:
+                continue
+
+            # Only apply _*.py to files, not directories.
+            is_file = os.path.isfile(path)
+            if is_file and not (os.path.basename(path).startswith("_") and
+                                os.path.splitext(path)[1] == ".py"):
                 continue
             valid_paths.append(path)
         self._log.info("Valid paths: %s", ", ".join(valid_paths))
         return valid_paths
+
+    def unload(self):
+        self._log.info("%s: Unloading directory: '%s'", self, self._path)
+        for path, module_ in tuple(self._modules.items()):
+            del self._modules[path]
+            module_.unload()
+
+    def check_freshness(self):
+        pass

--- a/dragonfly/loader.py
+++ b/dragonfly/loader.py
@@ -49,17 +49,18 @@ class CommandModule(object):
         return self._loaded
 
     def load(self):
-        self._log.info("%s: Loading module: '%s'" % (self, self._path))
+        self._log.info("%s: Loading module: '%s'", self, self._path)
 
         # Prepare namespace in which to execute the
         namespace = {"__file__": self._path}
 
         # Attempt to execute the module; handle any exceptions.
         try:
+            # pylint: disable=exec-used
             exec(compile(open(self._path).read(), self._path, 'exec'),
                  namespace)
         except Exception as e:
-            self._log.exception("%s: Error loading module: %s" % (self, e))
+            self._log.exception("%s: Error loading module: %s", self, e)
             self._loaded = False
             return
 
@@ -67,7 +68,7 @@ class CommandModule(object):
         self._namespace = namespace
 
     def unload(self):
-        self._log.info("%s: Unloading module: '%s'" % (self, self._path))
+        self._log.info("%s: Unloading module: '%s'", self, self._path)
 
     def check_freshness(self):
         pass
@@ -115,7 +116,7 @@ class CommandModuleDirectory(object):
         ])
 
     def _get_valid_paths(self):
-        self._log.info("Looking for command modules here: %s" % (self._path,))
+        self._log.info("Looking for command modules here: %s", self._path)
         valid_paths = []
         for filename in os.listdir(self._path):
             path = os.path.abspath(os.path.join(self._path, filename))
@@ -127,5 +128,5 @@ class CommandModuleDirectory(object):
             if path in self._excludes:
                 continue
             valid_paths.append(path)
-        self._log.info("Valid paths: %s" % (", ".join(valid_paths),))
+        self._log.info("Valid paths: %s", ", ".join(valid_paths))
         return valid_paths

--- a/dragonfly/loader.py
+++ b/dragonfly/loader.py
@@ -107,6 +107,13 @@ class CommandModuleDirectory(object):
                 module_ = self._modules[path]
                 module_.check_freshness()
 
+    @property
+    def successfully_loaded(self):
+        return not any([
+            module_ for module_ in self._modules.values()
+            if not module_.loaded
+        ])
+
     def _get_valid_paths(self):
         self._log.info("Looking for command modules here: %s" % (self._path,))
         valid_paths = []

--- a/dragonfly/loader.py
+++ b/dragonfly/loader.py
@@ -108,7 +108,7 @@ class CommandModuleDirectory(object):
                 module_.check_freshness()
 
     @property
-    def successfully_loaded(self):
+    def loaded(self):
         return not any([
             module_ for module_ in self._modules.values()
             if not module_.loaded

--- a/dragonfly/loader.py
+++ b/dragonfly/loader.py
@@ -81,6 +81,9 @@ class CommandModuleDirectory(object):
     _log = logging.getLogger("directory")
 
     def __init__(self, path, excludes=None):
+        if excludes is None:
+            excludes = []
+
         self._path = os.path.abspath(path)
         self._excludes = excludes
         self._modules = {}


### PR DESCRIPTION
Re: #98.

These commands are alternatives to Dragonfly's module loader scripts. Available options are similar to the "test" command options, with some new additions. The commands are working nicely with each engine backend. Recognition state messages are on by default, but can be disabled using the `--no-recobs-messages` option.

I'm not sure if the module loader scripts should be changed to use the `__main__.py` CLI functions directly. It just doesn't seem like it would be worth the effort. Most of the scripts aren't very long anyway.

Engine options can be specified via the `-o` / `--engine-options` command-line options. Here is an example:

```Shell
# Load command modules in the current working directory using the Kaldi engine.
python3 -m dragonfly load-directory --engine kaldi --engine-options model_dir=kaldi_model_zamia .

```

The Kaldi engine needs to be modified to cast string engine arguments to integers, floats, bools, etc. where appropriate (e.g. for `vad_*` arguments). The Sphinx engine still needs to be modified to allow configuring the engine this way. I haven't tested the `retain_dir` engine arguments for the SAPI5 or natlink engines, but I assume they work properly.

I still need to add a recursive option (`-r`, `--recursive`) for the `load-directory` command and update the CLI usage examples.