### PR TITLE
Make darwin get_window_module/pid error safe

### DIFF
--- a/dragonfly/windows/darwin_window.py
+++ b/dragonfly/windows/darwin_window.py
@@ -169,9 +169,12 @@ class DarwinWindow(BaseWindow):
     def _get_window_module(self):
         script = '''
         global module
-        tell application "System Events" to tell application process id %s
-            set module to name
-        end tell
+        set module to ""
+        try
+            tell application "System Events" to tell application process id %s
+                set module to name
+            end tell
+        end try
         return module
         ''' % (self._id)
         return applescript.AppleScript(script).run()
@@ -179,9 +182,12 @@ class DarwinWindow(BaseWindow):
     def _get_window_pid(self):
         script = '''
         global pid
-        tell application "System Events" to tell application process id %s
-            set pid to unix id
-        end tell
+        set pid to -1
+        try
+            tell application "System Events" to tell application process id %s
+                set pid to unix id
+            end tell
+        end try
         return pid
         ''' % (self._id)
         return applescript.AppleScript(script).run()


### PR DESCRIPTION
If these methods are called with application process id that no longer
exist, applescript will throw an exception.  This fix catches the
exception and returns empty module name and non-existent process id.