### PR TITLE
Make Dictation-only rules work with the Sphinx engine again

### DIFF
--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -24,7 +24,6 @@ Engine class for CMU Pocket Sphinx
 
 import contextlib
 import locale
-import logging
 import os
 import wave
 
@@ -71,9 +70,6 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
     def __init__(self):
         EngineBase.__init__(self)
         DelegateTimerManagerInterface.__init__(self)
-
-        # Set up the engine logger
-        logging.basicConfig()
 
         try:
             import sphinxwrapper, jsgf, pyaudio


### PR DESCRIPTION
Closes #23.

The engine attempts to use the language model hypothesis to decode dictation-only specs if no grammar rule matched. This allows using free-dictation with Pocket Sphinx, but not in any required combination with other Dragonfly elements in the same rule.