### PR TITLE
Clipboard toolkit improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,8 +149,9 @@ replace :code:`dragonfly` with :code:`dragonfly2` or remove lines like this
 altogether.
 
 If you are installing this on Linux, you will also need to install the
-`xdotool <https://www.semicomplete.com/projects/xdotool/>`__ and `wmctrl
-<https://www.freedesktop.org/wiki/Software/wmctrl/>`__ programs. You may
+`wmctrl <https://www.freedesktop.org/wiki/Software/wmctrl/>`__, `xdotool
+<https://www.semicomplete.com/projects/xdotool/>`__ and `xsel
+<http://www.vergenet.net/~conrad/software/xsel/>`__ programs. You may
 also need to manually set the ``XDG_SESSION_TYPE`` environment variable to
 ``x11``.
 

--- a/documentation/clipboard.txt
+++ b/documentation/clipboard.txt
@@ -16,6 +16,9 @@ on the platform:
  * :class:`dragonfly.windows.win32_clipboard.Win32Clipboard` is used on
    Windows.
 
+ * :class:`dragonfly.windows.x11_clipboard.XselClipboard` is used on
+   X11/Linux. This class requires the ``xclip`` program.
+
  * :class:`dragonfly.windows.pyperclip_clipboard.PyperclipClipboard` is used
    on other platforms, such as macOS or Linux.
 
@@ -101,6 +104,16 @@ Windows Clipboard context manager function
 ----------------------------------------------------------------------------
 
 .. autofunction:: dragonfly.windows.win32_clipboard.win32_clipboard_ctx
+
+
+X11 Clipboard classes
+----------------------------------------------------------------------------
+
+.. autoclass:: dragonfly.windows.x11_clipboard.BaseX11Clipboard
+   :members:
+
+.. autoclass:: dragonfly.windows.x11_clipboard.XselClipboard
+   :members:
 
 
 Pyperclip Clipboard class

--- a/documentation/installation.txt
+++ b/documentation/installation.txt
@@ -23,10 +23,11 @@ To be able to use the dragonfly, you will need the following:
  * **Natlink** *(only for Dragon users)* -- latest
    versions available from `SourceForge
    <https://sourceforge.net/projects/natlink/files/natlink/natlinktest4.1/>`_.
