### PR TITLE
Improve Windows keyboard action support for letter and number keys

### DIFF
--- a/dragonfly/actions/action_key.py
+++ b/dragonfly/actions/action_key.py
@@ -178,7 +178,7 @@ key, slowly moving down 4 lines, and then releasing the *shift* key: ::
     Key("shift:down, down/25:4, shift:up").execute()
 
 The following code locks the screen by pressing the *Windows* key together
-with the *l*: ::
+with the *l* key: ::
 
     Key("w-l").execute()
 
@@ -197,31 +197,37 @@ This is disabled by default because it ignores the up/down status of
 modifier keys (e.g. ctrl).
 
 It can be enabled by changing the ``unicode_keyboard`` setting in
-`~/.dragonfly2-speech/settings.cfg` to ``True``::
+`~/.dragonfly2-speech/settings.cfg` to ``True``: ::
 
     unicode_keyboard = True
 
 The ``use_hardware`` parameter can be set to ``True`` if you need to
-selectively require hardware events for a :class:`Key` action::
+selectively require hardware events for a :class:`Key` action: ::
 
-    # Only copy if 'c' is a typeable key.
+    # Passing use_hardware=True will guarantee that Ctrl+C is always
+    # pressed, regardless of the layout. See below.
     Key("c-c", use_hardware=True).execute()
 
 If the Unicode keyboard is not enabled or the ``use_hardware`` parameter is
 ``True``, then no keys will be typed and an error will be logged for
-untypeable keys::
+untypeable keys: ::
 
-   action.exec (ERROR): Execution failed: Keyboard interface cannot type this character: 'c'
+   action.exec (ERROR): Execution failed: Keyboard interface cannot type this character: 'μ'
+
+Keys in ranges 0-9, a-z and A-Z are always typeable. If keys in these ranges
+cannot be typed using the current keyboard layout, then the equivalent key
+will be used instead. For example, the following code will result in the 'я'
+key being pressed when using the main Cyrillic keyboard layout: ::
+
+   # This is equivalent to Key(u"я, Я, c-я").
+   Key("z, Z, c-z", use_hardware=True).execute()
 
 Unlike the :class:`Text` action, individual :class:`Key` actions can send
 both hardware *and* Unicode events. So the following example will work if
-the Unicode keyboard is enabled::
+the Unicode keyboard is enabled: ::
 
-    # Type 'σμ' and then press ctrl-z.
+    # Type 'σμ' and then press Ctrl+Z.
     Key(u"σ, μ, c-z").execute()
-
-Note that the 'z' in this example will be typed if the current layout cannot
-type the character.
 
 
 X11 key support

--- a/dragonfly/actions/action_paste.py
+++ b/dragonfly/actions/action_paste.py
@@ -71,11 +71,9 @@ class Paste(DynStrActionBase):
         if not format:
             format = self._default_format
         if paste is None:
-            try:
-                paste = Key(self._default_paste_spec)
-            except ActionError:
-                # Fallback on Shift-insert if 'v' isn't available.
-                paste = Key("s-insert/20")
+            # Pass use_hardware=True to guarantee that Ctrl+V is always
+            # pressed, regardless of the keyboard layout.
+            paste = Key(self._default_paste_spec, use_hardware=True)
         if isinstance(contents, string_types):
             spec = contents
             self.contents = None

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -55,7 +55,6 @@ It can be enabled by changing the ``unicode_keyboard`` setting in
 
     unicode_keyboard = True
 
-
 If you need to simulate typing arbitrary Unicode characters *and* have
 *individual* :class:`Text` actions respect modifier keys normally for normal
 characters, set the configuration as above and use the ``use_hardware``
@@ -65,7 +64,6 @@ parameter for :class:`Text` as follows:
 
    action = Text("σμ") + Key("ctrl:down") + Text("]", use_hardware=True) + Key("ctrl:up")
    action.execute()
-
 
 Some applications require hardware emulation versus Unicode keyboard
 emulation. If you use such applications, add their executable names to the
@@ -77,7 +75,15 @@ layout of the foreground window when calculating keyboard events. If any of
 the specified characters are not typeable using the current window's
 keyboard layout, then an error will be logged and no keys will be typed::
 
-    action.exec (ERROR): Execution failed: Keyboard interface cannot type this character: 'c'
+    action.exec (ERROR): Execution failed: Keyboard interface cannot type this character: 'μ'
+
+Keys in ranges 0-9, a-z and A-Z are always typeable. If keys in these ranges
+cannot be typed using the current keyboard layout, then the equivalent key
+will be used instead. For example, the following code will result in the 'я'
+key being pressed when using the main Cyrillic keyboard layout: ::
+
+   # This is equivalent to Text(u"яЯ").
+   Text("zZ").execute()
 
 These settings and parameters have no effect on other platforms.
 


### PR DESCRIPTION
This changes the Windows keyboard code to fallback on predefined virtual-key codes (see [this page](https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)) for keys in ranges 0-9, a-z and A-Z if the key cannot be typed using the current keyboard layout.  This means that the equivalent key will be typed instead, allowing common keyboard shortcuts, such as Ctrl+C, to work properly.

If the Windows Unicode keyboard is enabled and keys in these ranges cannot be typed on the current keyboard layout, then Dragonfly will fallback on Unicode events. In such a scenario, pressing Ctrl+C using something like `Key("c-c")` would result in "c" being pressed without the Ctrl modifier key held down. This problem is documented in detail in the [documentation on actions](https://dragonfly2.readthedocs.io/en/latest/actions.html).

### TODO
- [X] Improvements..
- [x] Update the relevant sections slightly before merging.
- [x] Use `use_hardware=True` in `Paste` action.
  This should have been done before these changes.