### PR TITLE
Make Kaldi and SAPI5 compilers handle Empty and Impossible elements

### DIFF
--- a/documentation/test_grammar_elements_basic_doctest.txt
+++ b/documentation/test_grammar_elements_basic_doctest.txt
@@ -140,3 +140,21 @@ Basic usage::
     u'greetings'
     >>> test_ref.recognize("hello")
     RecognitionFailure
+
+
+Empty element class
+============================================================================
+
+Usage::
+
+    >>> empty = Empty()
+    >>> test_empty = ElementTester(empty)
+    >>> test_empty.recognize("hello")
+    RecognitionFailure
+    >>> empty_seq = Sequence([Literal("hello"), Empty(),
+    ...                       Literal("goodbye")])
+    >>> test_empty = ElementTester(empty_seq)
+    >>> test_empty.recognize("hello goodbye")
+    [u'hello', True, u'goodbye']
+    >>> test_empty.recognize("hello empty goodbye")
+    RecognitionFailure

--- a/documentation/test_grammar_elements_basic_doctest.txt
+++ b/documentation/test_grammar_elements_basic_doctest.txt
@@ -158,3 +158,23 @@ Usage::
     [u'hello', True, u'goodbye']
     >>> test_empty.recognize("hello empty goodbye")
     RecognitionFailure
+
+
+Impossible element class
+============================================================================
+
+Usage::
+
+    >>> impossible = Impossible()
+    >>> test_impossible = ElementTester(impossible)
+    >>> test_impossible.recognize("hello")
+    RecognitionFailure
+    >>> test_impossible.recognize("")
+    RecognitionFailure
+    >>> impossible_seq = Sequence([Literal("hello"), Impossible(),
+    ...                       Literal("goodbye")])
+    >>> test_impossible = ElementTester(impossible_seq)
+    >>> test_impossible.recognize("hello goodbye")
+    RecognitionFailure
+    >>> test_impossible.recognize("hello empty goodbye")
+    RecognitionFailure

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -36,7 +36,8 @@ from .grammar.rule_mapping       import MappingRule
 from .grammar.elements  import (ElementBase, Sequence, Alternative,
                                 Optional, Repetition, Literal,
                                 ListRef, DictListRef, Dictation, Modifier,
-                                RuleRef, RuleWrap, Empty, Compound, Choice)
+                                RuleRef, RuleWrap, Compound, Choice,
+                                Empty, Impossible)
 
 from .grammar.context   import Context, AppContext, FuncContext
 from .grammar.list      import ListBase, List, DictList

--- a/dragonfly/engines/backend_kaldi/compiler.py
+++ b/dragonfly/engines/backend_kaldi/compiler.py
@@ -350,6 +350,10 @@ class KaldiCompiler(CompilerBase, KaldiAGCompiler):
         # FIXME: not impossible enough (lower probability?)
         fst.add_arc(src_state, dst_state, self.impossible_word, weight=0)
 
+    # @trace_compile
+    def _compile_empty(self, element, src_state, dst_state, grammar, kaldi_rule, fst):
+        pass
+
     #-----------------------------------------------------------------------
     # Utility methods.
 

--- a/dragonfly/engines/backend_kaldi/compiler.py
+++ b/dragonfly/engines/backend_kaldi/compiler.py
@@ -352,7 +352,8 @@ class KaldiCompiler(CompilerBase, KaldiAGCompiler):
 
     # @trace_compile
     def _compile_empty(self, element, src_state, dst_state, grammar, kaldi_rule, fst):
-        pass
+        src_state = self.add_weight_linkage(src_state, dst_state, self.get_weight(element), fst)
+        fst.add_arc(src_state, dst_state, WFST.eps)
 
     #-----------------------------------------------------------------------
     # Utility methods.

--- a/dragonfly/engines/backend_kaldi/compiler.py
+++ b/dragonfly/engines/backend_kaldi/compiler.py
@@ -348,7 +348,8 @@ class KaldiCompiler(CompilerBase, KaldiAGCompiler):
     # @trace_compile
     def _compile_impossible(self, element, src_state, dst_state, grammar, kaldi_rule, fst):
         # FIXME: not impossible enough (lower probability?)
-        fst.add_arc(src_state, dst_state, self.impossible_word, weight=0)
+        # Note: setting weight=0 breaks compilation!
+        fst.add_arc(src_state, dst_state, self.impossible_word, weight=1e-10)
 
     # @trace_compile
     def _compile_empty(self, element, src_state, dst_state, grammar, kaldi_rule, fst):

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -240,6 +240,8 @@ class NatlinkEngine(EngineBase):
                 if isinstance(word, text_type):
                     word = word.encode(encoding)
                 prepared_words.append(word)
+            if len(prepared_words) == 0:
+                raise TypeError("empty list or string")
         except Exception as e:
             raise MimicFailure("Invalid mimic input %r: %s."
                                % (words, e))

--- a/dragonfly/engines/backend_sapi5/compiler.py
+++ b/dragonfly/engines/backend_sapi5/compiler.py
@@ -221,3 +221,7 @@ class Sapi5Compiler(CompilerBase):
     def _compile_impossible(self, element, src_state, dst_state, grammar, grammar_handle):
         rule_handle = grammar_handle.Rules.FindRule("_FakeRule")
         src_state.AddRuleTransition(dst_state, rule_handle)
+
+    @trace_compile
+    def _compile_empty(self, element, src_state, dst_state, grammar, grammar_handle):
+        src_state.AddWordTransition(dst_state, '')

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -225,6 +225,10 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
         else:
             phrase = " ".join(words)
 
+        # Fail on empty input.
+        if not phrase:
+            raise MimicFailure("Invalid mimic input %r" % phrase)
+
         # Register a recognition observer for checking the success of this
         # mimic.
         observer = MimicObserver()

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -1018,6 +1018,10 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         if isinstance(words, (list, tuple)):
             words = " ".join(words)
 
+        # Fail on empty input.
+        if not words:
+            raise MimicFailure("Invalid mimic input %r" % words)
+
         if self.recognition_paused and words == self.config.WAKE_PHRASE:
             self.resume_recognition()
             return

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -177,6 +177,10 @@ class TextInputEngine(EngineBase):
             raise TypeError("%r is not a string or other iterable object"
                             % words)
 
+        # Fail on empty input.
+        if not words:
+            raise MimicFailure("Invalid mimic input %r" % words)
+
         # Notify observers that a recognition has begun.
         self._recognition_observer_manager.notify_begin()
 

--- a/dragonfly/grammar/elements_basic.py
+++ b/dragonfly/grammar/elements_basic.py
@@ -1074,7 +1074,17 @@ class Impossible(ElementBase):
     def decode(self, state):
         state.decode_attempt(self)
 
+        # Impossible elements always fail to decode.
         state.decode_failure(self)
+        return
+
+        # Turn this method into a generator by using 'yield'. This works
+        # even though the statement is unreachable.
+        # pylint: disable=unreachable
+        yield state
+
+    def value(self, node):
+        return self
 
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
This makes the Kaldi backend's compiler handle the Empty element in the
same way that the natlink backend handles it - by doing nothing with it.

Fixes #210.