### PR TITLE
Add get_current_engine() function that doesn't initialize an engine

### DIFF
--- a/documentation/faq.txt
+++ b/documentation/faq.txt
@@ -329,6 +329,23 @@ command-based speech recognition. This is because of the built-in commands
 and dictation output. Dragonfly defaults to the *in-process* SAPI5 engine
 because it doesn't have these defaults.
 
+Is there an easy way to check which speech recognition engine is in use?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Yes. The current engine can be checked using the
+:py:meth:`dragonfly.engines.get_current_engine` function. The following code
+prints the name of the current engine if one has been initialized:
+
+.. code-block:: python
+
+   from dragonfly import get_current_engine
+   engine = get_current_engine()
+   if engine:
+       print("Engine name: %r" % engine.name)
+   else:
+       print("No engine has been initialized.")
+
+
 .. _RefFAQUnansweredQuestions:
 
 Unanswered Questions

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -25,7 +25,8 @@ from .config            import Config, Section, Item
 from .error             import DragonflyError, GrammarError
 
 # --------------------------------------------------------------------------
-from .engines           import get_engine, EngineError, MimicFailure
+from .engines           import (get_engine, EngineError, MimicFailure,
+                                get_current_engine)
 
 # --------------------------------------------------------------------------
 from .grammar.grammar_base       import Grammar

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -50,6 +50,7 @@ def get_engine(name=None, **kwargs):
         :param \\**kwargs: optional keyword arguments passed through to the
             engine for engine-specific configuration.
         :rtype: EngineBase
+        :returns: engine object
         :raises: EngineError
     """
     global _default_engine, _engines_by_name
@@ -162,6 +163,20 @@ def get_engine(name=None, **kwargs):
         else:
             raise EngineError("Requested engine %r not available."
                               % (name,))
+
+
+def get_current_engine():
+    """
+        Get the currently initialized SR engine object.
+
+        If an SR engine has not been initialized yet, ``None`` will be
+        returned instead.
+
+        :rtype: EngineBase | None
+        :returns: engine object or None
+    """
+    global _default_engine
+    return _default_engine
 
 
 # ---------------------------------------------------------------------------

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -174,6 +174,20 @@ def get_current_engine():
 
         :rtype: EngineBase | None
         :returns: engine object or None
+
+        Usage example:
+
+        .. code-block:: python
+
+           # Print the name of the current engine if one has been
+           # initialized.
+           from dragonfly import get_current_engine
+           engine = get_current_engine()
+           if engine:
+               print("Engine name: %r" % engine.name)
+           else:
+               print("No engine has been initialized.")
+
     """
     global _default_engine
     return _default_engine


### PR DESCRIPTION
CC @daanzu

This function returns the current SR engine. If an SR engine has not been initialized yet, then `None` will be returned instead. This is in contrast to the `get_engine()` function which will initialize an SR engine if one is not initialized yet.

One good use case for this is checking the current engine name.