### PR TITLE
Enhance engine dependency checks and log messages

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -44,7 +44,9 @@ mock_modules = {
     "win32clipboard", "win32com", "win32com.client", "numpy",
     "win32com.client.gencache", "win32com.gen_py",  "win32com.shell",
     "win32con", "win32event", "win32file", "win32gui", "winsound",
-    "winxpgui", "psutil", "applescript",
+    "winxpgui", "psutil", "applescript", "jsgf", "jsgf.ext",
+    "sphinxwrapper", "pocketsphinx", "pyaudio", "kaldi_active_grammar",
+    "webrtcvad"
 }
 
 for module_name in mock_modules:

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -25,6 +25,7 @@ Main SR engine back-end interface
 """
 
 import logging
+import os
 import traceback
 from .base import EngineBase, EngineError, MimicFailure
 
@@ -62,7 +63,11 @@ def get_engine(name=None, **kwargs):
         #  been loaded, return it.
         return _default_engine
 
-    if not name or name == "natlink":
+    # Check if we're on Windows. If name is None and we're not on Windows,
+    # then we don't evaluate Windows-only engines like natlink.
+    windows = os.name == 'nt'
+
+    if (windows and not name) or name == "natlink":
         # Attempt to retrieve the natlink back-end.
         try:
             from .backend_natlink import is_engine_available
@@ -80,7 +85,8 @@ def get_engine(name=None, **kwargs):
             if name:
                 raise EngineError(message)
 
-    if not name or name in ["sapi5shared", "sapi5inproc", "sapi5"]:
+    sapi5_names = ["sapi5shared", "sapi5inproc", "sapi5"]
+    if (windows and not name) or name in sapi5_names:
         # Attempt to retrieve the sapi5 back-end.
         try:
             from .backend_sapi5 import is_engine_available

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -154,7 +154,14 @@ def get_engine(name=None, **kwargs):
     if not name:
         raise EngineError("No usable engines found.")
     else:
-        raise EngineError("Requested engine %r not available." % (name,))
+        valid_names = ["natlink", "kaldi", "sphinx", "sapi5shared"
+                       "sapi5inproc", "sapi5"]
+        if name not in valid_names:
+            raise EngineError("Requested engine %r is not a valid engine "
+                              "name." % (name,))
+        else:
+            raise EngineError("Requested engine %r not available."
+                              % (name,))
 
 
 # ---------------------------------------------------------------------------

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -79,8 +79,6 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing natlink engine:"
                        " %s" % (e,))
-            log.exception(message)
-            traceback.print_exc()
             print(message)
             if name:
                 raise EngineError(message)
@@ -98,8 +96,6 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing sapi5 engine:"
                        " %s" % (e,))
-            log.exception(message)
-            traceback.print_exc()
             print(message)
             if name:
                 raise EngineError(message)
@@ -117,8 +113,6 @@ def get_engine(name=None, **kwargs):
             message = ("Exception while initializing sphinx engine:"
                        " %s" % (e,))
             log.exception(message)
-            traceback.print_exc()
-            print(message)
             if name:
                 raise EngineError(message)
 
@@ -134,8 +128,6 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing kaldi engine:"
                        " %s" % (e,))
-            log.exception(message)
-            traceback.print_exc()
             print(message)
             if name:
                 raise EngineError(message)
@@ -155,8 +147,6 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing text-input engine:"
                        " %s" % (e,))
-            log.exception(message)
-            traceback.print_exc()
             print(message)
             if name:
                 raise EngineError(message)

--- a/dragonfly/engines/backend_kaldi/__init__.py
+++ b/dragonfly/engines/backend_kaldi/__init__.py
@@ -25,6 +25,7 @@ SR back-end package for Kaldi
 """
 
 import logging
+import struct
 _log = logging.getLogger("engine.kaldi")
 
 
@@ -39,7 +40,11 @@ def is_engine_available(**kwargs):
     global _engine
     if _engine:
         return True
-
+    
+    if struct.calcsize("P") == 4:  # 32-bit
+        _log.error("The python environment is 32-bit. Kaldi requires a 64-bit python environment")
+        return False
+        
     return True
 
 

