### PR TITLE
Change Dragonfly's CLI to expand glob patterns where necessary

### DIFF
--- a/documentation/cli.txt
+++ b/documentation/cli.txt
@@ -12,7 +12,7 @@ Command-line Interface (CLI)
 Usage Examples
 ----------------------------------------------------------------------------
 Below are some examples using each of the available sub-commands. All
-examples should work in Bash. Most should work in Windows PowerShell.
+examples should work in Bash, PowerShell, cmd.exe, etc.
 
 :code:`test` examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is required for shells like cmd.exe that can't really handle glob patterns like '_*.py'. The application has to do the work.

These changes should make the following example commands work properly on Windows using cmd.exe or MS PowerShell:

```Shell
python -m dragonfly test dragonfly/examples/_*.py
python -m dragonfly load dragonfly/examples/_*.py

```

These commands already worked properly on Unix/POSIX shells like Bash.

Thanks @LexiconCode for bringing this to my attention :-)