### PR TITLE
Fix DNS dictation bug where formatting can be applied incorrectly

### DIFF
--- a/documentation/test_word_formatting_v11_doctest.txt
+++ b/documentation/test_word_formatting_v11_doctest.txt
@@ -162,3 +162,12 @@ forms and formatting info::
   #    u'1234'
   #    >>> format_dictation_dns11("thirty four")
   #    u'34'
+
+Spoken words with multiple, context-dependent written forms, such as "point"
+and ".", are formatted correctly::
+
+    >>> format_dictation_dns11("\cap\cap what is the point of that "
+    ...                         "?\question-mark\question-mark")
+    u'What is the point of that?'
+    >>> format_dictation_dns11(".\point\point")
+    u'.'

--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -373,7 +373,6 @@ class WordParserDns11(WordParserBase):
             flags = WordFlags()
         return flags
 
-
     def parse_input(self, input):
         # Not unicode (Python 2) or str (Python 3)
         if not isinstance(input, text_type):
@@ -381,6 +380,7 @@ class WordParserDns11(WordParserBase):
             # encoded strings. Here we convert them to Unicode for internal
             # processing.
             input = text_type(input).encode("windows-1252")
+
         parts = input.split("\\")
         if len(parts) == 1:
             # Word doesn't have "written\property\spoken" form, so
@@ -406,11 +406,6 @@ class WordParserDns11(WordParserBase):
             written = "\\".join(parts[:-2])
             property = parts[-2]
             spoken = parts[-1]
-        """ The if statement below allows users to add the spoken form
-        # (or the written form if and only if there isn't a spoken form)
-        # of their own custom Dragon vocabulary words into the property_mapping """
-        if spoken in self.property_map:
-            property = spoken
 
         word_flags = self.create_word_flags(property)
 


### PR DESCRIPTION
Fixes #311.

This bug causes formatting to be applied to regular spoken words
that happen to match DNS word properties, but were not provided in
written\property\spoken form by DNS.

One example of this is the spoken word "point", which can be
written as "." or "point".