--- a/dragonfly/engines/backend_kaldi/__init__.py
+++ b/dragonfly/engines/backend_kaldi/__init__.py
@@ -40,11 +40,24 @@ def is_engine_available(**kwargs):
     global _engine
     if _engine:
         return True
-    
+
     if struct.calcsize("P") == 4:  # 32-bit
-        _log.error("The python environment is 32-bit. Kaldi requires a 64-bit python environment")
+        _log.warning("The python environment is 32-bit. Kaldi requires a "
+                     "64-bit python environment")
         return False
-        
+
+    # Attempt to import the engine class from the module.
+    try:
+        from .engine import KaldiEngine
+        return True
+    except ImportError as e:
+        _log.warning("Failed to import from Kaldi engine module: %s", e)
+        return False
+    except Exception as e:
+        _log.exception("Exception during import of Kaldi engine module: %s",
+                       e)
+        return False
+
     return True
 
 

--- a/dragonfly/engines/backend_natlink/__init__.py
+++ b/dragonfly/engines/backend_natlink/__init__.py
@@ -26,6 +26,8 @@ SR back-end package for DNS and Natlink
 
 import logging
 import struct
+import platform
+
 _log = logging.getLogger("engine.natlink")
 
 
@@ -46,29 +48,39 @@ def is_engine_available(**kwargs):
     if _engine:
         return True
 
-    if struct.calcsize("P") == 8:  # 64-bit
-        _log.error("The python environment is 64-bit. Natlink requires a 32-bit python environment")
+    platform_name = platform.system()
+    if platform_name != 'Windows':
+        _log.warning("%s is not supported by the Natlink engine backend",
+                     platform_name)
         return False
-        
+
+    if struct.calcsize("P") == 8:  # 64-bit
+        _log.warning("The python environment is 64-bit. Natlink requires a "
+                     "32-bit python environment")
+        return False
+
     # Attempt to import natlink.
     try:
         import natlink
     except ImportError as e:
-        _log.info("Requested engine 'natlink' is not available: Natlink is not installed: %s" % (e,))
+        _log.warning("Requested engine 'natlink' is not available: Natlink "
+                     "is not installed: %s", e)
         return False
     except Exception as e:
-        _log.exception("Exception during import of natlink package: %s" % (e,))
+        _log.exception("Exception during import of natlink package: "
+                       "%s", e)
         return False
 
     try:
         if natlink.isNatSpeakRunning():
             return True
         else:
-            _log.info("Natlink is available but NaturallySpeaking is not"
-                      " running.")
+            _log.warning("Natlink is available but NaturallySpeaking is not"
+                         " running.")
             return False
     except Exception as e:
-        _log.exception("Exception during natlink.isNatSpeakRunning(): %s" % (e,))
+        _log.exception("Exception during natlink.isNatSpeakRunning(): "
+                       "%s", e)
         return False
 
 

