### PR TITLE
Fix recognition observer bug with the KaldiEngine.mimic() method

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -305,6 +305,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
 
         recognition = self._parse_recognition(output, mimic=True)
         if not recognition.kaldi_rule:
+            recognition.fail()
             raise MimicFailure("No matching rule found for %r." % (output,))
         recognition.process()
         self._log.debug("End of mimic: rule %s, %r" % (recognition.kaldi_rule, output))


### PR DESCRIPTION
CC @daanzu

I noticed this bug when running the test suite. This PR adds two missing `notify_failure()` calls.