### PR TITLE
Test suite changes

### DIFF
--- a/dragonfly/test/rule_testcase.py
+++ b/dragonfly/test/rule_testcase.py
@@ -34,12 +34,15 @@ class RuleTestCase(unittest.TestCase):
 
     def run(self, result=None):
         self.engine = get_engine()
-        self.engine.connect()
         self.grammar = RuleTestGrammar()
-        try:
-            return unittest.TestCase.run(self, result)
-        finally:
-            self.engine.disconnect()
+        return unittest.TestCase.run(self, result)
+
+    def tearDown(self):
+        self.grammar.unload()
+        for rule in self.grammar.rules:
+            self.grammar.remove_rule(rule)
+        for lst in self.grammar.lists:
+            self.grammar.remove_list(lst)
 
     def add_rule(self, rule):
         self.grammar.add_rule(rule)

--- a/dragonfly/test/test_contexts.py
+++ b/dragonfly/test/test_contexts.py
@@ -65,7 +65,6 @@ class TestRules(RuleTestCase):
         context = TestContext(True)
         self.add_rule(CompoundRule(name="r1", spec="test context",
                                    context=context))
-        self.grammar.load()
 
         # Test that the rule matches when in-context.
         results = self.recognize_node("test context").words()
@@ -77,10 +76,12 @@ class TestRules(RuleTestCase):
         context.active = False
         self.process_grammars_context()
         try:
+            self.grammar.load()
             self.grammar.set_exclusiveness(True)
             self.assertRaises(MimicFailure, self.engine.mimic, "test context")
         finally:
             self.grammar.set_exclusiveness(False)
+            self.grammar.unload()
 
         # Test again after going back into context.
         context.active = True

--- a/dragonfly/test/test_engine_kaldi.py
+++ b/dragonfly/test/test_engine_kaldi.py
@@ -83,9 +83,6 @@ class KaldiEngineCase(unittest.TestCase):
         # Map for test functions
         self.test_map = {}
 
-        # Connect the engine.
-        self.engine.connect()
-
         # Register a recognition observer.
         self.test_recobs = RecognitionObserverTester()
         self.test_recobs.register()
@@ -93,7 +90,6 @@ class KaldiEngineCase(unittest.TestCase):
     def tearDown(self):
         self.test_map.clear()
         self.test_recobs.unregister()
-        self.engine.disconnect()
 
     # ---------------------------------------------------------------------
     # Methods for control-flow assertion.

--- a/dragonfly/test/test_engine_natlink.py
+++ b/dragonfly/test/test_engine_natlink.py
@@ -31,13 +31,9 @@ class TestEngineNatlink(unittest.TestCase):
         engine = get_engine("natlink")
         assert isinstance(engine, EngineBase)
         assert engine.name == "natlink"
-        engine.connect()
-        try:
-            engine.speak("testing natlink")
-            from dragonfly import Literal
-            from dragonfly.test import ElementTester
-            tester = ElementTester(Literal("hello world"))
-            results = tester.recognize("hello world")
-            assert results == "hello world"
-        finally:
-            engine.disconnect()
+        engine.speak("testing natlink")
+        from dragonfly import Literal
+        from dragonfly.test import ElementTester
+        tester = ElementTester(Literal("hello world"))
+        results = tester.recognize("hello world")
+        assert results == "hello world"

--- a/dragonfly/test/test_engine_text.py
+++ b/dragonfly/test/test_engine_text.py
@@ -38,11 +38,7 @@ class TestEngineText(unittest.TestCase):
         engine = get_engine("text")
         assert isinstance(engine, EngineBase)
         assert engine.name == "text"
-        engine.connect()
         self.engine = engine
-
-    def tearDown(self):
-        self.engine.disconnect()
 
     def test_literal(self):
         """ Verify that the text engine is usable. """

--- a/dragonfly/test/test_rpc.py
+++ b/dragonfly/test/test_rpc.py
@@ -46,11 +46,8 @@ class RPCTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.current_response = None
 
-        # Start the server on a different port for the tests and esure the
-        # engine is connected.
+        # Start the server on a different port for the tests.
         cls.server = RPCServer(port=50052)
-        engine = get_engine()
-        engine.connect()
         cls.server.start()
 
     @classmethod

--- a/dragonfly/test/test_timer.py
+++ b/dragonfly/test/test_timer.py
@@ -46,9 +46,6 @@ class TestTimer(unittest.TestCase):
         logging.getLogger("engine.timer").addHandler(self.log_capture)
         self.engine = get_engine()
 
-        # Ensure the engine is connected to avoid errors.
-        self.engine.connect()
-
     def test_timer_callback_exception(self):
         """ Test handling of exceptions during timer callback. """
 


### PR DESCRIPTION
This PR introduces a few changes to Dragonfly's test suite, most notably removing unnecessary calls to `engine.connect()` and `engine.disconnect()`, which only need to be called at the start and the end of the test suite respectively. I still need to fix some problems before merging.

@daanzu This seems to have fixed the memory leak issues with Kaldi I mentioned somewhere. I tested with KaldiAG version 1.8.0.