### PR TITLE
Fix Win32 modifier bug where control could be released if held down

### DIFF
--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -32,8 +32,9 @@ Window class for Windows
 
 from ctypes          import windll, pointer, c_wchar, c_ulong
 
-import win32gui
+import win32api
 import win32con
+import win32gui
 
 from .base_window    import BaseWindow
 from .rectangle      import Rectangle
@@ -234,7 +235,10 @@ class Win32Window(BaseWindow):
             # Press a key so Windows allows us to use SetForegroundWindow()
             # (received last input event). See Microsoft's documentation on
             # SetForegroundWindow() for why this works.
-            Key("control:down,control:up").execute()
+            # Only do this if neither the left or right control keys are
+            # held down.
+            if win32api.GetKeyState(win32con.VK_CONTROL) == 0:
+                Key("control:down,control:up").execute()
 
             # Set the foreground window.
             self._set_foreground()


### PR DESCRIPTION
This changes the `Win32Window.set_foreground()` method to only press and release control if the key isn't currently held down.

Control is pressed in that method as a workaround to get Windows to reliably set the foreground window (see PR #106). This will break that workaround in some cases. This is largely unavoidable. If it becomes a problem, then the method could be changed to press a key that isn't used as frequently.