### PR TITLE
Verify that natlink is on the Python path in is_engine_available()

### DIFF
--- a/dragonfly/engines/backend_natlink/__init__.py
+++ b/dragonfly/engines/backend_natlink/__init__.py
@@ -25,8 +25,10 @@ SR back-end package for DNS and Natlink
 """
 
 import logging
-import struct
+import os
 import platform
+import struct
+import sys
 
 _log = logging.getLogger("engine.natlink")
 
@@ -44,6 +46,7 @@ def is_engine_available(**kwargs):
         :param \\**kwargs: optional keyword arguments passed through to the
             engine for engine-specific configuration.
     """
+    # pylint: disable=too-many-return-statements
     global _engine
     if _engine:
         return True
@@ -63,9 +66,30 @@ def is_engine_available(**kwargs):
     try:
         import natlink
     except ImportError as e:
-        _log.warning("Requested engine 'natlink' is not available: Natlink "
-                     "is not installed: %s", e)
-        return False
+        # Add Natlink's default 'core' directory path to sys.path if
+        # necessary.
+        coredir_path = r'C:\\NatLink\\NatLink\\MacroSystem\\core'
+        pyd_filename = 'natlink.pyd'
+        pyd_path = os.path.join(coredir_path, pyd_filename)
+        import_failure = True
+        if os.path.isdir(coredir_path):
+            if not os.path.isfile(pyd_path):
+                _log.warning("Requested engine 'natlink' is not available: "
+                             "The %r file is missing from Natlink's core "
+                             "directory", pyd_filename)
+                return False
+
+            # Add the core directory to the path and try importing again.
+            sys.path.append(coredir_path)
+            try:
+                import natlink
+                import_failure = False
+            except ImportError:
+                pass
+        if import_failure:
+            _log.warning("Requested engine 'natlink' is not available: "
+                         "Natlink is not installed: %s", e)
+            return False
     except Exception as e:
         _log.exception("Exception during import of natlink package: "
                        "%s", e)


### PR DESCRIPTION
Fixes #222.

This adds Natlink's default 'core' directory to 'sys.path' in the event it fails to be imported during `is_engine_available()`. The path is added if it is a valid path and contains the  'natlink.pyd' file. This should allow natlink's modules to be imported.

Thanks @LexiconCode for most of this code.