### PR TITLE
Fix some Python 2.7 encoding bugs

### DIFF
--- a/dragonfly/__main__.py
+++ b/dragonfly/__main__.py
@@ -6,6 +6,8 @@ import re
 import sys
 import time
 
+import six
+
 from dragonfly import get_engine, MimicFailure, EngineError
 from dragonfly.loader import CommandModule, CommandModuleDirectory
 
@@ -71,7 +73,13 @@ def _on_begin():
 
 
 def _on_recognition(words):
-    print("Recognized: %s" % " ".join(words))
+    message = u"Recognized: %s" % u" ".join(words)
+
+    # This only seems to be an issue with Python 2.7 on Windows.
+    if six.PY2:
+        encoding = sys.stdout.encoding or "ascii"
+        message = message.encode(encoding, errors='replace')
+    print(message)
 
 
 def _on_failure():

--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -187,7 +187,7 @@ class BoundAction(ActionBase):
         ActionBase.__init__(self)
         self._action = action
         self._data = data
-        self._str = "%s, %s" % (action, data)
+        self._str = "%r, %r" % (action, data)
 
     #-----------------------------------------------------------------------
     # Execution methods.

--- a/dragonfly/examples/dfly-loader-natlink.py
+++ b/dragonfly/examples/dfly-loader-natlink.py
@@ -37,6 +37,9 @@ Some notes
 """
 
 import os.path
+import sys
+
+import six
 
 from dragonfly import get_engine
 from dragonfly.loader import CommandModuleDirectory
@@ -75,7 +78,13 @@ def main():
         print("Speech start detected.")
 
     def on_recognition(words):
-        print("Recognized: %s" % " ".join(words))
+        message = u"Recognized: %s" % u" ".join(words)
+
+        # This only seems to be an issue with Python 2.7 on Windows.
+        if six.PY2:
+            encoding = sys.stdout.encoding or "ascii"
+            message = message.encode(encoding, errors='replace')
+        print(message)
 
     def on_failure():
         print("Sorry, what was that?")

--- a/dragonfly/examples/dfly-loader-wsr.py
+++ b/dragonfly/examples/dfly-loader-wsr.py
@@ -15,6 +15,9 @@ directory it's in and loads any ``_*.py`` it finds.
 """
 
 import os.path
+import sys
+
+import six
 
 from dragonfly import get_engine
 from dragonfly.loader import CommandModuleDirectory
@@ -54,7 +57,13 @@ def main():
         print("Speech start detected.")
 
     def on_recognition(words):
-        print("Recognized: %s" % " ".join(words))
+        message = u"Recognized: %s" % u" ".join(words)
+
+        # This only seems to be an issue with Python 2.7 on Windows.
+        if six.PY2:
+            encoding = sys.stdout.encoding or "ascii"
+            message = message.encode(encoding, errors='replace')
+        print(message)
 
     def on_failure():
         print("Sorry, what was that?")

--- a/dragonfly/examples/kaldi_module_loader_plus.py
+++ b/dragonfly/examples/kaldi_module_loader_plus.py
@@ -14,8 +14,12 @@ finds.
 # recognition, etc
 
 from __future__ import print_function
-import os.path
+
 import logging
+import os.path
+import sys
+
+import six
 
 from dragonfly import get_engine
 from dragonfly import Grammar, MappingRule, Function, Dictation, FuncContext
@@ -138,7 +142,13 @@ def main():
         print("Speech start detected.")
 
     def on_recognition(words):
-        print("Recognized: %s" % " ".join(words))
+        message = u"Recognized: %s" % u" ".join(words)
+
+        # This only seems to be an issue with Python 2.7 on Windows.
+        if six.PY2:
+            encoding = sys.stdout.encoding or "ascii"
+            message = message.encode(encoding, errors='replace')
+        print(message)
 
     def on_failure():
         print("Sorry, what was that?")

--- a/dragonfly/examples/sphinx_module_loader.py
+++ b/dragonfly/examples/sphinx_module_loader.py
@@ -13,9 +13,11 @@ the CMU Pocket Sphinx engine. It scans the directory it's in and loads any
 # TODO Have a simple GUI for pausing, resuming, cancelling and stopping
 # recognition, etc
 
-import os.path
 import logging
+import os.path
+import sys
 
+import six
 
 from dragonfly import get_engine
 from dragonfly.loader import CommandModuleDirectory
@@ -73,7 +75,13 @@ def main():
         print("Speech start detected.")
 
     def on_recognition(words):
-        print("Recognized: %s" % " ".join(words))
+        message = u"Recognized: %s" % u" ".join(words)
+
+        # This only seems to be an issue with Python 2.7 on Windows.
+        if six.PY2:
+            encoding = sys.stdout.encoding or "ascii"
+            message = message.encode(encoding, errors='replace')
+        print(message)
 
     def on_failure():
         print("Sorry, what was that?")

--- a/dragonfly/examples/wsr_module_loader_plus.py
+++ b/dragonfly/examples/wsr_module_loader_plus.py
@@ -11,9 +11,13 @@ finds.
 # recognition, etc
 
 from __future__ import print_function
-import os.path
+
 import logging
+import os.path
+import sys
 import winsound
+
+import six
 
 from dragonfly import get_engine
 from dragonfly import Grammar, MappingRule, Function, Dictation, FuncContext
@@ -134,7 +138,13 @@ def main():
         print("Speech start detected.")
 
     def on_recognition(words):
-        print("Recognized: %s" % " ".join(words))
+        message = u"Recognized: %s" % u" ".join(words)
+
+        # This only seems to be an issue with Python 2.7 on Windows.
+        if six.PY2:
+            encoding = sys.stdout.encoding or "ascii"
+            message = message.encode(encoding, errors='replace')
+        print(message)
 
     def on_failure():
         print("Sorry, what was that?")


### PR DESCRIPTION
Fixes #203.

This changes Dragonfly's command-line interface and module loader scripts to suppress encoding errors in builtin `on_recognition()` callbacks when the character set of the output stream doesn't define special characters. This problem is specific to Python 2.7.

This also fixes a `UnicodeDecodeError` with the `BoundAction` class that could occur if non-ASCII characters were present in the action or data representation.

### Justification for not dropping Python 2.7 support
Even though Python 2.7 is end-of-life, I'm still fixing bugs specific to it because I am fairly certain that the majority of Dragonfly users still use Dragon and Natlink. Dragonfly's Natlink engine backend doesn't support Python 3.x yet, so I will not be dropping support for Python 2.7 until it does. And, to give people time to transition to Python 3, it will be some time after that.