### PR TITLE
Add support for quoted words in rules

### DIFF
--- a/documentation/elements.txt
+++ b/documentation/elements.txt
@@ -34,7 +34,8 @@ Repetition class
 Literal class
 ----------------------------------------------------------------------------
 .. autoclass:: dragonfly.grammar.elements_basic.Literal
-   :members: dependencies, gstring, decode, value, children
+   :members: dependencies, gstring, decode, value, children, words,
+             words_ext
 
 RuleRef class
 ----------------------------------------------------------------------------

--- a/documentation/test_grammar_elements_basic_doctest.txt
+++ b/documentation/test_grammar_elements_basic_doctest.txt
@@ -37,6 +37,55 @@ Usage::
     >>> test_literal.recognize("goodbye")
     RecognitionFailure
 
+Quoted words usage::
+
+    >>> # Quoted words are not joined in the 'words' property.
+    >>> # Also, double quotes are not present.
+    >>> literal = Literal('this is a "quoted string" example')
+    >>> literal.words
+    ['this', 'is', 'a', 'quoted', 'string', 'example']
+    >>> # The 'words_ext' property shows quoted words as single items.
+    >>> # Double quotes are also not present.
+    >>> literal.words_ext
+    ['this', 'is', 'a', 'quoted string', 'example']
+    >>> # Rules with quoted words can be recognized.
+    >>> test_literal = ElementTester(literal)
+    >>> test_literal.recognize('this is a quoted string example')
+    u'this is a quoted string example'
+
+Incomplete quotes::
+
+    >>> # Incomplete quotes are left in.
+    >>> literal = Literal('"quote')
+    >>> literal.words
+    ['"quote']
+    >>> literal.words_ext
+    ['"quote']
+    >>> literal = Literal('a "quoted string" example plus "quote')
+    >>> literal.words
+    ['a', 'quoted', 'string', 'example', 'plus', '"quote']
+    >>> literal.words_ext
+    ['a', 'quoted string', 'example', 'plus', '"quote']
+
+Non-default quote constructor arguments::
+
+    >>> literal = Literal(u'this is a «quoted string» example',
+    ...                   quote_start_str=u'«', quote_end_str=u'»')
+    >>> literal.words
+    ['this', 'is', 'a', 'quoted', 'string', 'example']
+    >>> literal.words_ext
+    ['this', 'is', 'a', 'quoted string', 'example']
+    >>> test_literal = ElementTester(literal)
+    >>> test_literal.recognize('this is a quoted string example')
+    u'this is a quoted string example'
+
+    >>> # Quotes are left in if specified.
+    >>> literal = Literal('"quoted string"', strip_quote_strs=False)
+    >>> literal.words
+    ['"quoted', 'string"']
+    >>> literal.words_ext
+    ['"quoted string"']
+
 
 Optional element class
 ============================================================================

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -268,6 +268,9 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
     def _get_language(self):
         return "en"
 
+    def _has_quoted_words_support(self):
+        return False
+
     def prepare_for_recognition(self):
         """ Can be called optionally before ``do_recognition()`` to speed up its starting of active recognition. """
         self._compiler.prepare_for_recognition()

--- a/dragonfly/engines/backend_natlink/compiler.py
+++ b/dragonfly/engines/backend_natlink/compiler.py
@@ -97,7 +97,10 @@ class NatlinkCompiler(CompilerBase):
         compiler.end_optional()
 
     def _compile_literal(self, element, compiler):
-        words = element.words
+        # Use the element's words extension property to enable use of
+        # quoted words. DNS will receive quoted words as single strings.
+        # This can help with accuracy in some cases.
+        words = element.words_ext
         if len(words) == 1:
             compiler.add_word(words[0])
         elif len(words) > 1:

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -344,7 +344,7 @@ class NatlinkEngine(EngineBase):
         return self._get_language_tag(language)
 
     def _has_quoted_words_support(self):
-        return False
+        return True
 
     def set_retain_directory(self, retain_dir):
         """

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -343,6 +343,9 @@ class NatlinkEngine(EngineBase):
         # Lookup and return the language tag.
         return self._get_language_tag(language)
 
+    def _has_quoted_words_support(self):
+        return False
+
     def set_retain_directory(self, retain_dir):
         """
         Set the directory where audio data is saved.

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -301,6 +301,9 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
         else:
             return "en"
 