--- a/dragonfly/engines/backend_natlink/__init__.py
+++ b/dragonfly/engines/backend_natlink/__init__.py
@@ -25,6 +25,7 @@ SR back-end package for DNS and Natlink
 """
 
 import logging
+import struct
 _log = logging.getLogger("engine.natlink")
 
 
@@ -45,11 +46,15 @@ def is_engine_available(**kwargs):
     if _engine:
         return True
 
+    if struct.calcsize("P") == 8:  # 64-bit
+        _log.exception("The python environment is 64-bit. Natlink requires a 32-bit python environment")
+        return False
+        
     # Attempt to import natlink.
     try:
         import natlink
     except ImportError as e:
-        _log.info("Failed to import natlink package: %s" % (e,))
+        _log.info("Requested engine 'natlink' is not available: Natlink is not installed: %s" % (e,))
         return False
     except Exception as e:
         _log.exception("Exception during import of natlink package: %s" % (e,))

--- a/dragonfly/engines/backend_natlink/__init__.py
+++ b/dragonfly/engines/backend_natlink/__init__.py
@@ -47,7 +47,7 @@ def is_engine_available(**kwargs):
         return True
 
     if struct.calcsize("P") == 8:  # 64-bit
-        _log.exception("The python environment is 64-bit. Natlink requires a 32-bit python environment")
+        _log.error("The python environment is 64-bit. Natlink requires a 32-bit python environment")
         return False
         
     # Attempt to import natlink.

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -75,8 +75,6 @@ class NatlinkEngine(EngineBase):
         EngineBase.__init__(self)
 
         self.platform = platform.system()
-        if self.platform != 'Windows':
-            raise EngineError("'{}' is not currently supported by Natlink.".format(self.platform))
 
         if struct.calcsize("P") == 8:  # 64-bit
             raise EngineError("The python environment is 64-bit. Natlink requires a 32-bit python environment")

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -31,6 +31,8 @@ Detecting sleep mode
 
 import os.path
 import sys
+import platform
+import struct
 import pywintypes
 from datetime import datetime
 from locale import getpreferredencoding
@@ -72,13 +74,20 @@ class NatlinkEngine(EngineBase):
     def __init__(self, retain_dir=None):
         EngineBase.__init__(self)
 
+        self.platform = platform.system()
+        if self.platform != 'Windows':
+            raise EngineError("'{}' is not currently supported by Natlink.".format(self.platform))
+
         self.natlink = None
         try:
             import natlink
         except ImportError:
             self._log.error("%s: failed to import natlink module." % self)
-            raise EngineError("Failed to import the Natlink module.")
+            raise EngineError("Requested engine 'natlink' is not available: Natlink is not installed.")
         self.natlink = natlink
+
+        if struct.calcsize("P") == 8:  # 64-bit
+            raise EngineError("The python environment is 64-bit. Natlink requires a 32-bit python environment")
 
         self._grammar_count = 0
         self._recognition_observer_manager = NatlinkRecObsManager(self)

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -31,8 +31,6 @@ Detecting sleep mode
 
 import os.path
 import sys
-import platform
-import struct
 import pywintypes
 from datetime import datetime
 from locale import getpreferredencoding

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -78,6 +78,9 @@ class NatlinkEngine(EngineBase):
         if self.platform != 'Windows':
             raise EngineError("'{}' is not currently supported by Natlink.".format(self.platform))
 
+        if struct.calcsize("P") == 8:  # 64-bit
+            raise EngineError("The python environment is 64-bit. Natlink requires a 32-bit python environment")
+        
         self.natlink = None
         try:
             import natlink
@@ -85,9 +88,6 @@ class NatlinkEngine(EngineBase):
             self._log.error("%s: failed to import natlink module." % self)
             raise EngineError("Requested engine 'natlink' is not available: Natlink is not installed.")
         self.natlink = natlink
-
-        if struct.calcsize("P") == 8:  # 64-bit
-            raise EngineError("The python environment is 64-bit. Natlink requires a 32-bit python environment")
 
         self._grammar_count = 0
         self._recognition_observer_manager = NatlinkRecObsManager(self)

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -74,11 +74,6 @@ class NatlinkEngine(EngineBase):
     def __init__(self, retain_dir=None):
         EngineBase.__init__(self)
 
-        self.platform = platform.system()
-
-        if struct.calcsize("P") == 8:  # 64-bit
-            raise EngineError("The python environment is 64-bit. Natlink requires a 32-bit python environment")
-        
         self.natlink = None
         try:
             import natlink

--- a/dragonfly/engines/backend_sapi5/__init__.py
+++ b/dragonfly/engines/backend_sapi5/__init__.py
@@ -40,6 +40,8 @@ The WSR / SAPI 5 back-end has two engine classes:
 """
 
 import logging
+import platform
+
 _log = logging.getLogger("engine.sapi5")
 
 
@@ -62,19 +64,25 @@ def is_engine_available(name, **kwargs):
     if _engine:
         return True
 
+    platform_name = platform.system()
+    if platform_name != 'Windows':
+        _log.warning("%s is not supported by the SAPI5 engine backend",
+                     platform_name)
+        return False
+
     # Attempt to import win32 package required for COM.
     try:
         from win32com.client import Dispatch
     except ImportError as e:
-        _log.info("Failed to import from win32com package: %s. Is it "
-                   "installed?" % e)
+        _log.warning("Failed to import from win32com package: %s. Is it "
+                     "installed?", e)
         return False
 
     try:
         from pywintypes import com_error
     except ImportError as e:
-        _log.info("Failed to import from the pywintypes package: %s. Is it "
-                   "installed?" % e)
+        _log.warning("Failed to import from the pywintypes package: %s. Is "
+                     "it installed?", e)
         return False
 
     # Attempt to connect to SAPI using the correct dispatch name.
