### PR TITLE
Use Dragonfly's Win32 Clipboard class on Windows

### DIFF
--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -66,7 +66,10 @@ if sys.platform.startswith("win"):
 
 # --------------------------------------------------------------------------
 
-from .util              import Clipboard
+if sys.platform.startswith("win"):
+    from .windows.clipboard import Clipboard
+else:
+    from .util              import Clipboard
 
 # --------------------------------------------------------------------------
 

--- a/dragonfly/test/suites.py
+++ b/dragonfly/test/suites.py
@@ -19,6 +19,8 @@
 #
 
 import logging
+import os
+import sys
 
 import pytest
 
@@ -49,6 +51,18 @@ common_names = [
     "documentation/test_grammar_list_doctest.txt",
     "documentation/test_recobs_doctest.txt",
 ]
+
+# Run clipboard tests if on a desktop system.
+desktop = (
+    # Windows
+    os.name == "nt" or
+    # X11
+    os.environ.get("XDG_SESSION_TYPE") == "x11" or
+    # macOS
+    sys.platform == "darwin"
+)
+if desktop:
+    common_names.insert(2, "test_clipboard")
 
 # Define spoken language test files. All of them work with the natlink and
 # text engines. The English tests should work with sapi5 and sphinx by

--- a/dragonfly/test/test_clipboard.py
+++ b/dragonfly/test/test_clipboard.py
@@ -21,7 +21,7 @@
 
 import unittest
 
-from dragonfly.util import Clipboard
+from dragonfly import Clipboard
 
 
 class TestClipboard(unittest.TestCase):

--- a/dragonfly/test/test_clipboard.py
+++ b/dragonfly/test/test_clipboard.py
@@ -28,6 +28,17 @@ class TestClipboard(unittest.TestCase):
     """
     Tests for the multi-platform Clipboard class.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        # Save the current contents of the clipboard.
+        cls.clipboard = Clipboard(from_system=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Restore the clipboard contents to what it was before the tests.
+        cls.clipboard.copy_to_system()
+
     def setUp(self):
         # Clear the clipboard before each test.
         Clipboard.clear_clipboard()

--- a/dragonfly/windows/clipboard.py
+++ b/dragonfly/windows/clipboard.py
@@ -32,6 +32,7 @@ import locale
 
 from six import text_type, integer_types
 
+import pywintypes
 import win32clipboard
 import win32con
 
@@ -67,6 +68,8 @@ class Clipboard(BaseClipboard):
             content = win32clipboard.GetClipboardData(cls.format_unicode)
             if not content:
                 content = win32clipboard.GetClipboardData(cls.format_text)
+        except (TypeError, pywintypes.error):
+            content = u""
         finally:
             win32clipboard.CloseClipboard()
         return content

--- a/dragonfly/windows/clipboard.py
+++ b/dragonfly/windows/clipboard.py
@@ -28,6 +28,8 @@ This file implements an interface to the Windows system clipboard.
 # pylint: disable=W0622
 # Suppress warnings about redefining the built-in 'format' function.
 
+import locale
+
 from six import text_type, integer_types
 
 import win32clipboard
@@ -106,6 +108,12 @@ class Clipboard(BaseClipboard):
         # Handle special case of text content.
         if not text is None:
             self._contents[self.format_unicode] = text_type(text)
+
+        # Use a binary string for CF_TEXT content.
+        cf_text_content = self._contents.get(self.format_text)
+        if isinstance(cf_text_content, text_type):
+            enc = locale.getpreferredencoding()
+            self._contents[self.format_text] = cf_text_content.encode(enc)
 
     def __repr__(self):
         arguments = []


### PR DESCRIPTION
Dragonfly was changed to use a cross-platform clipboard class a while ago. This simply changes the default Clipboard class to the original Win32 Clipboard class on Windows, as it supports more clipboard formats than the cross-platform class.

This change is backwards-compatible; both classes have the same methods and the cross-platform class was based on the Win32 class.