### PR TITLE
Change German integer impl. to support compound words in range 20-99

### DIFF
--- a/dragonfly/language/base/integer.py
+++ b/dragonfly/language/base/integer.py
@@ -80,7 +80,8 @@ class Integer(Alternative):
     # Methods for load-time setup.
 
     def _build_children(self, min, max):
-        children = [c.build_element(min, max)
+        memo = {}
+        children = [c.build_element(min, max, memo)
                     for c in self._builders]
         return [c for c in children if c]
 

--- a/dragonfly/language/de/number.py
+++ b/dragonfly/language/de/number.py
@@ -95,6 +95,7 @@ int_20_99       = MagnitudeIntBuilder(
                    multipliers = [int_20_90_10],
                    remainders  = [int_1_9],
                    modifier_function = int_20_99_func,
+                   modifier_mode = 1,  # MODE_AUGMENT (default)
                   )
 int_and_1_99    = CollectionIntBuilder(
                    spec        = "<element>",

--- a/dragonfly/language/de/number.py
+++ b/dragonfly/language/de/number.py
@@ -78,11 +78,23 @@ int_20_90_10    = MapIntBuilder({
                                  "achtzig":      8,
                                  "neunzig":      9,
                                })
+
+
+#---------------------------------------------------------------------------
+
+def int_20_99_func(text):
+    # Join any 'und' conjugates with the words on either side.
+    return text.replace(" und", "und").replace("und ", "und")
+
+
+#---------------------------------------------------------------------------
+
 int_20_99       = MagnitudeIntBuilder(
                    factor      = 10,
                    spec        = "[<remainder> und] <multiplier>",
                    multipliers = [int_20_90_10],
                    remainders  = [int_1_9],
+                   modifier_function = int_20_99_func,
                   )
 int_and_1_99    = CollectionIntBuilder(
                    spec        = "<element>",

--- a/dragonfly/test/test_language_de_number.py
+++ b/dragonfly/test/test_language_de_number.py
@@ -37,6 +37,7 @@ class GermanIntegerTestCase(ElementTestCase):
     def _build_element(self):
         return Integer(content=IntegerContent, min=0, max=10**12 - 1)
     input_output = [
+                    # Test a range of non-compound integer words.
                     ("null",                             0),
                     ("eins",                             1),
                     ("zwei",                             2),
@@ -61,6 +62,7 @@ class GermanIntegerTestCase(ElementTestCase):
                     ("ein und zwanzig",                 21),
                     ("zwei und zwanzig",                22),
                     ("drei und zwanzig",                23),
+                    ("ein und dreissig",                31),
                     ("vier und dreissig",               34),
                     ("fuenf und vierzig",               45),
                     ("sechs und fuenfzig",              56),
@@ -70,4 +72,28 @@ class GermanIntegerTestCase(ElementTestCase):
                     ("hundert",                        100),
                     ("ein hundert",                    100),
                     ("ein hundert drei und zwanzig",   123),
+                    ("drei hundert neun und achtzig",  389),
+                    ("ein tausend ein hundert ein und dreissig", 1131),
+                    ("ein und dreissig tausend ein hundert ein und dreissig", 31131),
+                    ("ein hundert ein und dreissig tausend ein hundert ein und dreissig", 131131),
+                    ("ein million ein hundert ein und dreissig tausend ein hundert ein und dreissig", 1131131),
+
+                    # Test a range of compound integer words.
+                    ("einundzwanzig",                  21),
+                    ("zweiundzwanzig",                 22),
+                    ("dreiundzwanzig",                 23),
+                    ("einunddreissig",                 31),
+                    ("vierunddreissig",                34),
+                    ("fuenfundvierzig",                45),
+                    ("sechsundfuenfzig",               56),
+                    ("siebenundsechzig",               67),
+                    ("achtundsiebzig",                 78),
+                    ("neunundachtzig",                 89),
+                    ("ein hundert dreiundzwanzig",     123),
+                    ("ein hundert einunddreissig",     131),
+                    ("drei hundert neunundachtzig",    389),
+                    ("ein tausend ein hundert einunddreissig", 1131),
+                    ("einunddreissig tausend ein hundert einunddreissig", 31131),
+                    ("ein hundert einunddreissig tausend ein hundert einunddreissig", 131131),
+                    ("ein million ein hundert einunddreissig tausend ein hundert einunddreissig", 1131131),
                    ]


### PR DESCRIPTION
Closes #306.

This PR adjusts the German language integer implementation so that integers between 20 and 99 can be spoken either as one word or multiple words, e.g. 'ein und zwanzig' and 'einundzwanzig' for the integer 21. This also fixes the problem when speaking larger numbers that include these words.

The changes to the internal integer classes may be useful in other language implementations. Before merging, I will add extra functionality for only using what I have called "modified paths". This will allow, to use my above example, recognizing 'einundzwanzig', but not 'ein und zwanzig'. I don't think this should be enabled for German language integers, however.

@tripfish If you get a chance, could you give this branch a try and let me know if there are issues? It seems to be working with Dragon and with all the test integers I have used.

Sorry this took me so long BTW!