### PR TITLE
Make some improvements to Dragonfly's macOS support

### DIFF
--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -56,10 +56,11 @@ class DarwinWindow(BaseWindow):
 
     @classmethod
     def get_foreground(cls):
-        script = '''
+        script = u'''
         global theId
         tell application "System Events"
-            set theId to id of first application process whose frontmost is true
+            set theId to id of first application process whose ¬
+            frontmost is true
         end tell
         return theId
         '''
@@ -83,10 +84,11 @@ class DarwinWindow(BaseWindow):
 
     @classmethod
     def get_all_windows(cls):
-        script = '''
+        script = u'''
         global appIds
         tell application "System Events"
-            set appIds to id of every application process whose background only is false
+            set appIds to id of every application process whose ¬
+            background only is false
         end tell
         return appIds
         '''

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -33,6 +33,7 @@ Window class for macOS
 
 import locale
 import logging
+import os
 
 from six import binary_type
 import applescript
@@ -67,6 +68,18 @@ class DarwinWindow(BaseWindow):
             window_id = window_id.decode(locale.getpreferredencoding())
 
         return cls.get_window(id=int(window_id))
+
+    @classmethod
+    def get_matching_windows(cls, executable=None, title=None):
+        # Convert absolute executable paths to basenames on macOS. This is
+        # necessary because DarwinWindow executable names are not absolute
+        # and will therefore never match.
+        if executable is not None and os.path.isabs(executable):
+            executable = os.path.basename(executable)
+
+        return super(DarwinWindow, cls).get_matching_windows(
+            executable, title
+        )
 
     @classmethod
     def get_all_windows(cls):

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -142,19 +142,22 @@ class DarwinWindow(BaseWindow):
         """
         Method to get an attribute of a macOS window.
 
+        **Note**: this method doesn't distinguish between multiple instances
+        of the same application.
+
         :param attribute: attribute name
         :type attribute: string
         :returns: attribute value
         """
         script = '''
-         tell application "%s"
+        tell application "%s"
             try
                 get %s of window 1
             on error errmess
                 log errmess
             end try
         end tell
-        ''' % (self._id, attribute)
+        ''' % (self.executable, attribute)
         return applescript.AppleScript(script).run()
 
     def _get_window_text(self):

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -34,7 +34,7 @@ Window class for macOS
 import locale
 import logging
 
-from six import binary_type, string_types, integer_types
+from six import binary_type
 import applescript
 
 from .base_window import BaseWindow
@@ -66,7 +66,7 @@ class DarwinWindow(BaseWindow):
         if isinstance(window_id, binary_type):
             window_id = window_id.decode(locale.getpreferredencoding())
 
-        return cls.get_window(id=str(window_id))
+        return cls.get_window(id=int(window_id))
 
     @classmethod
     def get_all_windows(cls):
@@ -77,7 +77,7 @@ class DarwinWindow(BaseWindow):
         end tell
         return appIds
         '''
-        return [cls.get_window(str(app_id)) for app_id in
+        return [cls.get_window(int(app_id)) for app_id in
                 applescript.AppleScript(script).run()]
 
     #-----------------------------------------------------------------------
@@ -85,17 +85,7 @@ class DarwinWindow(BaseWindow):
 
     def __init__(self, id):
         BaseWindow.__init__(self, id)
-        self._names.add(id)
-
-    #-----------------------------------------------------------------------
-    # Methods that control attribute access.
-
-    def _set_id(self, id):
-        if not isinstance(id, (string_types, integer_types)):
-            raise TypeError("Window id/handle must be an int or string,"
-                            " but received {0!r}".format(id))
-        self._id = id
-        self._windows_by_id[id] = self
+        self._names.add(str(id))
 
     #-----------------------------------------------------------------------
     # Methods and properties for window attributes.
@@ -159,9 +149,6 @@ class DarwinWindow(BaseWindow):
         return self.get_properties().get('pcls', '')
 
     def _get_window_module(self):
-        if not (self._id and isinstance(self._id, string_types)):
-            return ''
-
         script = '''
         global module
         tell application "System Events" to tell application process id %s
@@ -172,9 +159,6 @@ class DarwinWindow(BaseWindow):
         return applescript.AppleScript(script).run()
 
     def _get_window_pid(self):
-        if not (self._id and isinstance(self._id, string_types)):
-            return -1
-
         script = '''
         global pid
         tell application "System Events" to tell application process id %s

--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -251,7 +251,7 @@ class DarwinWindow(BaseWindow):
     def set_foreground(self):
         script = '''
         tell application "System Events" to tell application process id "%s"
-            activate window 1
+            set frontmost to true
         end tell
         ''' % self._id
         applescript.AppleScript(script).run()


### PR DESCRIPTION
This PR fixes the problem of identifying correctly windows of child process that share the same name but have unique IDs (e.g. all child processes of Caster have the same name Python).