### PR TITLE
Fix bug causing Win32Window.set_foreground() to fail sometimes

### DIFF
--- a/dragonfly/windows/win32_window.py
+++ b/dragonfly/windows/win32_window.py
@@ -237,7 +237,7 @@ class Win32Window(BaseWindow):
             # SetForegroundWindow() for why this works.
             # Only do this if neither the left or right control keys are
             # held down.
-            if win32api.GetKeyState(win32con.VK_CONTROL) == 0:
+            if win32api.GetKeyState(win32con.VK_CONTROL) >= 0:
                 Key("control:down,control:up").execute()
 
             # Set the foreground window.


### PR DESCRIPTION
Re: #213, #265.

This changes the method to properly check if the control key is already held down.