### PR TITLE
Optimize Kaldi & Sphinx window attribute checks on phrase start

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -453,8 +453,13 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
     def _compute_kaldi_rules_activity(self, phrase_start=True):
         if phrase_start:
             fg_window = Window.get_foreground()
+            window_info = {
+                "executable": fg_window.executable,
+                "title": fg_window.title,
+                "handle": fg_window.handle,
+            }
             for grammar_wrapper in self._iter_all_grammar_wrappers_dynamically():
-                grammar_wrapper.phrase_start_callback(fg_window)
+                grammar_wrapper.phrase_start_callback(**window_info)
         self.prepare_for_recognition()
         self._active_kaldi_rules = set()
         self._kaldi_rules_activity = [False] * self._compiler.num_kaldi_rules
@@ -588,8 +593,8 @@ class GrammarWrapper(GrammarWrapperBase):
         self.active = True
         self.exclusive = False
 
-    def phrase_start_callback(self, fg_window):
-        self.grammar.process_begin(fg_window.executable, fg_window.title, fg_window.handle)
+    def phrase_start_callback(self, executable, title, handle):
+        self.grammar.process_begin(executable, title, handle)
 
     def recognition_callback(self, recognition):
         words = recognition.words

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -630,13 +630,18 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
         return result
 
     def _speech_start_callback(self, mimicking):
-        # Get context info. Dragonfly has a handy static method for this:
+        # Get context info.
         fg_window = Window.get_foreground()
+        window_info = {
+            "executable": fg_window.executable,
+            "title": fg_window.title,
+            "handle": fg_window.handle,
+        }
 
         # Call process_begin for all grammars so that any out of context
         # grammar will not be used.
         for wrapper in self._grammar_wrappers.copy().values():
-            wrapper.process_begin(fg_window)
+            wrapper.process_begin(**window_info)
 
         if not mimicking:
             # Trim excess audio buffers from the start of the list. Keep a maximum 1

--- a/dragonfly/engines/backend_sphinx/grammar_wrapper.py
+++ b/dragonfly/engines/backend_sphinx/grammar_wrapper.py
@@ -135,9 +135,8 @@ class GrammarWrapper(GrammarWrapperBase):
         """
         return self.grammar.enabled and any(self.grammar.active_rules)
 
-    def process_begin(self, fg_window):
-        self.grammar.process_begin(fg_window.executable, fg_window.title,
-                                   fg_window.handle)
+    def process_begin(self, executable, title, handle):
+        self.grammar.process_begin(executable, title, handle)
 
     def process_words(self, words):
         # Return early if the grammar is disabled or if there are no active


### PR DESCRIPTION
This changes both engine back-ends to only get window attributes once per utterance. This change should reduce delays on macOS.

@daanzu This is the change I mentioned on Gitter. Sorry I didn't properly optimize the Sphinx engine code you ended up using in Kaldi!