### PR TITLE
Monitor changes

### DIFF
--- a/dragonfly/actions/action_mouse.py
+++ b/dragonfly/actions/action_mouse.py
@@ -215,8 +215,8 @@ class Mouse(DynStrActionBase):
     def _process_screen_position(self, spec, events):
         if not spec.startswith("[") or not spec.endswith("]"):
             return False
-        h_origin, h_value, v_origin, v_value = self._parse_position_pair(spec[1:-1])
-        event = MoveScreenEvent(h_origin, h_value, v_origin, v_value)
+        _, h_value, _, v_value = self._parse_position_pair(spec[1:-1])
+        event = MoveScreenEvent(True, h_value, True, v_value)
         events.append(event)
         return True
 

--- a/dragonfly/actions/action_mouse.py
+++ b/dragonfly/actions/action_mouse.py
@@ -44,14 +44,16 @@ window (``(0.5, 0.5)``) and then clicks the left mouse button once
     action = Mouse("(0.5, 0.5), left")
     action.execute()
 
-The line below moves the mouse cursor to 100 pixels left of the desktop's
-right edge and 250 pixels down from its top edge (``[-100, 250]``), and
-then double clicks the right mouse button (``right:2``)::
+The line below moves the mouse cursor to 100 pixels left of the primary
+monitor's left edge (if possible) and 250 pixels down from its top edge
+(``[-100, 250]``), and then double clicks the right mouse button
+(``right:2``)::
 
     # Square brackets ("[...]") give desktop-relative locations.
     # Integer locations ("1", "100", etc.) denote numbers of pixels.
-    # Negative numbers ("-100") are counted from the right-edge or the
-    #  bottom-edge of the desktop or window.
+    # Negative numbers ("-100") are counted from the left-edge of the
+    #  primary monitor. They are used to access monitors above or to the
+    #  left of the primary monitor.
     Mouse("[-100, 250], right:2").execute()
 
 The following command drags the mouse from the top right corner of the
@@ -78,9 +80,10 @@ following possible formats:
 
 Mouse movement actions:
 
- - location is absolute on the entire desktop:
+ - move the cursor relative to the top-left corner of the desktop monitor
+   containing coordinates ``[0, 0]`` (i.e. the primary monitor):
    ``[`` *number* ``,`` *number* ``]``
- - location is relative to the foreground window:
+ - move the cursor relative to the foreground window:
    ``(`` *number* ``,`` *number* ``)``
  - move the cursor relative to its current position:
    ``<`` *pixels* ``,`` *pixels* ``>``

--- a/dragonfly/windows/base_monitor.py
+++ b/dragonfly/windows/base_monitor.py
@@ -106,6 +106,27 @@ class BaseMonitor(object):
                          fset=_set_rectangle,
                          doc="Protected access to rectangle attribute.")
 
+    @property
+    def is_primary(self):
+        """
+        Whether this is the primary display monitor.
+
+        :rtype: bool
+        :returns: true or false
+        """
+        rect = self.rectangle
+        return rect.x == 0 and rect.y == 0
+
+    @property
+    def name(self):
+        """
+        The name of this monitor.
+
+        :rtype: str
+        :returns: monitor name
+        """
+        raise NotImplementedError()
+
 
 class FakeMonitor(BaseMonitor):
     """
@@ -115,3 +136,13 @@ class FakeMonitor(BaseMonitor):
     @classmethod
     def get_all_monitors(cls):
         return []
+
+    @property
+    def name(self):
+        """
+        The name of this monitor.
+
+        :rtype: str
+        :returns: monitor name
+        """
+        return self.__class__.__name__

--- a/dragonfly/windows/darwin_monitor.py
+++ b/dragonfly/windows/darwin_monitor.py
@@ -63,3 +63,16 @@ class DarwinMonitor(BaseMonitor):
             monitors.append(cls.get_monitor(handle, rectangle))
 
         return monitors
+
+    #-----------------------------------------------------------------------
+    # Methods that control attribute access.
+
+    @property
+    def name(self):
+        """ The name of this monitor. """
+        handle = self.handle
+        for screen in NSScreen.screens():
+            if screen.deviceDescription()['NSScreenNumber'] == handle:
+                return screen.localizedName()
+
+        return u"macOS monitor"

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -47,7 +47,7 @@ class Win32Monitor(BaseMonitor):
         :returns: true or false
         """
         monitor_info = win32api.GetMonitorInfo(self._handle)
-        return monitor_info["Flags"] == 1
+        return monitor_info["Flags"] & 1 == 1
 
     @property
     def name(self):

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -38,6 +38,17 @@ class Win32Monitor(BaseMonitor):
     #-----------------------------------------------------------------------
     # Class methods to create new Monitor objects.
 
