### PR TITLE
Change keyboard-related import-time side-effects

### DIFF
--- a/dragonfly/actions/action_base_keyboard.py
+++ b/dragonfly/actions/action_base_keyboard.py
@@ -32,7 +32,7 @@ import sys
 from .action_base  import DynStrActionBase
 from .keyboard     import Keyboard
 
-
+_CONFIG_LOADED = False
 UNICODE_KEYBOARD = False
 HARDWARE_APPS = [
     "tvnviewer.exe", "vncviewer.exe", "mstsc.exe", "virtualbox.exe"
@@ -50,6 +50,7 @@ def load_configuration():
     global UNICODE_KEYBOARD
     global HARDWARE_APPS
     global PAUSE_DEFAULT
+    global _CONFIG_LOADED
 
     home = os.path.expanduser("~")
     config_folder = os.path.join(home, ".dragonfly2-speech")
@@ -75,8 +76,7 @@ def load_configuration():
     if parser.has_option("Text", "pause_default"):
         PAUSE_DEFAULT = parser.getfloat("Text", "pause_default")
 
-
-load_configuration()
+    _CONFIG_LOADED = True
 
 
 class BaseKeyboardAction(DynStrActionBase):
@@ -109,6 +109,11 @@ class BaseKeyboardAction(DynStrActionBase):
         # Always use hardware_events for non-Windows platforms.
         if not sys.platform.startswith("win") or self._use_hardware:
             return True
+
+        # Load the keyboard configuration, if necessary.
+        global _CONFIG_LOADED
+        if not _CONFIG_LOADED:
+            load_configuration()
 
         # Otherwise check if hardware events should be used with the current
         # foreground window.

--- a/dragonfly/actions/action_paste.py
+++ b/dragonfly/actions/action_paste.py
@@ -63,20 +63,19 @@ class Paste(DynStrActionBase):
 
     _default_format = Clipboard.format_unicode
 
-    # Default paste action.
-    # Fallback on Shift-insert if 'v' isn't available. Use Super-v on macs.
-    try:
-        _default_paste = (Key("w-v/20") if sys.platform == "darwin"
-                          else Key("c-v/20"))
-    except ActionError:
-        _default_paste = Key("s-insert/20")
+    # Default paste action spec.
+    _default_paste_spec = "w-v/20" if sys.platform == "darwin" else "c-v/20"
 
     # pylint: disable=redefined-builtin
     def __init__(self, contents, format=None, paste=None, static=False):
         if not format:
             format = self._default_format
         if paste is None:
-            paste = self._default_paste
+            try:
+                paste = Key(self._default_paste_spec)
+            except ActionError:
+                # Fallback on Shift-insert if 'v' isn't available.
+                paste = Key("s-insert/20")
         if isinstance(contents, string_types):
             spec = contents
             self.contents = None


### PR DESCRIPTION
This changes a few keyboard-related side-effects that occur when certain dragonfly modules are imported:

* Dragonfly's config file (~/.dragonfly2-speech/settings.cfg) for the Windows keyboard will now only be generated and/or loaded from on Windows and only the first time a keyboard action is used. The file and its parent directory will no longer be created on other platforms.
* Change the `Paste` action class to instantiate the default paste action (`Key`) in the constructor, if necessary, rather than when the module is imported.