- * `Xdotool <https://www.semicomplete.com/projects/xdotool/>`__ and `wmctrl
-   <https://www.freedesktop.org/wiki/Software/wmctrl/>`__ programs *(only
+ * `wmctrl <https://www.freedesktop.org/wiki/Software/wmctrl/>`__, `xdotool
+   <https://www.semicomplete.com/projects/xdotool/>`__ and `xsel
+   <http://www.vergenet.net/~conrad/software/xsel/>`__ programs *(only
    for Linux/X11 users)* -- usually available from your system's package
-   manager
+   manager.
 
 **Note for Linux users**: Dragonfly is only fully functional in an X11
 session. You may also need to manually set the ``XDG_SESSION_TYPE``

--- a/documentation/kaldi_engine.txt
+++ b/documentation/kaldi_engine.txt
@@ -90,11 +90,11 @@ from `kaldi-active-grammar
 <https://github.com/daanzu/kaldi-active-grammar>`_. Unzip it into a
 directory within the directory containing your grammar modules.
 
-**Note for Linux:** Before proceeding, you'll need ``wmctrl`` and
-``xdotool``. Under ``apt``-based distributions, you can get them by
-running::
+**Note for Linux:** Before proceeding, you'll need to install the
+``wmctrl``, ``xdotool`` and ``xsel`` programs. Under ``apt``-based
+distributions, you can get them by running::
 
-  sudo apt install wmctrl xdotool
+  sudo apt install wmctrl xdotool xsel
 
 You may also need to manually set the ``XDG_SESSION_TYPE`` environment
 variable to ``x11``.

--- a/dragonfly/test/test_clipboard.py
+++ b/dragonfly/test/test_clipboard.py
@@ -79,6 +79,32 @@ class TestClipboard(unittest.TestCase):
         # Then test that it has been cleared.
         self.assertEqual(Clipboard.get_system_text(), "")
 
+    def test_convert_format_content(self):
+        # Define a convenient shorthand function for testing the
+        # Clipboard.convert_format_content() class method.
+        def convert(format, content):  # pylint: disable=redefined-builtin
+            return Clipboard.convert_format_content(format, content)
+
+        # Text strings used with format_text (ANSI) are converted.
+        self.assertEqual(convert(format_text, u"text"), b"text")
+
+        # Text strings used with format_unicode are not changed.
+        self.assertEqual(convert(format_unicode, u"text"), u"text")
+
+        # Binary strings used with format_unicode are converted.
+        self.assertEqual(convert(format_unicode, b"text"), u"text")
+
+        # Binary strings used with format_text are not changed.
+        self.assertEqual(convert(format_text, b"text"), b"text")
+
+        # Using non-string objects for text formats raises errors.
+        self.assertRaises(TypeError, convert, format_text, 0)
+        self.assertRaises(TypeError, convert, format_unicode, 0)
+        self.assertRaises(TypeError, convert, format_text, object())
+        self.assertRaises(TypeError, convert, format_unicode, object())
+        self.assertRaises(TypeError, convert, format_text, None)
+        self.assertRaises(TypeError, convert, format_unicode, None)
+
     def test_from_system_argument(self):
         # Test the optional from_system argument of Clipboard.__init__
         text = "something"

--- a/dragonfly/test/test_clipboard.py
+++ b/dragonfly/test/test_clipboard.py
@@ -19,6 +19,8 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
+import os
+from tempfile import NamedTemporaryFile, mkdtemp
 import unittest
 
 from dragonfly import Clipboard
@@ -26,6 +28,7 @@ from dragonfly import Clipboard
 
 format_unicode = Clipboard.format_unicode
 format_text = Clipboard.format_text
+format_hdrop = Clipboard.format_hdrop
 
 
 class TestClipboard(unittest.TestCase):
@@ -34,6 +37,8 @@ class TestClipboard(unittest.TestCase):
 
     These should pass on all supported platforms.
     """
+
+    #-----------------------------------------------------------------------
 
     @classmethod
     def setUpClass(cls):
@@ -48,6 +53,8 @@ class TestClipboard(unittest.TestCase):
     def setUp(self):
         # Clear the clipboard before each test.
         Clipboard.clear_clipboard()
+
+    #-----------------------------------------------------------------------
 
     def test_get_set_system_text(self):
         # Test with an empty system clipboard.
@@ -97,13 +104,73 @@ class TestClipboard(unittest.TestCase):
         # Binary strings used with format_text are not changed.
         self.assertEqual(convert(format_text, b"text"), b"text")
 
-        # Using non-string objects for text formats raises errors.
-        self.assertRaises(TypeError, convert, format_text, 0)
-        self.assertRaises(TypeError, convert, format_unicode, 0)
-        self.assertRaises(TypeError, convert, format_text, object())
-        self.assertRaises(TypeError, convert, format_unicode, object())
-        self.assertRaises(TypeError, convert, format_text, None)
-        self.assertRaises(TypeError, convert, format_unicode, None)
+        # Test format_hdrop with existing file paths.
+        with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+            # Strings are converted to tuples containing file paths. Test
+            # using Unicode and binary strings.
+            # First, test using one existing file.
+            for test_string in [u"%s\0\0", u"%s\n\n", u"%s\0", u"%s\n"]:
+                test_string = test_string % f1.name
+                f1name = u"%s" % f1.name
+                self.assertEqual(convert(format_hdrop, test_string),
+                                 (f1name,))
+                test_string = test_string.encode()
+                f1name = f1name.encode()
+                self.assertEqual(convert(format_hdrop, test_string),
+                                 (f1name,))
+
+            # Then, test using two.
+            for test_string in ["%s\0%s\0\0", "%s\n%s\0", "%s\n%s\n"]:
+                test_string = test_string % (f1.name, f2.name)
+                f1name, f2name = u"%s" % f1.name, u"%s" % f2.name
+                self.assertEqual(convert(format_hdrop, test_string),
+                                 (f1name, f2name))
+                test_string = test_string.encode()
+                f1name, f2name = f1name.encode(), f2name.encode()
+                self.assertEqual(convert(format_hdrop, test_string),
+                                 (f1name, f2name))
+
+            # Tuples and lists containing strings are accepted. Lists are
+            # converted to tuples.
+            self.assertEqual(convert(format_hdrop, (f1.name,)), (f1.name,))
+            self.assertEqual(convert(format_hdrop, [f1.name]), (f1.name,))
+
+        # Existing relative file paths are not accepted.
+        cwd = os.getcwd()
+        try:
+            # Make a temporary directory and enter it.
+            tempdir = mkdtemp()
+            os.chdir(tempdir)
+
+            # Test the relative file path.
+            with NamedTemporaryFile(dir=tempdir) as f:
+                basename = u"%s" % os.path.basename(f.name)
+                for test_obj in [basename, basename.encode(), [basename],
+                                 (basename,)]:
+                    self.assertRaises(ValueError, convert, format_hdrop,
+                                      test_obj)
+        finally:
+            # Return to the original working directory and delete tempdir.
+            os.chdir(cwd)
+            os.rmdir(tempdir)
+
+        # Errors are raised when unacceptable content is used with the text
+        # formats or with format_hdrop.
+        for test_obj in [object(), None, 0]:
+            self.assertRaises(TypeError, convert, format_text, test_obj)
+            self.assertRaises(TypeError, convert, format_unicode, test_obj)
+            self.assertRaises(TypeError, convert, format_hdrop, test_obj)
+            self.assertRaises(TypeError, convert, format_hdrop, (test_obj,))
+            self.assertRaises(TypeError, convert, format_hdrop, [test_obj])
+        for test_string in [u"", u"\n", u"\0", u"test\n", u"test\0"]:
+            self.assertRaises(ValueError, convert, format_hdrop,
+                              test_string)
+            self.assertRaises(ValueError, convert, format_hdrop,
+                              test_string.encode())
+
+        # Empty lists/tuples are not acceptable format_hdrop content.
+        self.assertRaises(ValueError, convert, format_hdrop, [])
+        self.assertRaises(ValueError, convert, format_hdrop, ())
 
     def test_from_system_argument(self):
         # Test the optional from_system argument of Clipboard.__init__
@@ -228,6 +295,7 @@ class TestClipboard(unittest.TestCase):
         c = Clipboard()
         self.assertFalse(c.has_format(format_unicode))
         self.assertFalse(c.has_format(format_text))
+        self.assertFalse(c.has_format(format_hdrop))
 
         # Test with one format.
         c = Clipboard(contents={format_unicode: u"unicode text"})
@@ -245,12 +313,14 @@ class TestClipboard(unittest.TestCase):
         c = Clipboard()
         self.assertRaises(ValueError, c.get_format, format_unicode)
         self.assertRaises(ValueError, c.get_format, format_text)
+        self.assertRaises(ValueError, c.get_format, format_hdrop)
 
         # Test with one format.
         text1 = u"unicode text"
         c = Clipboard(contents={format_unicode: text1})
         self.assertEqual(c.get_format(format_unicode), text1)
         self.assertRaises(ValueError, c.get_format, format_text)
+        self.assertRaises(ValueError, c.get_format, format_hdrop)
 
         # Test with two formats.
         text2 = b"text"
@@ -258,6 +328,14 @@ class TestClipboard(unittest.TestCase):
                                 format_text: text2})
         self.assertEqual(c.get_format(format_unicode), text1)
         self.assertEqual(c.get_format(format_text), text2)
+        self.assertRaises(ValueError, c.get_format, format_hdrop)
+
+        # Test with format_hdrop.
+        with NamedTemporaryFile() as f:
+            c = Clipboard(contents={format_hdrop: f.name})
+            self.assertRaises(ValueError, c.get_format, format_unicode)
+            self.assertRaises(ValueError, c.get_format, format_text)
+            self.assertEqual(c.get_format(format_hdrop), (f.name,))
 
     def test_set_format(self):
         # Test with one format.
@@ -277,14 +355,28 @@ class TestClipboard(unittest.TestCase):
         self.assertTrue(c.has_format(format_text))
         self.assertEqual(c.get_format(format_text), text2)
 
+        # Test with format_hdrop.
+        with NamedTemporaryFile() as f:
+            c.set_format(format_hdrop, f.name)
+            self.assertTrue(c.has_format(format_unicode))
+            self.assertTrue(c.has_format(format_text))
+            self.assertTrue(c.has_format(format_hdrop))
+            self.assertEqual(c.get_format(format_hdrop), (f.name,))
+
         # Setting a format to None removes the format's content from the
         # instance.
         c.set_format(format_text, None)
         self.assertFalse(c.has_format(format_text))
         self.assertRaises(ValueError, c.get_format, format_text)
+        self.assertTrue(c.has_format(format_unicode))
+        self.assertTrue(c.has_format(format_hdrop))
         c.set_format(format_unicode, None)
         self.assertFalse(c.has_format(format_unicode))
         self.assertRaises(ValueError, c.get_format, format_unicode)
+        self.assertTrue(c.has_format(format_hdrop))
+        c.set_format(format_hdrop, None)
+        self.assertFalse(c.has_format(format_hdrop))
+        self.assertRaises(ValueError, c.get_format, format_hdrop)
 
     def test_has_text(self):
         # Test with an empty Clipboard instance.
@@ -303,6 +395,11 @@ class TestClipboard(unittest.TestCase):
         # Test with format_text only.
         c = Clipboard(contents={format_text: b"text"})
         self.assertTrue(c.has_text())
+
+        # Test with format_hdrop only.
+        with NamedTemporaryFile() as f:
+            c = Clipboard(contents={format_hdrop: f.name})
+            self.assertFalse(c.has_text())
 
     def test_set_text(self):
         c = Clipboard()
@@ -341,6 +438,11 @@ class TestClipboard(unittest.TestCase):
         text2 = b"test"
         c.set_text(text2)
         self.assertEqual(c.get_text(), text2)
+
+        # Test with format_hdrop.
+        with NamedTemporaryFile() as f:
+            c = Clipboard(contents={format_hdrop: f.name})
+            self.assertIsNone(c.get_text())
 
     def test_flexible_string_types(self):
         # This is similar to the clipboard format conversion that Windows

--- a/dragonfly/windows/clipboard.py
+++ b/dragonfly/windows/clipboard.py
@@ -28,10 +28,14 @@ import sys
 
 from .base_clipboard import BaseClipboard
 
+
 # Import the clipboard classes and functions for the current platform.
 if sys.platform.startswith("win"):
     from .win32_clipboard import (Win32Clipboard as Clipboard,
-                                    win32_clipboard_ctx)
+                                  win32_clipboard_ctx)
+
+elif os.environ.get("XDG_SESSION_TYPE") == "x11":
+    from .x11_clipboard import XselClipboard as Clipboard
 
 else:
     from .pyperclip_clipboard import PyperclipClipboard as Clipboard

--- a/dragonfly/windows/pyperclip_clipboard.py
+++ b/dragonfly/windows/pyperclip_clipboard.py
@@ -26,6 +26,8 @@ and should work on Windows, Mac OS and Linux-based operating systems.
 # pylint: disable=W0622
 # Suppress warnings about redefining the built-in 'format' function.
 
+import os
+
 from six import integer_types
 import pyperclip
 
@@ -74,9 +76,16 @@ class PyperclipClipboard(BaseClipboard):
     # ----------------------------------------------------------------------
 
     def copy_from_system(self, formats=None, clear=False):
+        # Determine the supported formats.  Copied file paths may be
+        #  available to us on X11.
+        supported_formats = [self.format_text, self.format_unicode]
+        if os.environ.get("XDG_SESSION_TYPE") == "x11":
+            supported_formats.append(self.format_hdrop)
+
         # Determine which formats to retrieve.
+        caller_specified_formats = bool(formats)
         if not formats:
-            formats = (self.format_text, self.format_unicode)
+            formats = supported_formats
         elif isinstance(formats, integer_types):
             formats = (formats,)
 
@@ -90,9 +99,33 @@ class PyperclipClipboard(BaseClipboard):
         # This class only handles text formats.
         text = self.get_system_text()
         contents = {}
+
+        # Populate the clipboard contents dictionary and raise errors for
+        #  unavailable formats.
         for format in formats:
-            content = self.convert_format_content(format, text)
-            contents[format] = content
+            try:
+                err = False
+                content = self.convert_format_content(format, text)
+                contents[format] = content
+            except (ValueError, TypeError):
+                err = True
+
+            # Do not raise an error for CF_HDROP content if the caller did
+            #  not specify it.
+            if format == self.format_hdrop and not caller_specified_formats:
+                err = False
+
+            # Always raise an error if the format is not supported.
+            if format not in supported_formats:
+                err = True
+
+            # Raise an error if a specified clipboard format was not
+            #  available.
+            if err:
+                format_repr = self.format_names.get(format, format)
+                message = ("Specified clipboard format %r is not "
+                           "available." % format_repr)
+                raise TypeError(message)
         self._contents = contents
 
         # Then clear the system clipboard, if requested.

--- a/dragonfly/windows/pyperclip_clipboard.py
+++ b/dragonfly/windows/pyperclip_clipboard.py
@@ -90,12 +90,9 @@ class PyperclipClipboard(BaseClipboard):
         # This class only handles text formats.
         text = self.get_system_text()
         contents = {}
-        if self.format_text in formats:
-            text = self.convert_format_content(self.format_text, text)
-            contents[self.format_text] = text
-        if self.format_unicode in formats:
-            text = self.convert_format_content(self.format_unicode, text)
-            contents[self.format_unicode] = text
+        for format in formats:
+            content = self.convert_format_content(format, text)
+            contents[format] = content
         self._contents = contents
 
         # Then clear the system clipboard, if requested.

--- a/dragonfly/windows/x11_clipboard.py
+++ b/dragonfly/windows/x11_clipboard.py
@@ -1,0 +1,195 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2007, 2008 by Christo Butcher
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+This file implements interfaces to the X selections (clipboards):
+
+ * Abstract BaseX11Clipboard interface to the X selections.
+
+"""
+
+# pylint: disable=W0622
+# Suppress warnings about redefining the built-in 'format' function.
+
+from six import integer_types
+
+from .base_clipboard import BaseClipboard
+
+
+#===========================================================================
+
+
+class BaseX11Clipboard(BaseClipboard):
+    """
+    Base X11 clipboard class.
+    """
+
+    format_text      = 1
+    format_unicode   = 13
+    format_hdrop     = 15
+
+    # Include formats for the standard three X selections.
+    #: Format for the primary X selection.
+    format_x_primary   = 0x10000
+
+    #: Format for the secondary X selection.
+    format_x_secondary = 0x10001
+
+    #: Format for the clipboard X selection (alias of format_unicode).
+    format_x_clipboard = 13
+
+    format_names = {
+        format_text:        "text",
+        format_unicode:     "unicode",
+        format_x_primary:   "x_primary",
+        format_x_secondary: "x_secondary",
+        format_hdrop:       "hdrop",
+    }
+
+    #-----------------------------------------------------------------------
+
+    @classmethod
+    def _get_x_selection(cls, format):
+        raise NotImplementedError()
+
+    @classmethod
+    def _set_x_selection(cls, format, content):
+        raise NotImplementedError()
+
+    #-----------------------------------------------------------------------
+
+    @classmethod
+    def get_system_text(cls):
+        try:
+            return cls._get_x_selection(cls.format_x_clipboard)
+        except TypeError:
+            # Return the empty string if there is nothing in the selection
+            #  or if its contents could not be retrieved.
+            return u""
+
+    @classmethod
+    def set_system_text(cls, content):
+        # If *content* is None, clear the clipboard and return early.
+        if content is None:
+            cls.clear_clipboard()
+            return
+
+        # Otherwise, convert *content* and set the system clipboard data.
+        content = cls.convert_format_content(cls.format_unicode, content)
+        cls._set_x_selection(cls.format_x_clipboard, content)
+
+    @classmethod
+    def clear_clipboard(cls):
+        cls.set_system_text(u"")
+
+    #-----------------------------------------------------------------------
+
+    def copy_from_system(self, formats=None, clear=False):
+        # pylint: disable=too-many-branches
+        # Determine which formats to retrieve.
+        supported_formats = (self.format_text, self.format_unicode,
+                             self.format_hdrop, self.format_x_primary,
+                             self.format_x_secondary)
+        caller_specified_formats = bool(formats)
+        if not formats:
+            formats = supported_formats
+        elif isinstance(formats, integer_types):
+            formats = (formats,)
+
+        # Verify that the given formats are valid.
+        for format in formats:
+            if not isinstance(format, integer_types):
+                raise TypeError("Invalid clipboard format: %r"
+                                % format)
+
+        # Retrieve the system clipboard content.
+        try:
+            clipboard_text = self._get_x_selection(self.format_x_clipboard)
+        except TypeError:
+            clipboard_text = u""
+        contents = {}
+
+        # Populate the clipboard contents dictionary and raise errors for
+        #  unavailable formats.
+        for format in formats:
+            err = False
+            try:
+                # Retrieve and use other X selections as text, if required.
+                if format in (self.format_x_primary,
+                              self.format_x_secondary):
+                    text = self._get_x_selection(format)
+                else:
+                    text = clipboard_text
+
+                # Attempt to convert and set text for this clipboard format.
+                content = self.convert_format_content(format, text)
+                contents[format] = content
+            except (ValueError, TypeError):
+                err = True
+
+            # Do not raise errors for formats that the caller did not
+            #  specify.
+            if format in supported_formats and not caller_specified_formats:
+                err = False
+
+            # Always raise an error if the format is not supported.
+            if format not in supported_formats:
+                err = True
+
+            # Raise an error if a specified clipboard format was not
+            #  available.
+            if err:
+                format_repr = self.format_names.get(format, format)
+                message = ("Specified clipboard format %r is not "
+                           "available." % format_repr)
+                raise TypeError(message)
+        self._contents = contents
+
+        # Then clear the system clipboard, if requested.
+        if clear:
+            self.clear_clipboard()
+
+    def copy_to_system(self, clear=True):
+        # Clear the system clipboard, if requested.
+        if clear:
+            self.clear_clipboard()
+
+        # Transfer content to the X selections.
+        # Text content is put on the clipboard selection, if necessary.
+        text = self.get_text()
+        if text is not None:
+            self._set_x_selection(self.format_x_clipboard, text)
+
+        # CF_HDROP content is put on the clipboard selection, if necessary.
+        #  This might not work properly.
+        elif self.has_format(self.format_hdrop):
+            file_paths = self.get_format(self.format_hdrop)
+            content = u"\n".join(file_paths) + u"\n"
+            self._set_x_selection(self.format_x_clipboard, content)
+
+        # Set the primary selection content, if necessary.
+        if self.has_format(self.format_x_primary):
+            content = self.get_format(self.format_x_primary)
+            self._set_x_selection(self.format_x_primary, content)
+
+        # Set the secondary selection content, if necessary.
+        if self.has_format(self.format_x_secondary):
+            content = self.get_format(self.format_x_secondary)
+            self._set_x_selection(self.format_x_secondary, content)


### PR DESCRIPTION
This PR includes a number of improvements to Dragonfly's clipboard toolkit, mostly related to clipboard formats.

Re: #226.

### Change Summary

* Adjust `BaseClipboard` class to handle the `CF_HDROP` clipboard format for copied files.
* Add abstract `BaseX11Clipboard` interface to the [X selections](https://specifications.freedesktop.org/clipboards-spec/clipboards-latest.txt).
* Add `XselClipboard` class for use on X11.
  This class implements `BaseX11Clipboard` using the [`xsel`](http://www.vergenet.net/~conrad/software/xsel/) program and is now the default Clipboard class on X11. It supports all three X selections: PRIMARY, SECONDARY and CLIPBOARD. `CF_HDROP` content can be retrieved.
* Improve clipboard format support of the `PyperclipClipboard` class.
  * `CF_HDROP` content can be retrieved on X11.
  * Errors are raised in `copy_from_system()` for unsupported or unavailable formats.
* Improve the `win32_clipboard_ctx()` context manager function.
  * Add optional `timeout` and `step` arguments.
  * Use a shorter wait time between each attempt to open the clipboard (1 ms vs 10 ms).
* Update Clipboard unit tests.

### Notes

The abstract `BaseX11Clipboard` class should make it easier to implement a `Clipboard` class that uses the relevant X11 APIs directly instead of shelling out to `xsel`. Only the following abstract class methods need to be implemented:
* `cls._get_x_selection(format)`
* `cls._set_x_selection(format, content)`

This could potentially be done using [python-xlib](https://github.com/python-xlib/python-xlib) and would allow us to specify particular target data formats.

I have tried implementing `BaseX11Clipboard` using [`xclip`](https://launchpad.net/xclip), however, there is a bug which makes it difficult to set X selections via standard input (stdin).