### PR TITLE
Add UnsafeActionSeries class to be used via the | and |= operators

### DIFF
--- a/documentation/test_action_base_doctest.txt
+++ b/documentation/test_action_base_doctest.txt
@@ -16,7 +16,7 @@ Test tool
 
 The following PrintAction is used in this test suite::
 
-    >>> from dragonfly import ActionBase, Repeat
+    >>> from dragonfly import ActionBase, Repeat, Function
     >>> class PrintAction(ActionBase):
     ...     def __init__(self, name):
     ...         ActionBase.__init__(self)
@@ -68,6 +68,40 @@ Concatenation of multiple actions::
     executing 'a'
     executing 'b'
     executing 'a'
+    executing 'a'
+    executing 'b'
+    executing 'a'
+
+
+Concatenating failing actions
+----------------------------------------------------------------------------
+
+Series execution normally stops if an action in the series fails::
+
+    >>> bad_function = Function(lambda: 1/0)
+    >>> # This will produce log messages about a ZeroDivisionError.
+    >>> failing_series = (a + bad_function + b)
+    >>> failing_series.execute()
+    executing 'a'
+
+
+Series execution will continue if 'stop_on_failures' is False::
+
+    >>> failing_series.stop_on_failures = False
+    >>> failing_series.execute()
+    executing 'a'
+    executing 'b'
+
+
+Or if using the '|' or '|=' operators::
+
+    >>> (a | bad_function | b).execute()
+    executing 'a'
+    executing 'b'
+    >>> unsafe_action = a | b
+    >>> unsafe_action |= bad_function
+    >>> unsafe_action |= a
+    >>> unsafe_action.execute()
     executing 'a'
     executing 'b'
     executing 'a'


### PR DESCRIPTION
This action class has the previous behaviour of `ActionSeries` where the series continues executing after an action fails. I've also updated the action doctests with cases on series execution failure.

### Comparison of ActionSeries and UnsafeActionSeries
```Python
from dragonfly import Key, Function

# ActionSeries:
# This will type 'a' and then stop when the function raises an error.
(Key("a") + Function(lambda: 1/0) + Key("b")).execute()

# UnsafeActionSeries:
# This will type 'a', log that the function raised an error and then type 'b'.
(Key("a") | Function(lambda: 1/0) | Key("b")).execute()
```

@daanzu This is what you had in mind, right?