### PR TITLE
Allow changing rules' and grammars' contexts after instantiation

### DIFF
--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -167,12 +167,19 @@ class Grammar(object):
     engine = property(lambda self: self._engine, _set_engine,
                       doc="A grammar's SR engine.")
 
-    def _set_context(self, context):
+    def set_context(self, context):
+        """
+            Set context for this grammar. This overwrites any
+            previous context.
+
+            Contexts are matched during :meth:`process_begin`.
+        """
+        if not isinstance(context, Context):
+            return
         self._context = context
 
-    context = property(lambda self: self._context, _set_context,
-                      doc="A grammar's context."
-                          " Can be modified at any time.")
+    context = property(lambda self: self._context,
+                       doc="Grammar's context.")
 
     # ----------------------------------------------------------------------
     # Methods for populating a grammar object instance.

--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -169,17 +169,26 @@ class Grammar(object):
 
     def set_context(self, context):
         """
-            Set context for this grammar. This overwrites any
-            previous context.
+            Set the context for this grammar, under which it and its rules
+            will be active and receive recognitions if it is also enabled.
 
-            Contexts are matched during :meth:`process_begin`.
+            Use of this method overwrites any previous context.
+
+            Contexts can be modified at any time, but will only be checked
+            when :meth:`process_begin` is called.
+
+            :param context: context within which to be active.  If *None*,
+                the grammar will always be active.
+            :type context: Context|None
         """
         if not isinstance(context, Context):
             return
         self._context = context
 
     context = property(lambda self: self._context,
-                       doc="Grammar's context.")
+                       doc="A grammar's context, under which it and its "
+                           "rules will be active and receive recognitions "
+                           "if it is also enabled.")
 
     # ----------------------------------------------------------------------
     # Methods for populating a grammar object instance.

--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -167,6 +167,13 @@ class Grammar(object):
     engine = property(lambda self: self._engine, _set_engine,
                       doc="A grammar's SR engine.")
 
+    def _set_context(self, context):
+        self._context = context
+
+    context = property(lambda self: self._context, _set_context,
+                      doc="A grammar's context."
+                          " Can be modified at any time.")
+
     # ----------------------------------------------------------------------
     # Methods for populating a grammar object instance.
 

--- a/dragonfly/grammar/grammar_base.py
+++ b/dragonfly/grammar/grammar_base.py
@@ -69,7 +69,9 @@ class Grammar(object):
     def __init__(self, name, description=None, context=None, engine=None):
         self._name = name
         self._description = description
-        assert isinstance(context, Context) or context is None
+        if not (isinstance(context, Context) or context is None):
+            raise TypeError("context must be either a Context object or "
+                            "None")
         self._context = context
 
         if engine:
@@ -181,8 +183,9 @@ class Grammar(object):
                 the grammar will always be active.
             :type context: Context|None
         """
-        if not isinstance(context, Context):
-            return
+        if not (isinstance(context, Context) or context is None):
+            raise TypeError("context must be either a Context object or "
+                            "None")
         self._context = context
 
     context = property(lambda self: self._context,

--- a/dragonfly/grammar/rule_base.py
+++ b/dragonfly/grammar/rule_base.py
@@ -157,19 +157,27 @@ class Rule(object):
 
     def set_context(self, context):
         """
-            Set context for this rule. This overwrites any
-            previous context.
+            Set the context for this rule, under which it will be active and
+            receive recognitions if it is also enabled and its grammar is
+            active.
 
-            Contexts are matched during :meth:`process_begin`.
+            Use of this method overwrites any previous context.
+
+            Contexts can be modified at any time, but will only be checked
+            when :meth:`process_begin` is called.
+
+            :param context: context within which to be active.  If *None*,
+                the rule will be active when its grammar is.
+            :type context: Context|None
         """
         if not isinstance(context, Context):
             return
         self._context = context
 
     context = property(lambda self: self._context,
-                       doc="This rule's context."
-                           " Can be modified at any time.")
-
+                       doc="This rule's context, under which it will be "
+                           "active and receive recognitions if it is also "
+                           "enabled and its grammar is active.")
     #-----------------------------------------------------------------------
     # Internal methods for controlling a rules active state.
 

--- a/dragonfly/grammar/rule_base.py
+++ b/dragonfly/grammar/rule_base.py
@@ -155,12 +155,20 @@ class Rule(object):
     grammar = property(_get_grammar, _set_grammar,
                        doc="This rule's grammar object.  (Set once)")
 
-    def _set_context(self, context):
+    def set_context(self, context):
+        """
+            Set context for this rule. This overwrites any
+            previous context.
+
+            Contexts are matched during :meth:`process_begin`.
+        """
+        if not isinstance(context, Context):
+            return
         self._context = context
 
-    context = property(lambda self: self._context, _set_context,
-                      doc="This rule's context."
-                          " Can be modified at any time.")
+    context = property(lambda self: self._context,
+                       doc="This rule's context."
+                           " Can be modified at any time.")
 
     #-----------------------------------------------------------------------
     # Internal methods for controlling a rules active state.

--- a/dragonfly/grammar/rule_base.py
+++ b/dragonfly/grammar/rule_base.py
@@ -155,6 +155,13 @@ class Rule(object):
     grammar = property(_get_grammar, _set_grammar,
                        doc="This rule's grammar object.  (Set once)")
 
+    def _set_context(self, context):
+        self._context = context
+
+    context = property(lambda self: self._context, _set_context,
+                      doc="This rule's context."
+                          " Can be modified at any time.")
+
     #-----------------------------------------------------------------------
     # Internal methods for controlling a rules active state.
 

--- a/dragonfly/grammar/rule_base.py
+++ b/dragonfly/grammar/rule_base.py
@@ -88,7 +88,9 @@ class Rule(object):
 
         self._active = None
         self._enabled = True
-        assert isinstance(context, Context) or context is None
+        if not (isinstance(context, Context) or context is None):
+            raise TypeError("context must be either a Context object or "
+                            "None")
         self._context = context
         self._grammar = None
 
@@ -170,8 +172,9 @@ class Rule(object):
                 the rule will be active when its grammar is.
             :type context: Context|None
         """
-        if not isinstance(context, Context):
-            return
+        if not (isinstance(context, Context) or context is None):
+            raise TypeError("context must be either a Context object or "
+                            "None")
         self._context = context
 
     context = property(lambda self: self._context,


### PR DESCRIPTION
This makes it possible to adjust contexts of grammars and rules after they have been instantiated.

Questions to be answered before merging:
* Are there any potential side effects? For example, could it occur that a context change happens during `process_recognition`?