### PR TITLE
get_engine() function changes

### DIFF
--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -95,6 +95,20 @@ def get_engine(name=None, **kwargs):
             if name:
                 raise EngineError(message)
 
+    if not engine and name in (None, "kaldi"):
+        # Attempt to retrieve the Kaldi back-end.
+        try:
+            from .backend_kaldi import is_engine_available
+            from .backend_kaldi import get_engine as get_specific_engine
+            if is_engine_available(**kwargs):
+                engine = get_specific_engine(**kwargs)
+        except Exception as e:
+            message = ("Exception while initializing kaldi engine:"
+                       " %s" % (e,))
+            log.warning(message)
+            if name:
+                raise EngineError(message)
+
     sapi5_names = (None, "sapi5shared", "sapi5inproc", "sapi5")
     if not engine and windows and name in sapi5_names:
         # Attempt to retrieve the sapi5 back-end.
@@ -119,20 +133,6 @@ def get_engine(name=None, **kwargs):
                 engine = get_specific_engine(**kwargs)
         except Exception as e:
             message = ("Exception while initializing sphinx engine:"
-                       " %s" % (e,))
-            log.warning(message)
-            if name:
-                raise EngineError(message)
-
-    if not engine and name in (None, "kaldi"):
-        # Attempt to retrieve the Kaldi back-end.
-        try:
-            from .backend_kaldi import is_engine_available
-            from .backend_kaldi import get_engine as get_specific_engine
-            if is_engine_available(**kwargs):
-                engine = get_specific_engine(**kwargs)
-        except Exception as e:
-            message = ("Exception while initializing kaldi engine:"
                        " %s" % (e,))
             log.warning(message)
             if name:

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -36,17 +36,37 @@ def get_engine(name=None, **kwargs):
     """
         Get the engine implementation.
 
-        This function will initialize an engine object using the
+        This function will initialize an engine instance using the
         ``get_engine`` and ``is_engine_available`` functions in the engine
-        packages and return an instance of the first available engine. If
+        packages and return an instance of the first available engine.  If
         one has already been initialized, it will be returned instead.
+
+        If no specific engine is requested and no engine has already been
+        initialized, this function will initialize and return an instance of
+        the first available engine in the following order:
+
+         =======================   =========================================
+         SR engine back-end        Engine name string(s)
+         =======================   =========================================
+         1. Dragon/Natlink         ``"natlink"``
+         2. Kaldi                  ``"kaldi"``
+         3. WSR/SAPI 5             ``"sapi5", "sapi5inproc", "sapi5shared"``
+         4. CMU Pocket Sphinx      ``"sphinx"``
+         =======================   =========================================
+
+        The :ref:`Text-input engine <RefTextEngine>` can be initialized by
+        specifying ``"text"`` as the engine name.  This back-end will
+        **not** be initialized if no specific engine is requested because
+        the back-end is not a real SR engine and is used mostly for testing.
+
+        **Arguments**:
 
         :param name: optional human-readable name of the engine to return.
         :type name: str
         :param \\**kwargs: optional keyword arguments passed through to the
             engine for engine-specific configuration.
         :rtype: EngineBase
-        :returns: engine object
+        :returns: engine instance
         :raises: EngineError
     """
     # pylint: disable=too-many-statements,too-many-branches

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -155,8 +155,11 @@ def get_engine(name=None, **kwargs):
             if name:
                 raise EngineError(message)
 
-    # Return the engine instance, if one has been initialized.
+    # Return the engine instance, if one has been initialized.  Log a
+    #  message about which SR engine back-end was used.
     if engine:
+        message = "Initialized %r SR engine: %r." % (engine.name, engine)
+        log.info(message)
         return engine
     elif not name:
         raise EngineError("No usable engines found.")

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -22,7 +22,7 @@
 
 import logging
 import os
-import traceback
+
 from .base import EngineBase, EngineError, MimicFailure
 
 
@@ -65,12 +65,12 @@ def get_engine(name=None, **kwargs):
         engine = None
 
     # Check if there is an already initialized engine *and* custom engine
-    #  initialization arguments.
+    #  initialization arguments.  This is not allowed.
     if engine and kwargs is not None and len(kwargs) > 0:
         message = ("Error: Passing get_engine arguments to an engine "
                    "that has already been initialized, hence these "
                    "arguments are ignored.")
-        print(message)
+        log.error(message)
         raise EngineError(message)
 
     # If there is a relevant initialized engine already, then return it.
@@ -91,7 +91,7 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing natlink engine:"
                        " %s" % (e,))
-            print(message)
+            log.warning(message)
             if name:
                 raise EngineError(message)
 
@@ -106,7 +106,7 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing sapi5 engine:"
                        " %s" % (e,))
-            print(message)
+            log.warning(message)
             if name:
                 raise EngineError(message)
 
@@ -120,7 +120,7 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing sphinx engine:"
                        " %s" % (e,))
-            log.exception(message)
+            log.warning(message)
             if name:
                 raise EngineError(message)
 
@@ -134,7 +134,7 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing kaldi engine:"
                        " %s" % (e,))
-            print(message)
+            log.warning(message)
             if name:
                 raise EngineError(message)
 
@@ -151,7 +151,7 @@ def get_engine(name=None, **kwargs):
         except Exception as e:
             message = ("Exception while initializing text-input engine:"
                        " %s" % (e,))
-            print(message)
+            log.warning(message)
             if name:
                 raise EngineError(message)
 


### PR DESCRIPTION
This makes the following changes to Dragonfly's `get_engine()` function:

- Change the function to return engine instances mainly at the end.
- Simplify some of the function's logic and add comments.
- Change the function to log messages instead of printing them.
- Change the function to log an info message for initialized engines (re: #330).
- Adjust order of preferred SR engine implementations: Kaldi is now preferred over SAPI 5 and Sphinx, if it is available (re: #330).
- Update the function documentation.