### PR TITLE
Set DPI awareness automatically when dragonfly is imported

### DIFF
--- a/documentation/faq.txt
+++ b/documentation/faq.txt
@@ -515,11 +515,14 @@ Why isn't Dragonfly code aware of DPI scaling settings on Windows?
 
 There can be problems with Dragonfly's monitor-related functionality on
 Windows Vista and above if the system is set up to use one or more monitors
-with a high number of dots per inch (DPI). The process running your Python
-code needs to be set as DPI-aware, if possible.
+with a high number of dots per inch (DPI). For this reason, Dragonfly
+*attempts* to set the DPI awareness for the process when it is imported. The
+``SetProcessDpiAwareness()`` function is used to do this on Windows 8.1 and
+above.
 
-The ``SetProcessDpiAwareness()`` function can be used to do this on Windows
-8.1 and above:
+If you need to set the DPI awareness manually using a different DPI
+awareness value, do so before importing dragonfly. The following is
+equivalent to what dragonfly does internally:
 
 .. code-block:: python
 
@@ -528,9 +531,9 @@ The ``SetProcessDpiAwareness()`` function can be used to do this on Windows
 
 The ``SetProcessDpiAware()`` function can be used instead on older Windows
 versions (e.g. Vista and 7). The ``SetProcessDpiAwarenessContext()``
-function can be used on Windows 10 (version 1703) and above. Both are
-functions in ``user32.dll`` instead of ``shcore.dll``. For more information
-on this topic, please see the following Microsoft documentation pages:
+function can be used on Windows 10 (version 1703) and above. For more
+information on this topic, please see the following Microsoft documentation
+pages:
 
 * `High DPI Desktop Application Development on Windows`_
 * `Setting the default DPI awareness for a process`_

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -22,6 +22,7 @@
 # This file imports a Win32-only module.
 
 import ctypes
+
 import win32api
 
 from .base_monitor import BaseMonitor
@@ -34,7 +35,11 @@ from .rectangle import Rectangle
 # changes. Unfortunately, this cannot be changed (presumably it is declared in a
 # manifest). When running from the command line, however, the default is
 # PROCESS_DPI_UNAWARE and can be adjusted here.
-ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
+try:
+    ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
+except OSError:
+    # Do nothing if SetProcessDpiAwareness() could not be called.
+    pass
 
 
 #===========================================================================

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -21,10 +21,20 @@
 # pylint: disable=E0401
 # This file imports a Win32-only module.
 
+import ctypes
 import win32api
 
 from .base_monitor import BaseMonitor
 from .rectangle import Rectangle
+
+# Force the current process to be DPI aware. This will ensure that the
+# resolution is reported properly even when DPI scaling is on. This appears to
+# be set to PROCESS_SYSTEM_DPI_AWARE when running embedded in Dragon, which
+# provides awareness of the DPI when the application starts, but not when it
+# changes. Unfortunately, this cannot be changed (presumably it is declared in a
+# manifest). When running from the command line, however, the default is
+# PROCESS_DPI_UNAWARE and can be adjusted here.
+ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
 
 
 #===========================================================================

--- a/dragonfly/windows/win32_monitor.py
+++ b/dragonfly/windows/win32_monitor.py
@@ -22,6 +22,7 @@
 # This file imports a Win32-only module.
 
 import ctypes
+import logging
 
 import win32api
 
@@ -36,7 +37,16 @@ from .rectangle import Rectangle
 # manifest). When running from the command line, however, the default is
 # PROCESS_DPI_UNAWARE and can be adjusted here.
 try:
-    ctypes.windll.shcore.SetProcessDpiAwareness(2)  # PROCESS_PER_MONITOR_DPI_AWARE
+    log = logging.getLogger("monitor.init")
+    value = 2  # PROCESS_PER_MONITOR_DPI_AWARE
+    hresult = ctypes.windll.shcore.SetProcessDpiAwareness(value)
+    if hresult == -2147024809:  # E_INVALIDARG
+        log.warning("DPI awareness could not be set; "
+                    "SetProcessDpiAwareness() received an invalid "
+                    "argument: %d", value)
+    elif hresult == -2147024891:  # E_ACCESSDENIED
+        log.warning("DPI awareness could not be set; it has been set "
+                    "already.")
 except OSError:
     # Do nothing if SetProcessDpiAwareness() could not be called.
     pass


### PR DESCRIPTION
Closes #289.

This is @wolfmanstout's patch (https://github.com/dictation-toolbox/dragonfly/commit/c3a1b1e306a720e5b2e1ad3b8c5c3d4e1e30c668) with a safety check for older versions of Windows, plus some logging if setting the process DPI awareness fails (`E_INVALIDARG` and `E_ACCESSDENIED` are handled). I have also updated the relevant FAQ added in 4e5f0a9.

Microsoft's documentation indicates that the Windows 10 [`SetProcessDpiAwarenessContext()`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext) function is recommended instead of `SetProcessDpiAwareness()` in situations where the DPI awareness cannot be set in the application manifest. I don't understand how to use that function though, so this will do.

@LexiconCode Regarding the issues you mentioned in #289, let me know if this works properly. I think it should be fine.