@@ -88,10 +96,10 @@ def is_engine_available(name, **kwargs):
     try:
         Dispatch(dispatch_name)
     except com_error as e:
-        _log.exception("COM error during dispatch: %s" % e)
+        _log.exception("COM error during dispatch: %s", e)
         return False
     except Exception as e:
-        _log.exception("Exception during Sapi5.isNatSpeakRunning(): %s" % e)
+        _log.exception("Exception during Sapi5 COM dispatch): %s", e)
         return False
     return True
 

--- a/dragonfly/engines/backend_sphinx/__init__.py
+++ b/dragonfly/engines/backend_sphinx/__init__.py
@@ -42,16 +42,16 @@ def is_engine_available():
     if _engine:
         return True
 
-    # Check the value of ENGINE_AVAILABLE. This will be False if a
-    # dependency or sub-dependency isn't available.
+    # Attempt to import the engine class from the module.
     try:
-        from .engine import ENGINE_AVAILABLE
-        return ENGINE_AVAILABLE
+        from .engine import SphinxEngine
+        return True
     except ImportError as e:
-        _log.info("Failed to import from Sphinx engine module: %s", e)
+        _log.warning("Failed to import from Sphinx engine module: %s", e)
         return False
     except Exception as e:
-        _log.info("Exception during import of Sphinx engine module: %s", e)
+        _log.exception("Exception during import of Sphinx engine module: "
+                       "%s", e)
         return False
 
     return True

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -29,29 +29,21 @@ import os
 import wave
 
 from six import binary_type, text_type, string_types, PY2
+from jsgf import RootGrammar, PublicRule, Literal
+from sphinxwrapper import PocketSphinx
 
 from dragonfly import Window
-from .recobs import SphinxRecObsManager
-from .timer import SphinxTimerManager
-from .training import write_training_data, write_transcript_files
 from ..base import (EngineBase, EngineError, MimicFailure,
                     DelegateTimerManagerInterface,
                     DictationContainerBase)
-
-try:
-    from jsgf import RootGrammar, PublicRule, Literal
-    from sphinxwrapper import PocketSphinx
-    from .compiler import SphinxJSGFCompiler
-    from .grammar_wrapper import GrammarWrapper
-    from .misc import (EngineConfig, WaveRecognitionObserver,
-                       get_decoder_config_object)
-    from .recording import PyAudioRecorder
-    ENGINE_AVAILABLE = True
-except ImportError:
-    # Import a few things here optionally for readability (the engine won't
-    # start without them) and so that autodoc can import this module without
-    # them.
-    ENGINE_AVAILABLE = False
+from .compiler import SphinxJSGFCompiler
+from .grammar_wrapper import GrammarWrapper
+from .misc import (EngineConfig, WaveRecognitionObserver,
+                   get_decoder_config_object)
+from .recobs import SphinxRecObsManager
+from .recording import PyAudioRecorder
+from .timer import SphinxTimerManager
+from .training import write_training_data, write_transcript_files
 
 
 class UnknownWordError(Exception):
@@ -83,9 +75,9 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         # Set up the engine logger
         logging.basicConfig()
 
-        if not ENGINE_AVAILABLE:
-            self._log.error("%s: Failed to import jsgf, pyaudio and/or "
-                            "sphinxwrapper. Are they installed?" % self)
+        try:
+            import sphinxwrapper, jsgf, pyaudio
+        except ImportError as e:
             raise EngineError("Failed to import Pocket Sphinx engine "
                               "dependencies.")
 


### PR DESCRIPTION
The purpose of this pull request is to enhance error messages related to dependencies for speech recognition engines.  These checks will help inform users during call to get engine and the CLI.

The enhancements include:
Natlink
- Checking OS (only Windows is supported)
- Rewording message checking for natlink clarifying that it needs to be installed.
- Checking python environment to ensure its 32-bit
WSR
- Checking OS (only Windows is supported)
kaldi
- Checking python environment to ensure its 64-bit
All Backends
- Check if the requested engine name is a supported engine.

Example output
```
PS D:\Backup\Library\Documents\Caster> cmd /c python -m dragonfly load --engine foo _caster.py
ERROR:command:Requested engine 'foo' is not a valid engine name.
```

