### PR TITLE
Change SAPI5 engine backend to use the recognizer language

### DIFF
--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -40,7 +40,6 @@ from threading import Thread, Event
 from six import text_type, binary_type, string_types, PY2
 
 from ..base        import EngineBase, EngineError, MimicFailure
-from ...error import GrammarError
 from .dictation    import NatlinkDictationContainer
 from .recobs       import NatlinkRecObsManager
 from .timer        import NatlinkTimerManager
@@ -340,41 +339,8 @@ class NatlinkEngine(EngineBase):
         app = win32com.client.Dispatch("Dragon.DgnEngineControl")
         language = app.SpeakerLanguage("")
 
-        # Lookup the language tags.
-        tags = self._language_tags.get(language)
-        if tags:
-            return tags[0]
-
-        # The _language_tags dictionary didn't contain the language, so
-        # get the best match by using the primary language identifier.
-        # This allows us to match unlisted language variants.
-        primary_id = language & 0x00ff
-        for lang_id, (tag, _) in self._language_tags.items():
-            if primary_id == lang_id & 0x00ff:  # Match found.
-                return tag
-
-        # Speaker language wasn't found.
-        self._log.error("Unknown speaker language: 0x%04x" % language)
-        raise GrammarError("Unknown speaker language: 0x%04x" % language)
-
-    _language_tags = {
-                      0x0c09: ("en", "AustralianEnglish"),
-                      0xf00a: ("es", "CastilianSpanish"),
-                      0x0413: ("nl", "Dutch"),
-                      0x0009: ("en", "English"),
-                      0x040c: ("fr", "French"),
-                      0x0407: ("de", "German"),
-                      0xf009: ("en", "IndianEnglish"),
-                      0x0410: ("it", "Italian"),
-                      0x0411: ("jp", "Japanese"),
-                      0xf40a: ("es", "LatinAmericanSpanish"),
-                      0x0416: ("pt", "Portuguese"),
-                      0xf409: ("en", "SingaporeanEnglish"),
-                      0x040a: ("es", "Spanish"),
-                      0x0809: ("en", "UKEnglish"),
-                      0x0409: ("en", "USEnglish"),
-                      0xf809: ("en", "CAEnglish"),
-                     }
+        # Lookup and return the language tag.
+        return self._get_language_tag(language)
 
     def set_retain_directory(self, retain_dir):
         """

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -285,7 +285,19 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
         self._speaker.Speak(text)
 
     def _get_language(self):
-        return "en"
+        if not self._recognizer:
+            return "en"
+
+        # Get Windows language identifiers for supported languages from the
+        # recognizer's current status information.
+        languages = self._recognizer.Status.SupportedLanguages
+
+        # Lookup and return the language tag for the first supported
+        # language ID.
+        if languages:
+            return self._get_language_tag(languages[0])
+        else:
+            return "en"
 
     def process_grammars_context(self, window=None):
         """

--- a/dragonfly/engines/base/engine.py
+++ b/dragonfly/engines/base/engine.py
@@ -291,5 +291,42 @@ class EngineBase(object):
         """
         return self._get_language()
 
+    def _get_language_tag(self, language_id):
+        # Get a language tag from the Windows language identifier.
+        tags = self._language_tags.get(language_id)
+        if tags:
+            return tags[0]
+
+        # The _language_tags dictionary didn't contain the language, so
+        # get the best match by using the primary language identifier.
+        # This allows us to match unlisted language variants.
+        primary_id = language_id & 0x00ff
+        for language_id2, (tag, _) in self._language_tags.items():
+            if primary_id == language_id2 & 0x00ff:  # Match found.
+                return tag
+
+        # Speaker language wasn't found.
+        self._log.error("Unknown speaker language: 0x%04x" % language_id)
+        raise EngineError("Unknown speaker language: 0x%04x" % language_id)
+
+    _language_tags = {
+                      0x0c09: ("en", "AustralianEnglish"),
+                      0xf00a: ("es", "CastilianSpanish"),
+                      0xf809: ("en", "CAEnglish"),
+                      0x0413: ("nl", "Dutch"),
+                      0x0009: ("en", "English"),
+                      0x040c: ("fr", "French"),
+                      0x0407: ("de", "German"),
+                      0xf009: ("en", "IndianEnglish"),
+                      0x0410: ("it", "Italian"),
+                      0x0411: ("jp", "Japanese"),
+                      0xf40a: ("es", "LatinAmericanSpanish"),
+                      0x0416: ("pt", "Portuguese"),
+                      0xf409: ("en", "SingaporeanEnglish"),
+                      0x040a: ("es", "Spanish"),
+                      0x0809: ("en", "UKEnglish"),
+                      0x0409: ("en", "USEnglish"),
+                     }
+
     def _get_language(self):
         raise NotImplementedError("Engine %s not implemented." % self)

--- a/dragonfly/engines/base/engine.py
+++ b/dragonfly/engines/base/engine.py
@@ -313,6 +313,7 @@ class EngineBase(object):
                       0x0c09: ("en", "AustralianEnglish"),
                       0xf00a: ("es", "CastilianSpanish"),
                       0xf809: ("en", "CAEnglish"),
+                      0x0004: ("zh", "Chinese"),
                       0x0413: ("nl", "Dutch"),
                       0x0009: ("en", "English"),
                       0x040c: ("fr", "French"),


### PR DESCRIPTION
Rather than always returning "en", the `engine.language` property now returns a language tag matching the language selected in the Windows Speech Recognition options window.

The internal language tag matching code in `NatlinkEngine` has been moved to the `EngineBase` class so both engine classes can use it.