### PR TITLE
Change the XdotoolKeyboard class to use '--delay 0' for typing keys

### DIFF
--- a/dragonfly/actions/keyboard/_x11_xdotool.py
+++ b/dragonfly/actions/keyboard/_x11_xdotool.py
@@ -60,9 +60,9 @@ class XdotoolKeyboard(BaseX11Keyboard):
 
             # Add arguments for pressing keys.
             if down:
-                arguments += ['keydown', key]
+                arguments += ['keydown', '--delay', '0', key]
             else:
-                arguments += ['keyup', key]
+                arguments += ['keyup', '--delay', '0', key]
 
             # Instruct xdotool to sleep after the keyboard event if
             # necessary.


### PR DESCRIPTION
CC @tbenst, @shervinemami.

This makes Dragonfly's Key and Text action classes type keys much faster on X11.

This does not affect key event delays defined in action specs (e.g. `Key("shift:down/3, down/3, shift:up/3")`). In fact, these delays should be more precise with these changes.