### PR TITLE
Add __str__ method to essential action classes for visualization

### DIFF
--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -24,6 +24,7 @@ ActionBase base class
 
 """
 
+from functools import reduce
 from locale import getpreferredencoding
 import logging
 
@@ -259,6 +260,9 @@ class ActionSeries(ActionBase):
         # Override execute() to discard the return value.
         ActionBase.execute(self, data)
 
+    def __str__(self):
+        return reduce((lambda x, y: "{}+{}".format(x, y)), self._actions)
+
 
 class UnsafeActionSeries(ActionSeries):
     stop_on_failures = False
@@ -299,6 +303,9 @@ class ActionRepetition(ActionBase):
         for _ in range(repeat):
             if self._action.execute(data) is False:
                 raise ActionError(str(self))
+
+    def __str__(self):
+        return '{{{}}}{}'.format(self._action, self._factor)
 
 
 #---------------------------------------------------------------------------
@@ -379,3 +386,6 @@ class Repeat(object):
                                   " (%s)" % (self._extra, e))
             count += additional
         return count
+
+    def __str__(self):
+        return '{}'.format(self._extra if self._extra else self._count)

--- a/dragonfly/actions/action_function.py
+++ b/dragonfly/actions/action_function.py
@@ -122,8 +122,7 @@ class Function(ActionBase):
             argspec = inspect.getfullargspec(self._function)
 
         args, varkw = argspec[0], argspec[2]
-        if varkw:  self._filter_keywords = False
-        else:      self._filter_keywords = True
+        self._filter_keywords = not varkw
         self._valid_keywords = set(args)
 
     def _execute(self, data=None):
@@ -148,3 +147,11 @@ class Function(ActionBase):
             self._log.exception("Exception from function %s:",
                                 self._function.__name__)
             raise ActionError("%s: %s" % (self, e))
+
+    def __str__(self):
+        if (self._str == '<lambda>'):
+            try:
+                return '{}()'.format(inspect.getsource(self._function).strip())
+            except OSError:
+                pass
+        return '{}()'.format(self._str)

--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -512,3 +512,6 @@ class Key(BaseKeyboardAction):
         else:
             self._keyboard.send_keyboard_events(events)
         return True
+
+    def __str__(self):
+        return '[{}]'.format(self._spec)

--- a/dragonfly/actions/action_mouse.py
+++ b/dragonfly/actions/action_mouse.py
@@ -343,3 +343,6 @@ class Mouse(DynStrActionBase):
         window = Window.get_foreground()
         for event in events:
             event.execute(window)
+
+    def __str__(self):
+        return '<{}>'.format(self._spec)

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -162,7 +162,7 @@ class Text(BaseKeyboardAction):
         "\n": typeables["enter"],
         "\t": typeables["tab"],
     }
-    
+
     def __init__(self, spec=None, static=False, pause=None,
                  autofmt=False, use_hardware=False):
         # Use the default pause time if pause in None.
@@ -267,3 +267,6 @@ class Text(BaseKeyboardAction):
         else:
             self._keyboard.send_keyboard_events(keyboard_events)
         return True
+
+    def __str__(self):
+        return u"{!r}".format(self._spec)

--- a/dragonfly/test/test_actions.py
+++ b/dragonfly/test/test_actions.py
@@ -35,7 +35,7 @@ class TestNonAsciiText(unittest.TestCase):
         """ Test handling of non-ASCII characters in Text action. """
 
         action = Text(u"touché")
-        self.assertEqual(str(action), "Text(%r)" % (u"touché",))
+        self.assertEqual(str(action), "%r" % (u"touché",))
 
 
 class TestNonAsciiPaste(unittest.TestCase):


### PR DESCRIPTION
I would like to add these method for rules visualization purposes.  They provide mnemonic representation of actions that can be used to visualize the actions dragonfly rules invoke.