### PR TITLE
Change X11Window.maximize() method to use maximization hints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,11 +149,12 @@ replace :code:`dragonfly` with :code:`dragonfly2` or remove lines like this
 altogether.
 
 If you are installing this on Linux, you will also need to install the
-`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ program for the
-``Key`` and ``Text`` actions to work. Please note that Dragonfly is only
-fully functional in an X11 session. Input action classes, application
-contexts and the ``Window`` class will **not** be functional under Wayland.
-It is recommended that Wayland users switch to X11.
+`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ and `wmctrl
+<https://www.freedesktop.org/wiki/Software/wmctrl/>`__ programs. Please note
+that Dragonfly is only fully functional in an X11 session. Input action
+classes, application contexts and the ``Window`` class will **not** be
+functional under Wayland. It is recommended that Wayland users switch to
+X11.
 
 If you have dragonfly installed under the original *dragonfly*
 distribution name, you'll need to remove the old version using:

--- a/documentation/faq.txt
+++ b/documentation/faq.txt
@@ -572,12 +572,16 @@ Why aren't Dragonfly's input actions working on my Linux system?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dragonfly's :code:`Key`, :code:`Text` and :code:`Mouse` action classes use
-`xdotool`_ on Linux. These actions will not work if it isn't installed. It
-can normally be installed through your system's package manager. On
-Debian-based or Ubuntu-based systems, this is done by running the following
-console command::
+the `xdotool`_ program on Linux. These actions will not work if it isn't
+installed. It can normally be installed through your system's package
+manager. On Debian-based or Ubuntu-based systems, this is done by running
+the following console command::
 
   sudo apt install xdotool
+
+The :code:`Window` class also requires the `wmctrl`_ program::
+
+  sudo apt install wmctrl
 
 The keyboard/mouse input classes will only work in an X11 session. You will
 get the following error if you are using `Wayland`_ or something else::
@@ -633,5 +637,6 @@ touch:
 .. _python-modernize: https://pypi.org/project/modernize/
 .. _pywin32: https://github.com/mhammond/pywin32
 .. _switch to X11: https://askubuntu.com/questions/961304/how-do-you-switch-from-wayland-back-to-xorg-in-ubuntu-17-10
+.. _wmctrl: https://www.freedesktop.org/wiki/Software/wmctrl/
 .. _xdotool: https://www.semicomplete.com/projects/xdotool
 .. _ydotool: https://github.com/ReimuNotMoe/ydotool

--- a/documentation/installation.txt
+++ b/documentation/installation.txt
@@ -42,11 +42,12 @@ replace :code:`dragonfly` with :code:`dragonfly2` or remove lines like this
 altogether.
 
 If you are installing this on Linux, you will also need to install the
-`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ program for the
-``Key`` and ``Text`` actions to work. Please note that Dragonfly is only
-fully functional in an X11 session. Input action classes, application
-contexts and the ``Window`` class will **not** be functional under Wayland.
-It is recommended that Wayland users switch to X11.
+`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ and `wmctrl
+<https://www.freedesktop.org/wiki/Software/wmctrl/>`__ programs. Please note
+that Dragonfly is only fully functional in an X11 session. Input action
+classes, application contexts and the ``Window`` class will **not** be
+functional under Wayland. It is recommended that Wayland users switch to
+X11.
 
 If you have dragonfly installed under the original *dragonfly*
 distribution name, you'll need to remove the old version using:

--- a/documentation/kaldi_engine.txt
+++ b/documentation/kaldi_engine.txt
@@ -90,10 +90,11 @@ from `kaldi-active-grammar
 <https://github.com/daanzu/kaldi-active-grammar>`_. Unzip it into a
 directory within the directory containing your grammar modules.
 
-**Note for Linux:** Before proceeding, you'll need ``xdotool``.
-Under ``apt``-based distributions, you can get them by running::
+**Note for Linux:** Before proceeding, you'll need ``wmctrl`` and
+``xdotool``. Under ``apt``-based distributions, you can get them by
+running::
 
-  sudo apt install xdotool
+  sudo apt install wmctrl xdotool
 
 Once the dependencies and model are installed, you're ready to go!
 

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -57,8 +57,17 @@ class X11Window(BaseWindow):
     # Methods and attributes for running commands.
 
     # Commands
+    wmctrl = "wmctrl"
     xdotool = "xdotool"
     xprop = "xprop"
+
+    @classmethod
+    def _run_command_simple(cls, exe, arguments):
+        # Run the command and return whether or not it succeeded based on
+        # the return code.
+        stdout, return_code = cls._run_command(exe, arguments)
+        if stdout: print(stdout)
+        return return_code == 0
 
     @classmethod
     def _run_xdotool_command(cls, arguments):
@@ -66,11 +75,11 @@ class X11Window(BaseWindow):
 
     @classmethod
     def _run_xdotool_command_simple(cls, arguments):
