### PR TITLE
Fix various encoding bugs and related issues

### DIFF
--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -28,7 +28,7 @@ from functools import reduce
 from locale import getpreferredencoding
 import logging
 
-from six import PY2, integer_types
+from six import PY2, integer_types, text_type
 
 
 #---------------------------------------------------------------------------
@@ -220,7 +220,8 @@ class ActionSeries(ActionBase):
     def _set_str(self):
         # Use a flat list of the series actions for a more readable
         # string representation.
-        self._str = ", ".join(str(a) for a in self.flat_action_list())
+        self._str = u", ".join(text_type(a)
+                               for a in self.flat_action_list())
 
     def flat_action_list(self):
         # Get a flattened list of the series actions.

--- a/dragonfly/actions/action_base.py
+++ b/dragonfly/actions/action_base.py
@@ -272,6 +272,9 @@ class UnsafeActionSeries(ActionSeries):
         for action in self._actions:
             action.execute(data)
 
+    def __str__(self):
+        return reduce((lambda x, y: "{}|{}".format(x, y)), self._actions)
+
 
 #---------------------------------------------------------------------------
 

--- a/dragonfly/actions/action_function.py
+++ b/dragonfly/actions/action_function.py
@@ -151,7 +151,8 @@ class Function(ActionBase):
     def __str__(self):
         if (self._str == '<lambda>'):
             try:
-                return '{}()'.format(inspect.getsource(self._function).strip())
+                return '{!r}()'.format(inspect.getsource(self._function)
+                                       .strip())
             except OSError:
                 pass
-        return '{}()'.format(self._str)
+        return '{!r}()'.format(self._str)

--- a/dragonfly/actions/action_function.py
+++ b/dragonfly/actions/action_function.py
@@ -153,6 +153,6 @@ class Function(ActionBase):
             try:
                 return '{!r}()'.format(inspect.getsource(self._function)
                                        .strip())
-            except OSError:
+            except (OSError, IOError):
                 pass
         return '{!r}()'.format(self._str)

--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -514,4 +514,4 @@ class Key(BaseKeyboardAction):
         return True
 
     def __str__(self):
-        return '[{}]'.format(self._spec)
+        return '[{!r}]'.format(self._spec)

--- a/dragonfly/loader.py
+++ b/dragonfly/loader.py
@@ -27,6 +27,8 @@ Command module loading classes
 import os.path
 import logging
 
+import six
+
 # --------------------------------------------------------------------------
 # Command module class; wraps a single command-module.
 
@@ -57,8 +59,10 @@ class CommandModule(object):
         # Attempt to execute the module; handle any exceptions.
         try:
             # pylint: disable=exec-used
-            exec(compile(open(self._path).read(), self._path, 'exec'),
-                 namespace)
+            # Read from the file in binary mode to avoid decoding issues.
+            with open(self._path, "rb") as f:
+                contents = f.read()
+            exec(compile(contents, self._path, 'exec'), namespace)
         except Exception as e:
             self._log.exception("%s: Error loading module: %s", self, e)
             self._loaded = False

--- a/dragonfly/test/test_actions.py
+++ b/dragonfly/test/test_actions.py
@@ -19,12 +19,16 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-
 import unittest
+
+from six import PY2
+
 from dragonfly.actions.action_base import Repeat
-from dragonfly.actions.action_text import Text
-from dragonfly.actions.action_paste import Paste
+from dragonfly.actions.action_function import Function
+from dragonfly.actions.action_key import Key
 from dragonfly.actions.action_mimic import Mimic
+from dragonfly.actions.action_paste import Paste
+from dragonfly.actions.action_text import Text
 
 
 #===========================================================================
@@ -36,6 +40,35 @@ class TestNonAsciiText(unittest.TestCase):
 
         action = Text(u"touché")
         self.assertEqual(str(action), "%r" % (u"touché",))
+
+
+class TestNonAsciiKey(unittest.TestCase):
+
+    def test_non_ascii_key(self):
+        """ Test handling of non-ASCII characters in Key action. """
+
+        action = Key(u"é")
+        self.assertEqual(str(action), "[%r]" % (u"é",))
+
+
+class TestNonAsciiActionSeries(unittest.TestCase):
+
+    def test_non_ascii_key(self):
+        """ Test handling of non-ASCII characters in ActionSeries actions.
+        """
+
+        action = Key(u"é") + Text(u"á")
+        self.assertEqual(str(action), "[%r]+%r" % (u"é", u"á"))
+
+
+class TestNonAsciiFunction(unittest.TestCase):
+
+    def test_non_ascii_function(self):
+        """ Test handling of non-ASCII characters in Function action. """
+
+        action = Function(lambda: u"é")
+        expected = u"\\xe9" if PY2 else u"é"
+        self.assertIn(expected, str(action))
 
 
 class TestNonAsciiPaste(unittest.TestCase):
@@ -54,6 +87,7 @@ class TestNonAsciiMimic(unittest.TestCase):
 
         action = Mimic("touché")
         self.assertEqual(str(action), "Mimic(%r)" % ("touché",))
+
 
 class TestRepeat(unittest.TestCase):
 

--- a/dragonfly/test/test_actions.py
+++ b/dragonfly/test/test_actions.py
@@ -60,6 +60,9 @@ class TestNonAsciiActionSeries(unittest.TestCase):
         action = Key(u"é") + Text(u"á")
         self.assertEqual(str(action), "[%r]+%r" % (u"é", u"á"))
 
+        action = Key(u"é") | Text(u"á")
+        self.assertEqual(str(action), "[%r]|%r" % (u"é", u"á"))
+
 
 class TestNonAsciiFunction(unittest.TestCase):
 


### PR DESCRIPTION
- Command module files are now always opened in binary mode 'rb'.
  This stops Python 3.x from using potentially incorrect character
  encodings to decode source code files.
- Command module files are now correctly closed after being opened
  and read from.
- Fix `__str__` visualization methods that break Unicode support.
  Re: #219.
  This also adds some extra test cases in test_actions.py.

- Add missing `__str__` visualization method for UnsafeActionSeries.
  This uses the '|' separator instead of '+' and includes a test in
  test_actions.py.

- Add missing catch for IOErrors in the `Function.__str__()` method
  An IOError is raised if the inspect module couldn't get the
  function's source code.