### PR TITLE
Change the setup_log() function to output log messages to stderr

### DIFF
--- a/dragonfly/test/test_log.py
+++ b/dragonfly/test/test_log.py
@@ -96,9 +96,9 @@ class LogTestCase(unittest.TestCase):
         logger.error("test_filtering - error")
         expected = ["grammar (WARNING): test_filtering - warning",
                     "grammar (ERROR): test_filtering - error"]
-        self.assertEqual(self._output.lines, expected)
+        self.assertEqual(self._error.lines, expected)
 
-        self._output.clear()
+        self._error.clear()
         logger = logging.getLogger("grammar.begin")
         logger.debug("test_filtering - debug")
         logger.info("test_filtering - info")
@@ -107,9 +107,9 @@ class LogTestCase(unittest.TestCase):
         expected = ["grammar.begin (INFO): test_filtering - info",
                     "grammar.begin (WARNING): test_filtering - warning",
                     "grammar.begin (ERROR): test_filtering - error"]
-        self.assertEqual(self._output.lines, expected)
+        self.assertEqual(self._error.lines, expected)
 
-        self._output.clear()
+        self._error.clear()
         logger = logging.getLogger("grammar.load")
         logger.debug("test_filtering - debug")
         logger.info("test_filtering - info")
@@ -117,7 +117,7 @@ class LogTestCase(unittest.TestCase):
         logger.error("test_filtering - error")
         expected = ["grammar.load (WARNING): test_filtering - warning",
                     "grammar.load (ERROR): test_filtering - error"]
-        self.assertEqual(self._output.lines, expected)
+        self.assertEqual(self._error.lines, expected)
 
     def _new_lines(self):
         filename = None


### PR DESCRIPTION
This is being changed to be more consistent with Python's logging framework.

The `use_stdout` parameter has been left in for backwards-compatibility and does nothing.

@daanzu Hopefully this makes the temporary fix added by #235 work properly if `setup_log()` is used instead of `logging.basicConfig()`.