-        # Run the command and return whether or not it succeeded based on
-        # the return code.
-        stdout, return_code = cls._run_command(cls.xdotool, arguments)
-        if stdout: print(stdout)
-        return return_code == 0
+        return cls._run_command_simple(cls.xdotool, arguments)
+
+    @classmethod
+    def _run_wmctrl_command_simple(cls, arguments):
+        return cls._run_command_simple(cls.wmctrl, arguments)
 
     @classmethod
     def _run_xprop_command(cls, arguments):
@@ -437,17 +446,19 @@ class X11Window(BaseWindow):
         return self._run_xdotool_command_simple(['windowminimize',
                                                  self.id])
 
-    def _toggle_maximize(self):
-        # Doesn't seem possible with xdotool. We'll try pressing a-f10
-        # with the window focused. Only maximize if set_foreground()
-        # succeeded.
-        return self.set_foreground() and self._run_xdotool_command_simple([
-            'keydown', 'Alt_L', 'key', 'F10', 'keyup', 'Alt_L'
+    def _toggle_maximize(self, is_maximized):
+        # Use wmctrl to add or remove the maximized window properties from
+        # the window's _NET_WM_STATE set.
+        # Note: this should be possible with xprop, but is not supported.
+        maximized_props = 'maximized_vert,maximized_horz'
+        add_remove = 'remove' if is_maximized else 'add'
+        return self._run_wmctrl_command_simple([
+            '-ir', self.id, '-b', '%s,%s' % (add_remove, maximized_props)
         ])
 
     def maximize(self):
         if not self.is_maximized:
-            return self._toggle_maximize()
+            return self._toggle_maximize(False)
         return True  # already maximized.
 
     def restore(self):
@@ -457,7 +468,7 @@ class X11Window(BaseWindow):
                 'windowactivate', self.id
             ])
         elif self._is_maximized(state):
-            return self._toggle_maximize()
+            return self._toggle_maximize(True)
         else:
             # True if already restored or False if no _NET_WM_STATE.
             return state is not None

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -49,6 +49,12 @@ class X11Window(BaseWindow):
         Window control methods such as :meth:`close` will return ``True``
         if successful.
 
+        This class requires the following external programs:
+
+        * ``wmctrl``
+        * ``xdotool``
+        * ``xprop``
+
     """
 
     _log = logging.getLogger("window")

--- a/dragonfly/windows/x11_window.py
+++ b/dragonfly/windows/x11_window.py
@@ -62,30 +62,6 @@ class X11Window(BaseWindow):
     xprop = "xprop"
 
     @classmethod
-    def _run_command_simple(cls, exe, arguments):
-        # Run the command and return whether or not it succeeded based on
-        # the return code.
-        stdout, return_code = cls._run_command(exe, arguments)
-        if stdout: print(stdout)
-        return return_code == 0
-
-    @classmethod
-    def _run_xdotool_command(cls, arguments):
-        return cls._run_command(cls.xdotool, arguments)
-
-    @classmethod
-    def _run_xdotool_command_simple(cls, arguments):
-        return cls._run_command_simple(cls.xdotool, arguments)
-
-    @classmethod
-    def _run_wmctrl_command_simple(cls, arguments):
-        return cls._run_command_simple(cls.wmctrl, arguments)
-
-    @classmethod
-    def _run_xprop_command(cls, arguments):
-        return cls._run_command(cls.xprop, arguments)
-
-    @classmethod
     def _run_command(cls, command, arguments):
         """
         Run a command with arguments and return the result.
@@ -131,6 +107,30 @@ class X11Window(BaseWindow):
                            "%s installed?",
                            full_readable_command, e, command)
             raise e
+
+    @classmethod
+    def _run_command_simple(cls, exe, arguments):
+        # Run the command and return whether or not it succeeded based on
+        # the return code.
+        stdout, return_code = cls._run_command(exe, arguments)
+        if stdout: print(stdout)
+        return return_code == 0
+
+    @classmethod
+    def _run_wmctrl_command_simple(cls, arguments):
+        return cls._run_command_simple(cls.wmctrl, arguments)
+
+    @classmethod
+    def _run_xdotool_command(cls, arguments):
+        return cls._run_command(cls.xdotool, arguments)
+
+    @classmethod
+    def _run_xdotool_command_simple(cls, arguments):
+        return cls._run_command_simple(cls.xdotool, arguments)
+
+    @classmethod
+    def _run_xprop_command(cls, arguments):
+        return cls._run_command(cls.xprop, arguments)
 
     #-----------------------------------------------------------------------
     # Class methods to create new Window objects.


### PR DESCRIPTION
The ``wmctrl`` program is now used to adjust the [Extended Window Manager Hints](https://specifications.freedesktop.org/wm-spec/latest/) (EWMH) for window maximization in most X11 window managers. This is better than using a keyboard shortcut. The documentation has been updated to recommend installing both ``wmctrl`` and ``xdotool`` when using Dragonfly on Linux in an X11 session.

It should be noted that neither the current ``xdotool`` or ``xprop`` release versions can maximize the window by EWMH, so the new external dependency is necessary.