### PR TITLE
Clipboard toolkit additions, improvements and bug fixes

### DIFF
--- a/documentation/clipboard.txt
+++ b/documentation/clipboard.txt
@@ -100,10 +100,10 @@ Windows Clipboard class
    :members:
 
 
-Windows Clipboard context manager function
+Windows Clipboard context manager
 ----------------------------------------------------------------------------
 
-.. autofunction:: dragonfly.windows.win32_clipboard.win32_clipboard_ctx
+.. autoclass:: dragonfly.windows.win32_clipboard.win32_clipboard_ctx
 
 
 X11 Clipboard classes

--- a/dragonfly/test/test_clipboard.py
+++ b/dragonfly/test/test_clipboard.py
@@ -444,6 +444,46 @@ class TestClipboard(unittest.TestCase):
             c = Clipboard(contents={format_hdrop: f.name})
             self.assertIsNone(c.get_text())
 
+    def test_comparison(self):
+        # Test with two empty Clipboard instances.
+        self.assertEqual(Clipboard(), Clipboard())
+
+        # Test with format_unicode.
+        c1 = Clipboard(contents={format_unicode: u"unicode text"})
+        c2 = Clipboard(contents={format_unicode: u"unicode text"})
+        self.assertEqual(c1, c2)
+        self.assertNotEqual(c1, Clipboard())
+
+        # Test with the same clipboard instance.
+        self.assertEqual(c1, c1)
+
+        # Test with both text formats.
+        c1 = Clipboard(contents={format_unicode: u"unicode text",
+                                 format_text: b"text"})
+        c2 = Clipboard(contents={format_unicode: u"unicode text",
+                                 format_text: b"text"})
+        self.assertEqual(c1, c2)
+        self.assertNotEqual(c1, Clipboard())
+
+        # Test with format_text only.
+        c1 = Clipboard(contents={format_text: b"text"})
+        c2 = Clipboard(contents={format_text: b"text"})
+        self.assertEqual(c1, c2)
+        self.assertNotEqual(c1, Clipboard())
+
+        # Test with different text formats.
+        c1 = Clipboard(contents={format_unicode: u"unicode text"})
+        c2 = Clipboard(contents={format_text: b"text"})
+        self.assertNotEqual(c1, c2)
+
+        # Test with format_hdrop only.
+        with NamedTemporaryFile() as f:
+            c1 = Clipboard(contents={format_hdrop: f.name})
+            c2 = Clipboard(contents={format_hdrop: f.name})
+            self.assertEqual(c1, c2)
+            self.assertNotEqual(c1, Clipboard())
+            self.assertNotEqual(c1, Clipboard(text="text"))
+
     def test_flexible_string_types(self):
         # This is similar to the clipboard format conversion that Windows
         # performs when necessary. The Clipboard class should do this

--- a/dragonfly/windows/base_clipboard.py
+++ b/dragonfly/windows/base_clipboard.py
@@ -160,6 +160,36 @@ class BaseClipboard(object):
     @contextlib.contextmanager
     def synchronized_changes(cls, timeout, step=0.001, formats=None,
                              initial_clipboard=None):
+        """
+            Context manager for synchronizing local and system clipboard
+            changes.  This takes the same arguments as the
+            :meth:`wait_for_change` method.
+
+            Arguments:
+             - *timeout* (float) -- timeout in seconds.
+             - *step* (float, default: 0.001) -- number of seconds between
+               each check.
+             - *formats* (iterable, default: None) -- if not None, only
+               changes to the given content formats will register.  If None,
+               all formats will be observed.
+             - *initial_clipboard* (Clipboard, default: None) -- if a
+               clipboard is given, the method will wait until the system
+               clipboard differs from the instance's contents.
+
+            Use with a Python 'with' block::
+
+               from dragonfly import Clipboard, Key
+
+               # Copy the selected text with Ctrl+C and wait until a system
+               #  clipboard change is detected.
+               timeout = 3
+               with Clipboard.synchronized_changes(timeout):
+                   Key("c-c", use_hardware=True).execute()
+
+               # Retrieve the system text.
+               text = Clipboard.get_system_text()
+
+        """
         # Save the current clipboard contents, if necessary.
         if initial_clipboard:
             initial_clipboard = cls(from_system=True)

--- a/dragonfly/windows/base_clipboard.py
+++ b/dragonfly/windows/base_clipboard.py
@@ -25,6 +25,7 @@ This file contains the base interface to the system clipboard.
 # pylint: disable=W0622
 # Suppress warnings about redefining the built-in 'format' function.
 
+import contextlib
 import functools
 import locale
 import logging
@@ -154,6 +155,20 @@ class BaseClipboard(object):
             # Failure. Try again after *step* seconds.
             time.sleep(step)
         return result
+
+    @classmethod
+    @contextlib.contextmanager
+    def synchronized_changes(cls, timeout, step=0.001, formats=None,
+                             initial_clipboard=None):
+        # Save the current clipboard contents, if necessary.
+        if initial_clipboard:
+            initial_clipboard = cls(from_system=True)
+        try:
+            # Yield for clipboard operations.
+            yield
+        finally:
+            # Wait for the system clipboard to change.
+            cls.wait_for_change(timeout, step, formats, initial_clipboard)
 
     #-----------------------------------------------------------------------
 

--- a/dragonfly/windows/base_clipboard.py
+++ b/dragonfly/windows/base_clipboard.py
@@ -25,6 +25,7 @@ This file contains the base interface to the system clipboard.
 # pylint: disable=W0622
 # Suppress warnings about redefining the built-in 'format' function.
 
+import functools
 import locale
 import logging
 import os
@@ -36,6 +37,7 @@ from six import text_type, binary_type
 #===========================================================================
 
 
+@functools.total_ordering
 class BaseClipboard(object):
     """
     Base clipboard class.
@@ -245,6 +247,21 @@ class BaseClipboard(object):
         if text is not None:
             text = self.convert_format_content(self.format_unicode, text)
             self._contents[self.format_unicode] = text
+
+    def __eq__(self, other):
+        formats = self.get_available_formats()
+        if formats != other.get_available_formats():
+            return False
+        for format in formats:
+            if self.get_format(format) != other.get_format(format):
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __lt__(self, other):
+        return not self == other
 
     def __repr__(self):
         arguments = []


### PR DESCRIPTION
CC @LexiconCode

This PR adds a `Clipboard.wait_for_change()` method and makes `Clipboard` instances comparable.

The `wait_for_change()` method is a blocking method which returns whether or not the system clipboard changed within a specified timeout period.

On Windows, this method compares clipboard sequence numbers.  On other platforms, it compares the clipboard contents.  Both of these implementations use polling.

It might be helpful to have an optional `formats` argument for this method. That way you can poll for changes to specific clipboard formats.