### PR TITLE
Expose internal engine results objects via grammar callbacks

### DIFF
--- a/documentation/grammar.txt
+++ b/documentation/grammar.txt
@@ -64,6 +64,7 @@ the following methods of grammar classes to notify them of the results:
 The last three methods are not defined for the base Grammar class. They
 are only called if they are defined for derived classes.
 
+
 Example Grammar using recognition callbacks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -90,6 +91,9 @@ Example Grammar using recognition callbacks
             print("process_recognition_failure()")
             print(results)
 
+
+.. _RefGrammarCallbackResultsTypes:
+
 Recognition callbacks with results objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -112,6 +116,7 @@ Text input ("text")       ``None``
 .. [*] SAPI 5 does not yield results objects for other grammars, so
        ``process_recognition_other()`` callbacks will return ``None``
        instead.
+
 
 Grammar class
 ----------------------------------------------------------------------------

--- a/documentation/grammar.txt
+++ b/documentation/grammar.txt
@@ -53,7 +53,9 @@ the following methods of grammar classes to notify them of the results:
    allowing derived classes to easily implement custom functionality without
    losing the context matching implemented in ``Grammar.process_begin()``.
  - ``Grammar.process_recognition()``: Called when recognition has completed
-   successfully and results are meant for this grammar.
+   successfully and results are meant for this grammar. If defined, this
+   method should return whether to continue rule processing afterwards
+   (``True`` or ``False``).
  - ``Grammar.process_recognition_other()``: Called when recognition has
    completed successfully, but the results are not meant for this grammar.
  - ``Grammar.process_recognition_failure()``: Called when recognition was
@@ -62,6 +64,54 @@ the following methods of grammar classes to notify them of the results:
 The last three methods are not defined for the base Grammar class. They
 are only called if they are defined for derived classes.
 
+Example Grammar using recognition callbacks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+..  code-block:: python
+
+    from dragonfly import Grammar
+
+    class CallbackGrammar(Grammar):
+
+        def process_recognition(self, words, results):
+            print("process_recognition()")
+            print(words)
+            print(results)
+
+            # Grammar rule processing should continue after this method.
+            return True
+
+        def process_recognition_other(self, words, results):
+            print("process_recognition_other()")
+            print(words)
+            print(results)
+
+        def process_recognition_failure(self, results):
+            print("process_recognition_failure()")
+            print(results)
+
+Recognition callbacks with results objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The last three methods mentioned above can define an optional ``results``
+parameter, the value of which differs between each SR engine back-end:
+
+=======================   ===========================================
+SR engine back-end        Type of ``results`` objects
+=======================   ===========================================
+Dragon/Natlink            ``ResObj`` [*]_
+Kaldi                     ``None``
+CMU Pocket Sphinx         ``None``
+WSR/SAPI 5                ``ISpeechRecoResultDispatch`` [*]_ [*]_
+Text input ("text")       ``None``
+=======================   ===========================================
+
+.. [*] See the `natlink.txt`_ file for info on ``ResObj``.
+.. [*] See the SAPI 5 documentation on `ISpeechRecoResultDispatch`_
+       for how to use it.
+.. [*] SAPI 5 does not yield results objects for other grammars, so
+       ``process_recognition_other()`` callbacks will return ``None``
+       instead.
 
 Grammar class
 ----------------------------------------------------------------------------
@@ -76,3 +126,8 @@ ConnectionGrammar class
 
 .. autoclass:: dragonfly.grammar.grammar_connection.ConnectionGrammar
    :members: application, connection_up, connection_down
+
+
+.. Links.
+.. _natlink.txt: https://github.com/dictation-toolbox/natlink/blob/master/NatlinkSource/natlink.txt
+.. _ISpeechRecoResultDispatch: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ms722106(v=vs.85)

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -39,11 +39,12 @@ from threading import Thread, Event
 
 from six import text_type, binary_type, string_types, PY2
 
-from ..base        import EngineBase, EngineError, MimicFailure
+from ..base        import (EngineBase, EngineError, MimicFailure,
+                           GrammarWrapperBase)
+from .compiler     import NatlinkCompiler
 from .dictation    import NatlinkDictationContainer
 from .recobs       import NatlinkRecObsManager
 from .timer        import NatlinkTimerManager
