### PR TITLE
Support edge case of X11 backend when executable isn't valid

### DIFF
--- a/dragonfly/grammar/context.py
+++ b/dragonfly/grammar/context.py
@@ -298,23 +298,25 @@ class AppContext(Context):
         if isinstance(title, string_types):
             title = title.lower()
 
-        if self._executable and isinstance(executable, string_types):
+        if self._executable:
             found = False
-            for match in self._executable:
-                if executable.find(match) != -1:
-                    found = True
-                    break
+            if isinstance(executable, string_types):
+                for match in self._executable:
+                    if executable.find(match) != -1:
+                        found = True
+                        break
             if self._exclude == found:
                 self._log_match.debug("%s: No match, executable doesn't "
                                       "match.", self)
                 return False
 
-        if self._title and isinstance(title, string_types):
+        if self._title:
             found = False
-            for match in self._title:
-                if title.find(match) != -1:
-                    found = True
-                    break
+            if isinstance(title, string_types):
+                for match in self._title:
+                    if title.find(match) != -1:
+                        found = True
+                        break
             if self._exclude == found:
                 self._log_match.debug("%s: No match, title doesn't match.",
                                       self)

--- a/dragonfly/grammar/context.py
+++ b/dragonfly/grammar/context.py
@@ -293,10 +293,12 @@ class AppContext(Context):
     def matches(self, executable, title, handle):
         # pylint: disable=too-many-branches
         # Suppress warnings about too many if-else branches.
-        executable = executable.lower()
-        title = title.lower()
+        if isinstance(executable, string_types):
+            executable = executable.lower()
+        if isinstance(title, string_types):
+            title = title.lower()
 
-        if self._executable:
+        if self._executable and isinstance(executable, string_types):
             found = False
             for match in self._executable:
                 if executable.find(match) != -1:
@@ -307,7 +309,7 @@ class AppContext(Context):
                                       "match.", self)
                 return False
 
-        if self._title:
+        if self._title and isinstance(title, string_types):
             found = False
             for match in self._title:
                 if title.find(match) != -1:

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -342,12 +342,12 @@ class X11Window(BaseWindow):
     def _get_window_module(self):
         # Get the executable using the process ID and psutil.
         pid = self.pid
-        if pid is None:
+        if pid == -1:
             self._executable = ''
         elif self._executable == -1:
-            for p in psutil.process_iter(attrs=['pid', 'exe']):
+            for p in psutil.process_iter(attrs=['pid', 'exe', 'name']):
                 if p.info['pid'] == pid:
-                    self._executable = p.info['exe']
+                    self._executable = p.info['exe'] or p.info['name']
                     return self._executable
 
             # Set to '' if it wasn't found.


### PR DESCRIPTION
This fixes handling of a strange scenario on Linux X11 that I haven't bothered putting time into fully understanding, but I have found a solution that works for me, and shouldn't hurt anyone by adding this guard.

Details:
In my Linux machine (using the KDE Neon distro based on Ubuntu 18.04, and using Dragonfly 0.21 with KaldiAG v1.3.0 backend), if I run the command:
`kdialog --msgbox "Hello"`
then a popup dialog is shown, and I can use Dragonfly to press Enter, as expected.

But if a dialog is created by the "root" super user:
`sudo kdialog --msgbox "Hello"`
if I say anything while this dialog is active, then Dragonfly crashes because the "executable" variable is empty:
```
Speech start detected.
Traceback (most recent call last):
  File "kaldi_module_loader_plus.py", line 425, in <module>
    main(sys.argv[1:])
  File "kaldi_module_loader_plus.py", line 414, in main
    engine.do_recognition(on_begin, on_recognition, on_failure)
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/engines/base/engine.py", line 260, in do_recognition
    self._do_recognition(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/engines/backend_kaldi/engine.py", line 308, in _do_recognition
    kaldi_rules_activity = self._compute_kaldi_rules_activity()
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/engines/backend_kaldi/engine.py", line 415, in _compute_kaldi_rules_activity
    grammar_wrapper.phrase_start_callback(fg_window)
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/engines/backend_kaldi/engine.py", line 499, in phrase_start_callback
    self.grammar.process_begin(fg_window.executable, fg_window.title, fg_window.handle)
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/grammar/grammar_base.py", line 450, in process_begin
    or self._context.matches(executable, title, handle):
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/grammar/context.py", line 210, in matches
    return not self._child.matches(executable, title, handle)
  File "/usr/local/lib/python3.6/dist-packages/dragonfly/grammar/context.py", line 296, in matches
    executable = executable.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```