### PR TITLE
Fix incorrect dictation formatting for DNS letters

### DIFF
--- a/documentation/test_word_formatting_v11_doctest.txt
+++ b/documentation/test_word_formatting_v11_doctest.txt
@@ -131,6 +131,18 @@ of for example words not present in the dictionary::
     ...                        " H\\letter\\hotel N\\letter\\November")
     u'JOHN'
 
+Letters spoken in line within dictation have spaces separating adjacent
+words::
+
+    >>> format_dictation_dns11(["hello", "A\\letter\\alpha",
+    ...                         "B\\letter\\bravo", "C\\letter\\Charlie",
+    ...                         "world"])
+    u'hello ABC world'
+    >>> format_dictation_dns11(["hello", "A\\uppercase-letter\\capital A",
+    ...                         "B\\uppercase-letter\\capital B",
+    ...                         "C\\uppercase-letter\\capital C", "world"])
+    u'hello ABC world'
+
 Words may contain spaces in their written and/or spoken forms. For example
 a custom word added by the user might have the following form with a space
 in both spoken and written forms::

--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -329,8 +329,8 @@ class WordParserDns11(WordParserBase):
 
         "space-bar":        WordFlags("no_format", "spacebar", "no_space_after", "no_cap_reset", "no_space_before"),
         "spelling-cap":     WordFlags("no_format", "no_space_reset", "cap_next_force"),
-        "letter":           WordFlags(),
-        "uppercase-letter": WordFlags("no_space_after"),
+        "letter":           WordFlags("no_space_between"),
+        "uppercase-letter": WordFlags("no_space_between"),
         "numeral":          WordFlags("no_space_after"),
 
         "period":           WordFlags("two_spaces_after", "cap_next", "no_space_before", "not_after_period"),

--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -329,7 +329,7 @@ class WordParserDns11(WordParserBase):
 
         "space-bar":        WordFlags("no_format", "spacebar", "no_space_after", "no_cap_reset", "no_space_before"),
         "spelling-cap":     WordFlags("no_format", "no_space_reset", "cap_next_force"),
-        "letter":           WordFlags("no_space_after"),
+        "letter":           WordFlags(),
         "uppercase-letter": WordFlags("no_space_after"),
         "numeral":          WordFlags("no_space_after"),
 


### PR DESCRIPTION
This aligns formatting with Dragon's dictation formatting. For example, try "X variable". Without this change, it is formatted as "Xvariable".