### PR TITLE
Add high numbers to ShortIntegerRef

### DIFF
--- a/dragonfly/language/en/short_number.py
+++ b/dragonfly/language/en/short_number.py
@@ -41,7 +41,7 @@ The class works in the same way as :class:`IntegerRef`, by adding the following 
 
 from ..base.integer_internal  import (MapIntBuilder, CollectionIntBuilder,
                                       MagnitudeIntBuilder, IntegerContentBase)
-from .number import int_0, int_1_9, int_10_19, int_20_90_10
+from .number import int_0, int_1_9, int_10_19, int_and_1_99, int_20_90_10, int_100s, int_1000000s
 
 # Twenty five
 int_20_99       = MagnitudeIntBuilder(
@@ -96,8 +96,17 @@ int_x100_x999       = MagnitudeIntBuilder(
                    remainders  = [int_x01_x99, int_x10_x99]
                   )
 
+# Very similar to the one from number.py, but without int_1_9 multipliers
+# as these are handled above.
+int_1000s       = MagnitudeIntBuilder(
+                   factor      = 1000,
+                   spec        = "[<multiplier>] thousand [<remainder>]",
+                   multipliers = [int_10_19, int_20_99, int_100s],
+                   remainders  = [int_and_1_99, int_100s]
+                  )
 #---------------------------------------------------------------------------
 
 class ShortIntegerContent(IntegerContentBase):
     builders = [int_0, int_1_9, int_10_19, int_20_99, int_10_99,
-                int_x01_x99, int_x10_x99, int_x000_x099, int_x100_x999]
+                int_x01_x99, int_x10_x99, int_x000_x099, int_x100_x999,
+                int_1000s, int_1000000s]

--- a/dragonfly/test/test_language_en_number.py
+++ b/dragonfly/test/test_language_en_number.py
@@ -162,7 +162,7 @@ class ShortIntegerTestCase(ElementTestCase):
     """ Verify line integer class working as expected """
     def _build_element(self):
         from dragonfly.language.en.short_number       import ShortIntegerContent
-        return Integer(content=ShortIntegerContent, min=0, max=10_000_000)
+        return Integer(content=ShortIntegerContent, min=0, max=10000000)
     input_output = [
                     ("one",                           1),
                     ("ten",                           10),
@@ -186,11 +186,11 @@ class ShortIntegerTestCase(ElementTestCase):
                     ("one seven five three",          1753),
                     ("seventeen five three",          1753),
                     ("four thousand",                 4000),
-                    ("ten thousand",                  10_000),
-                    ("ninety thousand",               90_000),
-                    ("four hundred thousand",         400_000),
-                    ("four hundred thousand and fifty", 400_050),
-                    ("four hundred thousand three hundred and forty two", 400_342),
+                    ("ten thousand",                  10000),
+                    ("ninety thousand",               90000),
+                    ("four hundred thousand",         400000),
+                    ("four hundred thousand and fifty", 400050),
+                    ("four hundred thousand three hundred and forty two", 400342),
                     ("two hundred and thirty four thousand five hundred sixty seven", 234567),
-                    ("five million two hundred and thirty four thousand five hundred sixty seven", 5_234_567),
+                    ("five million two hundred and thirty four thousand five hundred sixty seven", 5234567),
                    ]

--- a/dragonfly/test/test_language_en_number.py
+++ b/dragonfly/test/test_language_en_number.py
@@ -162,7 +162,7 @@ class ShortIntegerTestCase(ElementTestCase):
     """ Verify line integer class working as expected """
     def _build_element(self):
         from dragonfly.language.en.short_number       import ShortIntegerContent
-        return Integer(content=ShortIntegerContent, min=0, max=10000)
+        return Integer(content=ShortIntegerContent, min=0, max=10_000_000)
     input_output = [
                     ("one",                           1),
                     ("ten",                           10),
@@ -186,4 +186,11 @@ class ShortIntegerTestCase(ElementTestCase):
                     ("one seven five three",          1753),
                     ("seventeen five three",          1753),
                     ("four thousand",                 4000),
+                    ("ten thousand",                  10_000),
+                    ("ninety thousand",               90_000),
+                    ("four hundred thousand",         400_000),
+                    ("four hundred thousand and fifty", 400_050),
+                    ("four hundred thousand three hundred and forty two", 400_342),
+                    ("two hundred and thirty four thousand five hundred sixty seven", 234567),
+                    ("five million two hundred and thirty four thousand five hundred sixty seven", 5_234_567),
                    ]


### PR DESCRIPTION
Fairly simple fix to add the high numbers, which will pretty much emulate the behaviour of IntegerRef.