+    def _has_quoted_words_support(self):
+        return False
+
     def process_grammars_context(self, window=None):
         """
             Enable/disable grammars & rules based on their current contexts.

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -1077,6 +1077,9 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
     def _get_language(self):
         return self.config.LANGUAGE
 
+    def _has_quoted_words_support(self):
+        return False
+
     # ----------------------------------------------------------------------
     # Training-related methods
 

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -255,6 +255,9 @@ class TextInputEngine(EngineBase):
 
         self._language = value
 
+    def _has_quoted_words_support(self):
+        return False
+
 
 class GrammarWrapper(GrammarWrapperBase):
 

--- a/dragonfly/engines/base/engine.py
+++ b/dragonfly/engines/base/engine.py
@@ -331,3 +331,15 @@ class EngineBase(object):
 
     def _get_language(self):
         raise NotImplementedError("Engine %s not implemented." % self)
+
+    @property
+    def quoted_words_support(self):
+        """
+        Whether this engine can compile and recognize quoted words.
+
+        :rtype: bool
+        """
+        return self._has_quoted_words_support()
+
+    def _has_quoted_words_support(self):
+        raise NotImplementedError("Engine %s not implemented." % self)

--- a/dragonfly/grammar/elements_basic.py
+++ b/dragonfly/grammar/elements_basic.py
@@ -831,7 +831,10 @@ class Literal(ElementBase):
 
         # Iterate through this element's words.
         # If all match, success.  Else, failure.
-        words = self._words_ext
+        if state.engine.quoted_words_support:
+            words = self._words_ext
+        else:
+            words = self._words
         for i in range(len(words)):
             word = state.word(i)
 

--- a/dragonfly/grammar/state.py
+++ b/dragonfly/grammar/state.py
@@ -74,6 +74,10 @@ class State(object):
         else:
             return None
 
+    @property
+    def engine(self):
+        return self._engine
+
     def rule(self, delta=0):
         i = self._index + delta
         if 0 <= i < len(self._results):


### PR DESCRIPTION
Closes #138.

As discussed in #138, use of quoted words can improve accuracy in some cases. This PR allows quoted words to be used in `Literal` elements, which in turn allows them to be used in `Compound` and `Choice` elements as well as in `MappingRule` and `CompoundRule` spec strings.

Only the Natlink engine back-end currently supports them completely. If quoted words are used with other engine back-ends, quoting is effectively ignored. I have added a `quoted_words_support` engine property for checking if the current engine can compile and recognize quoted words.

Using quoted strings with DNS/Natlink may in fact *decrease* recognition accuracy for certain phrases. I think this depends on the current DNS vocabulary.

### Usage examples

```Python
from dragonfly import Literal, CompoundRule, MappingRule, Text

# Using a quoted string in a Literal element.
literal = Literal('this is a "quoted string" example')

# Using a quoted string in a CompoundRule.
CompoundRule(spec='this is a "quoted string" example')

# Using a quoted string in a MappingRule.
MappingRule(
    mapping={
        'this is a "quoted string" example': Text("quoted string"),
    }
)

# Using a quoted string in a MappingRule via an extra.
MappingRule(
    mapping={
        'this is a <string> example': Text("quoted string"),
    },
    extras=[
        Literal('"quoted string"', 'string')
    ]
)

```

### Non-default Constructor Arguments

The implementation uses double quotes by default and can be configured to use different quote start and quote end strings via the constructor arguments. There is also a constructor argument for leaving quote strings in. See the following quoted words usage example from the doctests:

```Python

    >>> literal = Literal(u'this is a «quoted string» example',
    ...                   quote_start_str=u'«', quote_end_str=u'»')
    >>> literal.words
    ['this', 'is', 'a', 'quoted', 'string', 'example']
    >>> literal.words_ext
    ['this', 'is', 'a', 'quoted string', 'example']
    >>> test_literal = ElementTester(literal)
    >>> test_literal.recognize('this is a quoted string example')
    u'this is a quoted string example'

    >>> # Quotes are left in if specified.
    >>> literal = Literal('"quoted string"', strip_quote_strs=False)
    >>> literal.words
    ['"quoted', 'string"']
    >>> literal.words_ext
    ['"quoted string"']

```

Only one type of quoting is allowed, so single and double quoting cannot be used together.