### PR TITLE
Fix clipboard incorrect handling of None type

### DIFF
--- a/dragonfly/util/clipboard.py
+++ b/dragonfly/util/clipboard.py
@@ -149,9 +149,9 @@ class Clipboard(BaseClipboard):
             is available, this method returns *None*.
 
         """
-        return None if not self._content else self._content
+        return self._content
 
     def set_text(self, content):
-        self._content = text_type(content)
+        self._content = None if content is None else text_type(content)
 
     text = property(get_text, set_text)

--- a/dragonfly/windows/clipboard.py
+++ b/dragonfly/windows/clipboard.py
@@ -301,6 +301,9 @@ class Clipboard(BaseClipboard):
             return None
 
     def set_text(self, content):
-        self._contents[self.format_unicode] = text_type(content)
+        if content is None:
+            self._contents.pop(self.format_unicode, None)
+        else:
+            self._contents[self.format_unicode] = text_type(content)
 
     text = property(get_text, set_text)


### PR DESCRIPTION
Fixes a bug where the clipboard does not properly handle 'None'

```
>>> import dragonfly.util.clipboard
>>> clip = dragonfly.util.clipboard.Clipboard()
>>> clip.has_text()
False
>>> clip.set_text('None')
>>> clip.has_text()
True
>>> clip.get_text()
'None'
>>> clip.set_text(None)
>>> clip.has_text()
False
>>> clip.get_text()
>>> clip.set_text(False)
>>> clip.has_text()
True
>>> clip.get_text()
'False'
```

```
>>> import dragonfly.windows.clipboard
>>> clip2 = dragonfly.windows.clipboard.Clipboard()
>>> clip2.has_text()
False
>>> clip2.set_text('None')
>>> clip2.has_text()
True
>>> clip2.get_text()
'None'
>>> clip2.set_text(None)
>>> clip2.has_text()
False
>>> clip2.get_text()
>>> clip2.set_text(False)
>>> clip2.has_text()
True
>>> clip2.get_text()
'False'
```