### PR TITLE
Fix bug where some words cannot be used in grammars

### DIFF
--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -64,6 +64,7 @@ def map_word(word, encoding=getpreferredencoding(do_setlocale=False)):
     elif isinstance(word, binary_type):
         text_word = word.decode(encoding)
     if text_word:
+        # Strip suffix that is present on some words (e.g. "I" is "I\pronoun").
         backslash_index = text_word.find("\\")
         if backslash_index != -1:
             text_word = text_word[:backslash_index]

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -58,10 +58,16 @@ def map_word(word, encoding=getpreferredencoding(do_setlocale=False)):
     This wrapper ensures text output from the engine is Unicode. It assumes the
     encoding of byte streams is the current locale's preferred encoding by default.
     """
+    text_word = None
     if isinstance(word, text_type):
-        return word
+        text_word = word
     elif isinstance(word, binary_type):
-        return word.decode(encoding)
+        text_word = word.decode(encoding)
+    if text_word:
+        backslash_index = text_word.find("\\")
+        if backslash_index != -1:
+            text_word = text_word[:backslash_index]
+        return text_word
     return word
 
 


### PR DESCRIPTION
This fixes an issue where some words in utterances are reported with a suffix such as "I\pronoun" instead of "I", such that they are not matched when resolving the command. This is easily reproducible because you will not be able to execute a command with the word "I" in it. Simply stripping this suffix resolves the problem. I've been using this change locally for a while and it hasn't caused any trouble.