### PR TITLE
Improve error message when X11 can't be detected

### DIFF
--- a/dragonfly/actions/keyboard/_base.py
+++ b/dragonfly/actions/keyboard/_base.py
@@ -34,7 +34,12 @@ class BaseKeyboard(object):
     def send_keyboard_events(cls, events):
         """ Send a sequence of keyboard events. """
         raise NotImplementedError("Keyboard support is not implemented for "
-                                  "this platform!")
+                                  "this platform or your platform was not "
+                                  "detected correctly. On Linux, the "
+                                  "XDG_SESSION_TYPE environment variable may "
+                                  "not be set correctly in some circumstances, "
+                                  "in which case it can be set manually in "
+                                  "~/.profile.")
 
     @classmethod
     def get_typeable(cls, char, is_text=False):


### PR DESCRIPTION
I'm running i3wm on Arch Linux. XDG_SESSION_TYPE was set to "tty" despite running X11. It took me quite some time to figure out what was going on, so I wanted to make it easier for anyone encountering the same problem.