### PR TITLE
Add partial fix for dictation-related DNS recognition failures

### DIFF
--- a/documentation/faq.txt
+++ b/documentation/faq.txt
@@ -258,6 +258,48 @@ If threads still aren't working properly for you, please see the
 :ref:`RefFAQUnansweredQuestions` section.
 
 
+How do I fix "failed to decode recognition" errors?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"Failed to decode recognition" is the error message displayed when Dragonfly
+is unable to match what was said to a grammar rule. This can occur when
+saying command words to match a dictation part of a rule.
+
+One way around this to add a top-level grammar rule for dictating other
+words in your rules:
+
+.. code-block:: python
+
+   from dragonfly import Dictation, Text
+
+   mapping = {
+       "reserved (word|words) <text>": Text("%(text)s")
+   }
+
+   extras = [
+       Dictation("text")
+   ]
+
+
+Another way around the problem is to have an "extra" for reserved words:
+
+.. code-block:: python
+
+   from dragonfly import Choice, Text
+
+   mapping = {
+       "type <reserved>": Text("%(reserved)s")
+   }
+
+   extras = [
+       Choice("reserved", {
+           "alpha": "alpha",
+           "bravo": "bravo",
+           "charlie": "charlie",
+       })
+   ]
+
+
 How do I use an "extra" in a Dragonfly spec multiple times?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Re: #242.

This changes the Natlink engine to retry grammar rule decoding and recognition processing with non-grammar words set as dictation words instead.

This partial fix makes it possible to match dictation for all words except those in the current grammar. Fixing this issue completely would be quite difficult and time-consuming. Since it only occurs in some versions of Dragon, I think this fix should be sufficient. It would not be difficult to work around limitations by using a dedicated grammar for speaking command words in other grammars.