### PR TITLE
Support focusing windows without raising them on X11

### DIFF
--- a/dragonfly/actions/action_startapp.py
+++ b/dragonfly/actions/action_startapp.py
@@ -190,11 +190,16 @@ class BringApp(StartApp):
                if *True*, then attempt to bring the window to the foreground
                after starting the application. Does nothing if the
                application is already running.
+             - *focus_only* (*bool*, default *False*) -- if *True*, then
+               attempt to focus a matching window without raising it by
+               using the *set_focus()* method instead of *set_foreground()*.
+               This argument may do nothing depending on the platform.
 
         """
         self._title = kwargs.pop("title", None)
         self._index = kwargs.pop("index", None)
         self._filter_func = kwargs.pop("filter_func", None)
+        self._focus_only = kwargs.pop("focus_only", False)
         StartApp.__init__(self, *args, **kwargs)
 
     def _execute(self, data=None):
@@ -203,8 +208,10 @@ class BringApp(StartApp):
         title = self._title
         index = self._index
         filter_func = self._filter_func
+        focus_only = self._focus_only
         focus_action = FocusWindow(executable=target, title=title,
-                                   index=index, filter_func=filter_func)
+                                   index=index, filter_func=filter_func,
+                                   focus_only=focus_only)
         # Attempt to focus on an existing window.
         if not focus_action.execute():
             # Failed to focus on an existing window, so start

--- a/dragonfly/windows/base_window.py
+++ b/dragonfly/windows/base_window.py
@@ -336,6 +336,15 @@ class BaseWindow(object):
         """ Set the window as the foreground (active) window. """
         raise NotImplementedError()
 
+    def set_focus(self):
+        """
+        Set the window as the active window without raising it.
+
+        *Note*: this method will behave like :meth:`set_foreground()` in
+        environments where this isn't possible.
+        """
+        raise NotImplementedError()
+
     def move(self, rectangle, animate=None):
         """
         Move the window, optionally animating its movement.

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -269,3 +269,8 @@ class DarwinWindow(BaseWindow):
         end tell
         ''' % self._id
         applescript.AppleScript(script).run()
+
+    def set_focus(self):
+        # Setting window focus without raising the window doesn't appear to
+        # be possible in macOS, so fallback on set_foreground().
+        self.set_foreground()

--- a/dragonfly/windows/fake_window.py
+++ b/dragonfly/windows/fake_window.py
@@ -99,3 +99,6 @@ class FakeWindow(BaseWindow):
 
     def set_foreground(self):
         pass
+
+    def set_focus(self):
+        pass

--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -238,3 +238,8 @@ class Win32Window(BaseWindow):
 
             # Set the foreground window.
             self._set_foreground()
+
+    def set_focus(self):
+        # Setting window focus without raising the window doesn't appear to
+        # be possible in Windows, so fallback on set_foreground().
+        self.set_foreground()


### PR DESCRIPTION
This PR implements `set_focus()` methods for each `Window` class and allows using it in the `BringApp` and `FocusWindow` actions via an optional `focus_only` argument (`False` by default). The `X11Window` class has the `set_focus()` method since it was introduced (#102).

`set_focus()` and `focus_only` only currently do anything different on X11 (Linux). Windows and macOS don't seem to support focusing windows without raising them, so `set_focus()` is just an alias for `set_foreground()` on those platforms.