+    @property
+    def is_primary(self):
+        """
+        Whether this is the primary display monitor.
+
+        :rtype: bool
+        :returns: true or false
+        """
+        monitor_info = win32api.GetMonitorInfo(self._handle)
+        return monitor_info["Flags"] == 1
+
     @classmethod
     def get_all_monitors(cls):
         # Get an updated list of monitors.
@@ -54,6 +65,11 @@ class Win32Monitor(BaseMonitor):
             rectangle = Rectangle(top_left_x, top_left_y, dx, dy)
 
             # Get a new or updated monitor object and add it to the list.
-            monitors.append(cls.get_monitor(handle, rectangle))
+            # Ensure that the primary monitor is first on the list.
+            monitor = cls.get_monitor(handle, rectangle)
+            if monitor.is_primary:
+                monitors.insert(0, monitor)
+            else:
+                monitors.append(monitor)
 
         return monitors

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -38,28 +38,6 @@ class Win32Monitor(BaseMonitor):
     #-----------------------------------------------------------------------
     # Class methods to create new Monitor objects.
 
-    @property
-    def is_primary(self):
-        """
-        Whether this is the primary display monitor.
-
-        :rtype: bool
-        :returns: true or false
-        """
-        monitor_info = win32api.GetMonitorInfo(self._handle)
-        return monitor_info["Flags"] & 1 == 1
-
-    @property
-    def name(self):
-        """
-        The device name of this monitor.
-
-        :rtype: str
-        :returns: monitor name
-        """
-        monitor_info = win32api.GetMonitorInfo(self._handle)
-        return monitor_info["Device"]
-
     @classmethod
     def get_all_monitors(cls):
         # Get an updated list of monitors.
@@ -84,3 +62,28 @@ class Win32Monitor(BaseMonitor):
                 monitors.append(monitor)
 
         return monitors
+
+    #-----------------------------------------------------------------------
+    # Methods that control attribute access.
+
+    @property
+    def is_primary(self):
+        """
+        Whether this is the primary display monitor.
+
+        :rtype: bool
+        :returns: true or false
+        """
+        monitor_info = win32api.GetMonitorInfo(self._handle)
+        return monitor_info["Flags"] & 1 == 1
+
+    @property
+    def name(self):
+        """
+        The device name of this monitor.
+
+        :rtype: str
+        :returns: monitor name
+        """
+        monitor_info = win32api.GetMonitorInfo(self._handle)
+        return monitor_info["Device"]

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -49,6 +49,17 @@ class Win32Monitor(BaseMonitor):
         monitor_info = win32api.GetMonitorInfo(self._handle)
         return monitor_info["Flags"] == 1
 
+    @property
+    def name(self):
+        """
+        The device name of this monitor.
+
+        :rtype: str
+        :returns: monitor name
+        """
+        monitor_info = win32api.GetMonitorInfo(self._handle)
+        return monitor_info["Device"]
+
     @classmethod
     def get_all_monitors(cls):
         # Get an updated list of monitors.

--- a/dragonfly/windows/x11_monitor.py
+++ b/dragonfly/windows/x11_monitor.py
@@ -44,6 +44,7 @@ class X11Monitor(BaseMonitor):
     def __init__(self, name, rectangle):
         assert isinstance(name, string_types)
         self._name = name
+        self._primary = False
 
         # Get a numeric value from the name that we can use as a handle.
         handle = hash(name)
@@ -121,6 +122,7 @@ class X11Monitor(BaseMonitor):
 
             # Get a new or updated monitor object and add it to the list.
             monitor = cls.get_monitor(name, rectangle)
+            monitor.is_primary = primary
             if primary:
                 monitors.insert(0, monitor)
             else:
@@ -131,6 +133,13 @@ class X11Monitor(BaseMonitor):
 
     #-----------------------------------------------------------------------
     # Methods that control attribute access.
+
+    def _set_primary(self, value):
+        self._primary = bool(value)
+
+    is_primary = property(fget=lambda self: self._primary,
+                          fset=_set_primary, doc="Whether this is the "
+                          "primary display monitor.")
 
     def _set_name(self, name):
         assert isinstance(name, string_types)

--- a/dragonfly/windows/x11_monitor.py
+++ b/dragonfly/windows/x11_monitor.py
@@ -123,7 +123,9 @@ class X11Monitor(BaseMonitor):
             # Get a new or updated monitor object and add it to the list.
             monitor = cls.get_monitor(name, rectangle)
             monitor.is_primary = primary
-            if primary:
+
+            # Ensure that the origin monitor is the first in the list.
+            if origin_x == 0 and origin_y == 0:
                 monitors.insert(0, monitor)
             else:
                 monitors.append(monitor)


### PR DESCRIPTION
This PR changes the Win32 monitors list to always have the primary monitor first.

@MarkRx This fixes #228 for me. Please let me know if it fixes it for you.

I have also added a `Win32Monitor` `name` property that returns the device name, e.g. `"\\.\DISPLAY1"`. Device names reflect the monitor IDs shown in the control panel.