### PR TITLE
Change the Windows Clipboard class to poll for clipboard access

### DIFF
--- a/documentation/clipboard.txt
+++ b/documentation/clipboard.txt
@@ -66,3 +66,9 @@ Clipboard class
 
 .. autoclass:: dragonfly.windows.clipboard.Clipboard
    :members:
+
+
+Clipboard context manager function
+----------------------------------------------------------------------------
+
+.. autofunction:: dragonfly.windows.clipboard.win32_clipboard_ctx


### PR DESCRIPTION
The class now polls for clipboard access for up to 500 ms. The polling is necessary because the clipboard is a shared resource which may be in use by another process. If the clipboard could not be accessed after 500 ms, then an error will be raised. I have exposed and documented the `win32_clipboard_ctx` context manager function that does this, in case that's useful for anyone.

As the cross-platform `Clipboard` class already does this via pyperclip, this fixes a regression introduced in version 0.24.0 by using the old Windows `Clipboard` class on Windows.