-from .compiler     import NatlinkCompiler
 import dragonfly.grammar.state as state_
 
 
@@ -386,13 +387,11 @@ class NatlinkEngine(EngineBase):
 #---------------------------------------------------------------------------
 
 
-class GrammarWrapper(object):
+class GrammarWrapper(GrammarWrapperBase):
 
-    def __init__(self, grammar, grammar_object, engine, observer_manager):
-        self.grammar = grammar
+    def __init__(self, grammar, grammar_object, engine, recobs_manager):
+        GrammarWrapperBase.__init__(self, grammar, engine, recobs_manager)
         self.grammar_object = grammar_object
-        self.engine = engine
-        self.observer_manager = observer_manager
 
     def begin_callback(self, module_info):
         executable, title, handle = tuple(map_word(word)
@@ -443,13 +442,13 @@ class GrammarWrapper(object):
 
                     # Notify observers using the manager *before*
                     # processing.
-                    self.observer_manager.notify_recognition(words, r, root)
+                    self.recobs_manager.notify_recognition(words, r, root)
 
                     r.process_recognition(root)
 
                     # Notify observers using the manager *after*
                     # processing.
-                    self.observer_manager.notify_post_recognition(words, r, root)
+                    self.recobs_manager.notify_post_recognition(words, r, root)
                     return
 
         NatlinkEngine._log.warning("Grammar %s: failed to decode"

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -443,13 +443,16 @@ class GrammarWrapper(GrammarWrapperBase):
 
                     # Notify observers using the manager *before*
                     # processing.
-                    self.recobs_manager.notify_recognition(words, r, root)
+                    notify_args = (words, r, root, results)
+                    self.recobs_manager.notify_recognition(*notify_args)
 
                     r.process_recognition(root)
 
                     # Notify observers using the manager *after*
                     # processing.
-                    self.recobs_manager.notify_post_recognition(words, r, root)
+                    self.recobs_manager.notify_post_recognition(
+                        *notify_args
+                    )
                     return
 
         NatlinkEngine._log.warning("Grammar %s: failed to decode"

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -404,15 +404,14 @@ class GrammarWrapper(GrammarWrapperBase):
 
         if words == "other":
             func = getattr(self.grammar, "process_recognition_other", None)
-            if func:
-                words = tuple(map_word(w)
-                              for w in results.getWords(0))
-                func(words)
+            self._process_grammar_callback(
+                func, words=tuple(map_word(w) for w in results.getWords(0)),
+                results=results
+            )
             return
         elif words == "reject":
             func = getattr(self.grammar, "process_recognition_failure", None)
-            if func:
-                func()
+            self._process_grammar_callback(func, results=results)
             return
 
         # If the words argument was not "other" or "reject", then
@@ -425,7 +424,9 @@ class GrammarWrapper(GrammarWrapperBase):
         # Call the grammar's general process_recognition method, if present.
         func = getattr(self.grammar, "process_recognition", None)
         if func:
-            if not func(words):
+            if not self._process_grammar_callback(func, words=words,
+                                                  results=results):
+                # Return early if the method didn't return True or equiv.
                 return
 
         # Iterates through this grammar's rules, attempting

--- a/dragonfly/engines/backend_natlink/recobs.py
+++ b/dragonfly/engines/backend_natlink/recobs.py
@@ -49,18 +49,19 @@ class NatlinkRecObsManager(RecObsManagerBase):
         super(NatlinkRecObsManager, self).notify_begin()
         self._complete_flag = False
 
-    def notify_recognition(self, words, rule, root):
+    def notify_recognition(self, words, rule, root, results):
         if self._complete_flag:
             return
 
-        super(NatlinkRecObsManager, self).notify_recognition(words, rule, root)
+        super(NatlinkRecObsManager, self).notify_recognition(words, rule,
+                                                             root, results)
 
-    def notify_post_recognition(self, words, rule, root):
+    def notify_post_recognition(self, words, rule, root, results):
         if self._complete_flag:
             return
 
         super(NatlinkRecObsManager, self).notify_post_recognition(
-            words, rule, root
+            words, rule, root, results
         )
         self._complete_flag = True
 
@@ -97,9 +98,9 @@ class NatlinkRecObsGrammar(Grammar):
         raise RuntimeError("Recognition observer received an unexpected"
                            " recognition: %s" % (words,))
 
-    def process_recognition_other(self, words):
-        self._manager.notify_recognition(words, None, None)
-        self._manager.notify_post_recognition(words, None, None)
+    def process_recognition_other(self, words, results):
+        self._manager.notify_recognition(words, None, None, results)
+        self._manager.notify_post_recognition(words, None, None, results)
 
-    def process_recognition_failure(self):
-        self._manager.notify_failure()
+    def process_recognition_failure(self, results):
+        self._manager.notify_failure(results)

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -628,9 +628,12 @@ class GrammarWrapper(GrammarWrapperBase):
                         # Notify recognition observers, then process the
                         # rule.
                         root = s.build_parse_tree()
-                        self.recobs_manager.notify_recognition(words, r, root)
+                        notify_args = (words, r, root, newResult)
+                        self.recobs_manager.notify_recognition(*notify_args)
                         r.process_recognition(root)
-                        self.recobs_manager.notify_post_recognition(words, r, root)
+                        self.recobs_manager.notify_post_recognition(
+                            *notify_args
+                        )
                         return
 
         except Exception as e:

--- a/dragonfly/engines/backend_sapi5/recobs.py
+++ b/dragonfly/engines/backend_sapi5/recobs.py
@@ -71,5 +71,5 @@ class Sapi5RecObsGrammar(Grammar):
         raise RuntimeError("Recognition observer received an unexpected"
                            " recognition: %s" % (words,))
 
-    def process_recognition_failure(self):
-        self._manager.notify_failure()
+    def process_recognition_failure(self, results):
+        self._manager.notify_failure(results)

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -670,8 +670,9 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         )
 
         # Notify observers of failure.
+        results_obj = None  # TODO Use PS results object once implemented
         if not processing_occurred:
-            self._recognition_observer_manager.notify_failure()
+            self._recognition_observer_manager.notify_failure(results_obj)
 
         # Write the training data files if necessary.
         data_dir = self.config.TRAINING_DATA_DIR
@@ -737,11 +738,12 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
                 speech = speech.rstrip()  # remove trailing whitespace.
 
         # Notify observers if a keyphrase was matched.
+        results_obj = None  # TODO Use PS results object once implemented
         result = speech if speech in self._keyphrase_functions else ""
         words = tuple(result.split())
         if words:
             self._recognition_observer_manager.notify_recognition(
-                words, None, None
+                words, None, None, results_obj
             )
 
         # Call the registered function if there was a match and the function
@@ -759,7 +761,7 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         # Notify observers after calling the keyphrase function.
         if words:
             self._recognition_observer_manager.notify_post_recognition(
-                words, None, None
+                words, None, None, results_obj
             )
 
         return result
@@ -1195,9 +1197,12 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         # Notify observers about recognition resume.
         keyphrase = self.config.WAKE_PHRASE
         words = tuple(keyphrase.strip().split())
+        results_obj = None  # TODO Use PS results object once implemented
         if words and notify:
-            self._recognition_observer_manager.notify_recognition(words, None, None)
-            self._recognition_observer_manager.notify_post_recognition(words, None, None)
+            manager = self._recognition_observer_manager
+            arguments = (words, None, None, results_obj)
+            manager.notify_recognition(*arguments)
+            manager.notify_post_recognition(*arguments)
 
         # Restore the callbacks to normal
         def hypothesis(hyp):

--- a/dragonfly/engines/backend_sphinx/grammar_wrapper.py
+++ b/dragonfly/engines/backend_sphinx/grammar_wrapper.py
@@ -6,22 +6,22 @@ from jsgf import Literal, filter_expansion
 
 import dragonfly.grammar.state as state_
 
+from ..base import GrammarWrapperBase
 
-class GrammarWrapper(object):
+
+class GrammarWrapper(GrammarWrapperBase):
     """
     GrammarWrapper class for CMU Pocket Sphinx engine
     """
 
     _log = logging.getLogger("engine")
 
-    def __init__(self, grammar, engine, observer_manager, search_name):
+    def __init__(self, grammar, engine, recobs_manager, search_name):
         """
         :type grammar: Grammar
         :type engine: SphinxEngine
         """
-        self.grammar = grammar
-        self.engine = engine
-        self._observer_manager = observer_manager
+        GrammarWrapperBase.__init__(self, grammar, engine, recobs_manager)
         self.set_search = True
         self._search_name = search_name
         self.exclusive = False
@@ -158,7 +158,7 @@ class GrammarWrapper(object):
                     root = s.build_parse_tree()
 
                     # Notify observers using the manager *before* processing.
-                    self._observer_manager.notify_recognition(
+                    self.recobs_manager.notify_recognition(
                         tuple([word for word, _ in words]),
                         r,
                         root
@@ -168,7 +168,7 @@ class GrammarWrapper(object):
                     if not self.engine.training_session_active:
                         try:
                             r.process_recognition(root)
-                            self._observer_manager.notify_post_recognition(
+                            self.recobs_manager.notify_post_recognition(
                                 tuple([word for word, _ in words]),
                                 r,
                                 root

--- a/dragonfly/engines/backend_sphinx/grammar_wrapper.py
+++ b/dragonfly/engines/backend_sphinx/grammar_wrapper.py
@@ -125,29 +125,38 @@ class GrammarWrapper(GrammarWrapperBase):
 
         self._log.debug("Grammar %s: received recognition %r."
                         % (self.grammar.name, words))
+        results_obj = None  # TODO Use PS results object once implemented
+
+        # TODO Make special grammar callbacks work properly.
+        # These special methods are never called for this engine.
         if words == "other":
             func = getattr(self.grammar, "process_recognition_other", None)
-            if func:
-                func(words)
+            self._process_grammar_callback(func, words=words,
+                                           results=results_obj)
             return
         elif words == "reject":
-            func = getattr(self.grammar, "process_recognition_failure", None)
-            if func:
-                func()
+            func = getattr(self.grammar, "process_recognition_failure",
+                           None)
+            self._process_grammar_callback(func, results=results_obj)
             return
 
         # If the words argument was not "other" or "reject", then it is a
         # sequence of (word, rule_id) 2-tuples.
+        words_rules = tuple(words)
+        words = tuple(word for word, _ in words)
+
         # Call the grammar's general process_recognition method, if present.
         func = getattr(self.grammar, "process_recognition", None)
         if func:
-            if not func(words):
+            if not self._process_grammar_callback(func, words=words,
+                                                  results=results_obj):
+                # Return early if the method didn't return True or equiv.
                 return
 
         # Iterate through this grammar's rules, attempting to decode each.
         # If successful, call that rule's method for processing the
         # recognition and return.
-        s = state_.State(words, self.grammar.rule_names, self.engine)
+        s = state_.State(words_rules, self.grammar.rule_names, self.engine)
         for r in self.grammar.rules:
             if not (r.active and r.exported):
                 continue
@@ -157,11 +166,11 @@ class GrammarWrapper(GrammarWrapperBase):
                     # Build the parse tree used to process this rule.
                     root = s.build_parse_tree()
 
-                    # Notify observers using the manager *before* processing.
+                    # Notify observers using the manager *before*
+                    # processing.
+                    notify_args = (words, r, root, results_obj)
                     self.recobs_manager.notify_recognition(
-                        tuple([word for word, _ in words]),
-                        r,
-                        root
+                        *notify_args
                     )
 
                     # Process the rule if not in training mode.
@@ -169,9 +178,7 @@ class GrammarWrapper(GrammarWrapperBase):
                         try:
                             r.process_recognition(root)
                             self.recobs_manager.notify_post_recognition(
-                                tuple([word for word, _ in words]),
-                                r,
-                                root
+                                *notify_args
                             )
                         except Exception as e:
                             self._log.exception("Failed to process rule "

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -30,7 +30,7 @@ from dragonfly import Window
 
 from .recobs import TextRecobsManager
 from ..base import (EngineBase, MimicFailure, ThreadedTimerManager,
-                    DictationContainerBase)
+                    DictationContainerBase, GrammarWrapperBase)
 
 
 def _map_word(word):
@@ -256,14 +256,12 @@ class TextInputEngine(EngineBase):
         self._language = value
 
 
-class GrammarWrapper(object):
+class GrammarWrapper(GrammarWrapperBase):
 
     _log = logging.getLogger("engine")
 
-    def __init__(self, grammar, engine, observer_manager):
-        self.grammar = grammar
-        self.engine = engine
-        self._observer_manager = observer_manager
+    def __init__(self, grammar, engine, recobs_manager):
+        GrammarWrapperBase.__init__(self, grammar, engine, recobs_manager)
         self.exclusive = False
 
     def process_begin(self, executable, title, handle):
@@ -310,7 +308,7 @@ class GrammarWrapper(object):
                         root = s.build_parse_tree()
 
                         # Notify observers using the manager *before* processing.
-                        self._observer_manager.notify_recognition(
+                        self.recobs_manager.notify_recognition(
                             tuple([word for word, _ in words]),
                             r,
                             root
@@ -318,7 +316,7 @@ class GrammarWrapper(object):
 
                         r.process_recognition(root)
 
-                        self._observer_manager.notify_post_recognition(
+                        self.recobs_manager.notify_post_recognition(
                             tuple([word for word, _ in words]),
                             r,
                             root

--- a/dragonfly/engines/base/__init__.py
+++ b/dragonfly/engines/base/__init__.py
@@ -19,10 +19,11 @@
 #
 
 
-from .engine       import EngineBase, EngineError, MimicFailure
-from .compiler     import CompilerBase, CompilerError
-from .dictation    import DictationContainerBase
-from .recobs       import RecObsManagerBase
-from .timer        import (TimerManagerBase, ThreadedTimerManager,
-                           DelegateTimerManager,
-                           DelegateTimerManagerInterface)
+from .engine           import EngineBase, EngineError, MimicFailure
+from .compiler         import CompilerBase, CompilerError
+from .dictation        import DictationContainerBase
+from .grammar_wrapper  import GrammarWrapperBase
+from .recobs           import RecObsManagerBase
+from .timer            import (TimerManagerBase, ThreadedTimerManager,
+                               DelegateTimerManager,
+                               DelegateTimerManagerInterface)

--- a/dragonfly/engines/base/grammar_wrapper.py
+++ b/dragonfly/engines/base/grammar_wrapper.py
@@ -1,0 +1,51 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+GrammarWrapperBase class
+============================================================================
+
+"""
+
+try:
+    from inspect import getfullargspec as getargspec
+except ImportError:
+    # Fallback on the deprecated function.
+    from inspect import getargspec
+
+
+class GrammarWrapperBase(object):
+
+    def __init__(self, grammar, engine, recobs_manager):
+        self.grammar = grammar
+        self.engine = engine
+        self.recobs_manager = recobs_manager
+
+    def _process_grammar_callback(self, func, **kwargs):
+        if not func:
+            return
+
+        # Only send keyword arguments that the given function accepts.
+        argspec = getargspec(func)
+        arg_names, kwargs_names = argspec[0], argspec[2]
+        if not kwargs_names:
+            kwargs = { k: v for (k, v) in kwargs.items() if k in arg_names }
+
+        return func(**kwargs)

--- a/dragonfly/engines/base/recobs.py
+++ b/dragonfly/engines/base/recobs.py
@@ -101,21 +101,23 @@ class RecObsManagerBase(object):
     def notify_begin(self):
         self._process_observer_callbacks("on_begin", [])
 
-    def notify_recognition(self, words, rule, node):
+    def notify_recognition(self, words, rule, node, results):
         self._process_observer_callbacks("on_recognition", ["words"],
-                                         words=words, rule=rule, node=node)
-        self.notify_end()
+                                         words=words, rule=rule, node=node,
+                                         results=results)
+        self.notify_end(results)
 
-    def notify_failure(self):
-        self._process_observer_callbacks("on_failure", [])
-        self.notify_end()
+    def notify_failure(self, results):
+        self._process_observer_callbacks("on_failure", [], results=results)
+        self.notify_end(results)
 
-    def notify_end(self):
-        self._process_observer_callbacks("on_end", [])
+    def notify_end(self, results):
+        self._process_observer_callbacks("on_end", [], results=results)
 
-    def notify_post_recognition(self, words, rule, node):
+    def notify_post_recognition(self, words, rule, node, results):
         self._process_observer_callbacks("on_post_recognition", ["words"],
-                                         words=words, rule=rule, node=node)
+                                         words=words, rule=rule, node=node,
+                                         results=results)
 
     def _activate(self):
         raise NotImplementedError(str(self))

--- a/dragonfly/grammar/recobs.py
+++ b/dragonfly/grammar/recobs.py
@@ -73,7 +73,7 @@ class RecognitionObserver(object):
         detected.
         """
 
-    def on_recognition(self, words, rule, node):
+    def on_recognition(self, words, rule, node, results):
         """
         Method called when speech successfully decoded to a grammar rule or
         to dictation.
@@ -87,22 +87,30 @@ class RecognitionObserver(object):
         :type rule: Rule
         :param node: *optional* parse tree node
         :type node: Node
+        :param results: *optional* engine recognition results object
+        :type results: :ref:`engine-specific type<RefGrammarCallbackResultsTypes>`
         """
 
-    def on_failure(self):
+    def on_failure(self, results):
         """
         Method called when speech failed to decode to a grammar rule or to
         dictation.
+
+        :param results: *optional* engine recognition results object
+        :type results: :ref:`engine-specific type<RefGrammarCallbackResultsTypes>`
         """
 
-    def on_end(self):
+    def on_end(self, results):
         """
         Method called when speech ends, either with a successful
         recognition (after ``on_recognition``) or in failure (after
         ``on_failure``).
+
+        :param results: *optional* engine recognition results object
+        :type results: :ref:`engine-specific type<RefGrammarCallbackResultsTypes>`
         """
 
-    def on_post_recognition(self, words, rule, node):
+    def on_post_recognition(self, words, rule, node, results):
         """
         Method called when speech successfully decoded to a grammar rule or
         to dictation.
@@ -116,6 +124,8 @@ class RecognitionObserver(object):
         :type rule: Rule
         :param node: *optional* parse tree node
         :type node: Node
+        :param results: *optional* engine recognition results object
+        :type results: :ref:`engine-specific type<RefGrammarCallbackResultsTypes>`
         """
 
 

--- a/dragonfly/grammar/recobs_callbacks.py
+++ b/dragonfly/grammar/recobs_callbacks.py
@@ -80,23 +80,25 @@ class CallbackRecognitionObserver(RecognitionObserver):
         """"""
         self._process_recognition_event("on_begin", [])
 
-    def on_recognition(self, words, rule, node):
+    def on_recognition(self, words, rule, node, results):
         """"""
         self._process_recognition_event("on_recognition", ["words"],
-                                        words=words, rule=rule, node=node)
+                                        words=words, rule=rule, node=node,
+                                        results=results)
 
-    def on_failure(self):
+    def on_failure(self, results):
         """"""
-        self._process_recognition_event("on_failure", [])
+        self._process_recognition_event("on_failure", [], results=results)
 
-    def on_end(self):
+    def on_end(self, results):
         """"""
-        self._process_recognition_event("on_end", [])
+        self._process_recognition_event("on_end", [], results=results)
 
-    def on_post_recognition(self, words, rule, node):
+    def on_post_recognition(self, words, rule, node, results):
         """"""
         self._process_recognition_event("on_post_recognition", ["words"],
-                                        words=words, rule=rule, node=node)
+                                        words=words, rule=rule, node=node,
+                                        results=results)
 
 
 def register_beginning_callback(function):


### PR DESCRIPTION
This PR exposes internal engine results objects via grammar callbacks. This allows the following custom `Grammar` class to work:

```Python
class MyGrammar(Grammar):

    def process_recognition(self, words, results):
        print("process_recognition()")
        print(words)
        print(results)

        # This is required for rule processing to continue and needs to be documented!
        return True  

    def process_recognition_other(self, words, results):
        print("process_recognition_other()")
        print(words)
        print(results)

    def process_recognition_failure(self, results):
        print("process_recognition_failure()")
        print(results)

```

I have implemented and tested this for WSR/SAPI 5. I will add the requested Natlink implementation before merging. For consistency, I'd like to also have something implemented for the CMU Pocket Sphinx engine.

I've also updated the documentation section on `Grammar` recognition callbacks.

@daanzu Do you think there is anything useful the Kaldi engine could expose this way?