### PR TITLE
Fix issues with the Windows keyboard input code

### DIFF
--- a/dragonfly/actions/keyboard/_win32.py
+++ b/dragonfly/actions/keyboard/_win32.py
@@ -305,8 +305,13 @@ class Keyboard(BaseKeyboard):
         except TypeError:
             code = -1
 
+        # Fallback on the keycode in CHAR_VK_MAP, if applicable.
+        if code == -1 and char in Win32KeySymbols.CHAR_VK_MAP:
+            code = Win32KeySymbols.CHAR_VK_MAP[char]
+
         if code == -1:
             raise ValueError("Unknown char: %r" % char)
+
         return code
 
     @classmethod

--- a/dragonfly/actions/sendinput.py
+++ b/dragonfly/actions/sendinput.py
@@ -35,6 +35,7 @@ import win32api
 
 # These virtual keys don't have corresponding scancodes.
 # The list was found experimentally and is open to improvement.
+# TODO Remove this and defer to the Win32 MapVirtualKey(Ex) function.
 SOFT_KEYS = [x for x in range(0xc1, 0xdb)]
 SOFT_KEYS += [x for x in range(0x15, 0x1b)]
 SOFT_KEYS += [x for x in range(0x1c, 0x20)]
@@ -107,16 +108,14 @@ class KeyboardInput(Structure):
         if virtual_keycode == 0:
             flags |= 4  # KEYEVENTF_UNICODE
         else:
-            if virtual_keycode not in self.soft_keys:
+            if scancode != 0 and virtual_keycode not in self.soft_keys:
                 flags |= 8  # KEYEVENTF_SCANCODE
             if virtual_keycode in self.extended_keys:
                 flags |= win32con.KEYEVENTF_EXTENDEDKEY
         if not down:
             flags |= win32con.KEYEVENTF_KEYUP
-        
 
         extra = pointer(c_ulong(0))
-        # print(virtual_keycode, scancode, flags, 0, extra)
         Structure.__init__(self, virtual_keycode, scancode, flags, 0, extra)
 
 

--- a/dragonfly/actions/sendinput.py
+++ b/dragonfly/actions/sendinput.py
@@ -30,25 +30,9 @@ for simulating keyboard and mouse events.
 
 from ctypes import (c_short, c_long, c_ushort, c_ulong, sizeof,
                     POINTER, pointer, Structure, Union, windll)
+
 import win32con
 import win32api
-
-# These virtual keys don't have corresponding scancodes.
-# The list was found experimentally and is open to improvement.
-# TODO Remove this and defer to the Win32 MapVirtualKey(Ex) function.
-SOFT_KEYS = [x for x in range(0xc1, 0xdb)]
-SOFT_KEYS += [x for x in range(0x15, 0x1b)]
-SOFT_KEYS += [x for x in range(0x1c, 0x20)]
-SOFT_KEYS += [x for x in range(0x3a, 0x41)]
-SOFT_KEYS += [x for x in range(0x88, 0x90)]
-SOFT_KEYS += [x for x in range(0xa6, 0xba)]
-SOFT_KEYS += [
-    0xe0, 0xe5, 0xe7, 0xe8, 0xfc, 0x01, 0x02, 0x4, 0x5, 0x6, 0x7, 0x0a, 0x0b,
-    0x0e, 0x0f, 0x5d, 0x5e, 0x5f
-]
-SOFT_KEYS += [
-    win32con.VK_SNAPSHOT
-]
 
 
 class KeyboardInput(Structure):
@@ -59,7 +43,6 @@ class KeyboardInput(Structure):
                 ("dwFlags", c_ulong),
                 ("time", c_ulong),
                 ("dwExtraInfo", POINTER(c_ulong))]
-    soft_keys = set(SOFT_KEYS)
 
     # pylint: disable=line-too-long
 
@@ -94,22 +77,29 @@ class KeyboardInput(Structure):
         win32con.VK_RWIN,
     ))
 
-    def __init__(self, virtual_keycode, down, scancode=-1, layout=None):
+    def __init__(self, virtual_keycode, down, scancode=None, layout=None):
         """Initialize structure based on key type."""
-        if scancode == -1:
-            if not layout:
-                scancode = windll.user32.MapVirtualKeyW(virtual_keycode, 0)
-            else:
-                # Assume that 'layout' is a keyboard layout (HKL).
-                scancode = windll.user32.MapVirtualKeyExW(virtual_keycode,
-                                                          0, layout)
-
         flags = 0
         if virtual_keycode == 0:
             flags |= 4  # KEYEVENTF_UNICODE
         else:
-            if scancode != 0 and virtual_keycode not in self.soft_keys:
+            # Translate *virtual_keycode* into a scan code, if necessary.
+            #  Assume that *layout* is a keyboard layout (HKL).
+            if scancode is None:
+                user32 = windll.user32
+                if layout is None:
+                    scancode = user32.MapVirtualKeyW(virtual_keycode, 0)
+                else:
+                    scancode = user32.MapVirtualKeyExW(virtual_keycode, 0,
+                                                       layout)
+
+            # Add the KEYEVENTF_SCANCODE flag if the Win32 MapVirtualKey(Ex)
+            #  function returned a translation.  If not, then fallback on
+            #  the specified keycode.
+            if scancode:
                 flags |= 8  # KEYEVENTF_SCANCODE
+
+            # Add the KEYEVENTF_EXTENDEDKEY flag, if necessary.
             if virtual_keycode in self.extended_keys:
                 flags |= win32con.KEYEVENTF_EXTENDEDKEY
         if not down:


### PR DESCRIPTION
This PR fixes a few bugs with the Windows keyboard input code and cleans it up a bit. The changes are as follows:

- Fix a Windows keyboard input bug related to letter and number keys.
- Change the `KeyboardInput` struct to only translate virtual keycodes to scan codes when necessary (in `__init__`).
- Remove the hardcoded "soft" keys set and defer to the Win32 `MapVirtualKey` / `MapVirtualKeyEx` function instead, which returns 0 for virtual keycodes that don't have corresponding scancodes.
- Fix Windows keyboard input bug related to scan codes.
  The `KeyboardInput` struct in `sendinput.py` now falls back on the virtual-key code if there is no equivalent scan code available. This is not done if the virtual keycode is 0 (for `KEYEVENTF_UNICODE` mode).

These changes fix bugs that occur with different keyboard layouts and should make this implementation more reliable.