### PR TITLE
Make SR engine text-to-speech functionality more flexible

### DIFF
--- a/documentation/base_engine.txt
+++ b/documentation/base_engine.txt
@@ -10,8 +10,8 @@ Base engine classes
 EngineBase class
 ----------------------------------------------------------------------------
 
-The :class:`dragonfly.engines.engine_base.EngineBase` class forms the base
-class for this specific speech recognition engine classes.  It defines
+The :class:`dragonfly.engines.base.EngineBase` class forms the base
+class for the specific speech recognition engine classes.  It defines
 the stubs required and performs some of the logic necessary for
 Dragonfly to be able to interact with a speech recognition engine.
 

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -91,6 +91,7 @@ mock_modules = {
     "numpy",
     "pyperclip",
     "regex",
+    "natlink"
 }
 
 for module_name in mock_modules:

--- a/documentation/engines.txt
+++ b/documentation/engines.txt
@@ -8,6 +8,10 @@ Dragonfly supports multiple speech recognition engines as its backend.
 The *engines* sub-package implements the interface code for each
 supported engine.
 
+Also contained within this sub-package are a number of text-to-speech
+implementations.  These can be used independently of the speech recognition
+engines via the ``get_speaker()`` function.
+
 
 Main SR engine back-end interface
 ----------------------------------------------------------------------------
@@ -28,3 +32,14 @@ Engine back-ends
     kaldi_engine
     sphinx_engine
     text_engine
+
+Text-to-speech (speaker) back-ends
+----------------------------------------------------------------------------
+
+For more information on the available text-to-speech implementations, see
+the following sections:
+
+.. toctree::
+    :maxdepth: 2
+
+    speakers

--- a/dragonfly/__init__.py
+++ b/dragonfly/__init__.py
@@ -20,15 +20,15 @@
 
 import sys
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 from .config            import Config, Section, Item
 from .error             import DragonflyError, GrammarError
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 from .engines           import (get_engine, EngineError, MimicFailure,
-                                get_current_engine)
+                                get_current_engine, get_speaker)
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 from .grammar.grammar_base       import Grammar
 from .grammar.grammar_connection import ConnectionGrammar
 from .grammar.rule_base          import Rule
@@ -52,7 +52,7 @@ from .grammar.recobs_callbacks   import (CallbackRecognitionObserver,
                                          register_ending_callback,
                                          register_post_recognition_callback)
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 
 from .actions           import (ActionBase, DynStrActionBase, ActionError,
                                 Repeat, Key, Text, Mouse, Paste, Pause,
@@ -65,25 +65,25 @@ if sys.platform.startswith("win"):
     from .actions       import (KeyboardInput, MouseInput, HardwareInput,
                                 make_input_array, send_input_array)
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 
 if sys.platform.startswith("win"):
     from .windows.clipboard import Clipboard
 else:
     from .util              import Clipboard
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 
 from .windows.rectangle import Rectangle, unit
 from .windows.point     import Point
 from .windows           import Window, Monitor, monitors
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 from .language          import (Integer, IntegerRef, ShortIntegerRef,
                                 Digits, DigitsRef,
                                 Number, NumberRef)
 
-# --------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 from .accessibility     import (CursorPosition, TextQuery,
                                 get_accessibility_controller,
                                 get_stopping_accessibility_controller)

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -35,7 +35,7 @@ _speakers_by_name = {}
 
 _sapi5_names = ("sapi5shared", "sapi5inproc", "sapi5")
 _valid_engine_names = ("natlink", "kaldi", "sphinx", "text") + _sapi5_names
-_valid_speaker_names = ("natlink", "text") + _sapi5_names
+_valid_speaker_names = ("natlink", "text", "espeak", "flite") + _sapi5_names
 
 
 
@@ -286,6 +286,32 @@ def get_speaker(name=None):
                 speaker = NatlinkSpeaker()
         except Exception as e:
             message = ("Exception while initializing natlink speaker:"
+                       " %s" % (e,))
+            log.warning(message)
+            if name:
+                raise EngineError(message)
+
+    if not speaker and name in (None, "espeak"):
+        # Check if eSpeak is available.
+        try:
+            from .base.speaker_stdin import EspeakSpeaker
+            if EspeakSpeaker.is_available():
+                speaker = EspeakSpeaker()
+        except Exception as e:
+            message = ("Exception while initializing eSpeak speaker:"
+                       " %s" % (e,))
+            log.warning(message)
+            if name:
+                raise EngineError(message)
+
+    if not speaker and name in (None, "flite"):
+        # Check if CMU Flite is available.
+        try:
+            from .base.speaker_stdin import FliteSpeaker
+            if FliteSpeaker.is_available():
+                speaker = FliteSpeaker()
+        except Exception as e:
+            message = ("Exception while initializing Flite speaker:"
                        " %s" % (e,))
             log.warning(message)
             if name:

--- a/dragonfly/engines/__init__.py
+++ b/dragonfly/engines/__init__.py
@@ -248,7 +248,45 @@ def register_engine_init(engine):
 
 def get_speaker(name=None):
     """
-        Get the speaker (text-to-speech) implementation.
+        Get the text-to-speech (speaker) implementation.
+
+        This function will initialize and return a speaker instance instance
+        of the available speaker back-end.  If one has already been
+        initialized, it will be returned instead.
+
+        If no specific speaker back-end is requested and no speaker has
+        already been initialized, this function will initialize and return
+        an instance of the first available back-end in the following order:
+
+         =======================   =========================================
+         TTS speaker back-end      Speaker name string(s)
+         =======================   =========================================
+         1. SAPI 5                 ``"sapi5"``
+         2. Dragon/Natlink         ``"natlink"``
+         3. eSpeak                 ``"espeak"``
+         4. CMU Flite              ``"flite"``
+         5. Text (stdout)          ``"text"``
+         =======================   =========================================
+
+        The first two speaker back-ends are only available on Microsoft
+        Windows.  The second requires that Dragon NaturallySpeaking and
+        Natlink are installed on the system.
+
+        The third and fourth back-ends, eSpeak and CMU Flite, may be used on
+        most platforms.  These require that the appropriate command-line
+        programs are installed on the system.
+
+        The last back-end (text) is used as a fallback when no real speaker
+        implementation is available.  This back-end writes input text to
+        stdout, i.e., prints text to the console.
+
+        **Arguments**:
+
+        :param name: optional human-readable name of the speaker to return.
+        :type name: str
+        :rtype: SpeakerBase
+        :returns: speaker instance
+        :raises: EngineError
     """
     global _default_speaker, _speakers_by_name
     log = logging.getLogger("speaker")

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -30,6 +30,7 @@ from six                   import string_types, print_, reraise
 from six.moves             import zip
 from kaldi_active_grammar  import KaldiError, KaldiRule
 
+import dragonfly.engines
 from dragonfly.windows.window  import Window
 from dragonfly.engines.base    import (EngineBase,
                                        EngineError,
@@ -320,9 +321,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
 
     def speak(self, text):
         """ Speak the given *text* using text-to-speech. """
-        # FIXME
-        self._log.warning("Text-to-speech is not implemented for this engine; printing text instead.")
-        print_(text)
+        dragonfly.engines.get_speaker().speak(text)
 
     def _get_language(self):
         return "en"

--- a/dragonfly/engines/backend_natlink/engine.py
+++ b/dragonfly/engines/backend_natlink/engine.py
@@ -38,11 +38,12 @@ from datetime   import datetime
 from locale     import getpreferredencoding
 from threading  import Thread, Event
 
-from six import text_type, binary_type, string_types, PY2
+from six        import text_type, binary_type, string_types, PY2
 
 
 from dragonfly.engines.base  import (EngineBase, EngineError, MimicFailure,
                                     GrammarWrapperBase)
+from dragonfly.engines.backend_natlink.speaker    import NatlinkSpeaker
 from dragonfly.engines.backend_natlink.compiler   import NatlinkCompiler
 from dragonfly.engines.backend_natlink.dictation  import \
     NatlinkDictationContainer
@@ -140,6 +141,7 @@ class NatlinkEngine(EngineBase):
         self._timer_manager = NatlinkTimerManager(0.02, self)
         self._timer_thread = None
         self._retain_dir = None
+        self._speaker = NatlinkSpeaker()
         try:
             self.set_retain_directory(retain_dir)
         except EngineError as err:
@@ -351,16 +353,7 @@ class NatlinkEngine(EngineBase):
 
     def speak(self, text):
         """ Speak the given *text* using text-to-speech. """
-        # Store the current mic state.
-        mic_state = self.natlink.getMicState()
-
-        # Say the text.
-        self.natlink.execScript('TTSPlayString "%s"' % text)
-
-        # Restore the previous mic state if necessary.
-        # This is to have consistent behaviour for each version of Dragon.
-        if mic_state != self.natlink.getMicState():
-            self.natlink.setMicState(mic_state)
+        self._speaker.speak(text)
 
     def _get_language(self):
         # Get a Windows language identifier from Dragon.

--- a/dragonfly/engines/backend_natlink/speaker.py
+++ b/dragonfly/engines/backend_natlink/speaker.py
@@ -1,0 +1,50 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2021 by Dane Finlay
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+DNS and Natlink text-to-speech class
+============================================================================
+
+"""
+
+import natlink
+
+from dragonfly.engines.base.speaker import SpeakerBase
+
+#---------------------------------------------------------------------------
+
+class NatlinkSpeaker(SpeakerBase):
+
+    _name = "natlink"
+
+    def __init__(self):
+        self._register()
+
+    def speak(self, text):
+        # Store the current mic state.
+        mic_state = natlink.getMicState()
+
+        # Say the text.
+        natlink.execScript('TTSPlayString "%s"' % text)
+
+        # Restore the previous mic state if necessary.  This is done for
+        #  consistent behaviour for each supported version of DNS.
+        if mic_state != natlink.getMicState():
+            natlink.setMicState(mic_state)

--- a/dragonfly/engines/backend_natlink/speaker.py
+++ b/dragonfly/engines/backend_natlink/speaker.py
@@ -19,7 +19,7 @@
 #
 
 """
-DNS and Natlink text-to-speech class
+Natlink and DNS text-to-speech class
 ============================================================================
 
 """
@@ -31,6 +31,13 @@ from dragonfly.engines.base.speaker import SpeakerBase
 #---------------------------------------------------------------------------
 
 class NatlinkSpeaker(SpeakerBase):
+    """
+    This speaker class uses the text-to-speech functionality embedded into
+    Dragon NaturallySpeaking (DNS).
+
+    It is available only on Microsoft Windows and requires (DNS) and Natlink
+    to be installed on the system.
+    """
 
     _name = "natlink"
 

--- a/dragonfly/engines/backend_sapi5/engine.py
+++ b/dragonfly/engines/backend_sapi5/engine.py
@@ -49,6 +49,7 @@ from dragonfly.engines.base    import (EngineBase, EngineError,
                                        DelegateTimerManagerInterface,
                                        DictationContainerBase,
                                        GrammarWrapperBase)
+from dragonfly.engines.backend_sapi5.speaker   import Sapi5Speaker
 from dragonfly.engines.backend_sapi5.compiler  import Sapi5Compiler
 from dragonfly.engines.backend_sapi5.recobs    import Sapi5RecObsManager
 
@@ -110,9 +111,8 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
         EnsureDispatch(self.recognizer_dispatch_name)
         EnsureDispatch("SAPI.SpVoice")
         self._recognizer  = None
-        self._speaker     = None
         self._compiler    = None
-
+        self._speaker     = None
         self._recognition_observer_manager = Sapi5RecObsManager(self)
         self._timer_manager = DelegateTimerManager(0.02, self)
 
@@ -125,7 +125,7 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
     def connect(self):
         """ Connect to back-end SR engine. """
         self._recognizer  = Dispatch(self.recognizer_dispatch_name)
-        self._speaker     = Dispatch("SAPI.SpVoice")
+        self._speaker     = Sapi5Speaker()
         self._compiler    = Sapi5Compiler()
 
     def disconnect(self):
@@ -303,7 +303,7 @@ class Sapi5SharedEngine(EngineBase, DelegateTimerManagerInterface):
 
     def speak(self, text):
         """ Speak the given *text* using text-to-speech. """
-        self._speaker.Speak(text)
+        self._speaker.speak(text)
 
     def _get_language(self):
         if not self._recognizer:

--- a/dragonfly/engines/backend_sapi5/speaker.py
+++ b/dragonfly/engines/backend_sapi5/speaker.py
@@ -32,6 +32,13 @@ from dragonfly.engines.base.speaker import SpeakerBase
 #---------------------------------------------------------------------------
 
 class Sapi5Speaker(SpeakerBase):
+    """
+    This speaker class uses the SAPI 5 text-to-speech functionality.  It is
+    available on Microsoft Windows Vista and above.
+
+    It has no specific requirements other than the pywin32 library, which is
+    required to use Dragonfly on Microsoft Windows.
+    """
 
     _name = "sapi5"
 

--- a/dragonfly/engines/backend_sapi5/speaker.py
+++ b/dragonfly/engines/backend_sapi5/speaker.py
@@ -1,6 +1,6 @@
 #
 # This file is part of Dragonfly.
-# (c) Copyright 2007, 2008 by Christo Butcher
+# (c) Copyright 2021 by Dane Finlay
 # Licensed under the LGPL.
 #
 #   Dragonfly is free software: you can redistribute it and/or modify it
@@ -18,13 +18,27 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
+"""
+SAPI 5 text-to-speech class
+============================================================================
 
-from .engine           import EngineBase, EngineError, MimicFailure
-from .compiler         import CompilerBase, CompilerError
-from .dictation        import DictationContainerBase
-from .grammar_wrapper  import GrammarWrapperBase
-from .recobs           import RecObsManagerBase
-from .speaker          import SpeakerBase
-from .timer            import (TimerManagerBase, ThreadedTimerManager,
-                               DelegateTimerManager,
-                               DelegateTimerManagerInterface)
+"""
+
+from win32com.client            import Dispatch
+from win32com.client.gencache   import EnsureDispatch
+
+from dragonfly.engines.base.speaker import SpeakerBase
+
+#---------------------------------------------------------------------------
+
+class Sapi5Speaker(SpeakerBase):
+
+    _name = "sapi5"
+
+    def __init__(self):
+        EnsureDispatch("SAPI.SpVoice")
+        self._spvoice = Dispatch("SAPI.SpVoice")
+        self._register()
+
+    def speak(self, text):
+        self._spvoice.Speak(text)

--- a/dragonfly/engines/backend_sphinx/engine.py
+++ b/dragonfly/engines/backend_sphinx/engine.py
@@ -31,6 +31,7 @@ from six            import binary_type, text_type, string_types, PY2
 from jsgf           import RootGrammar, PublicRule, Literal
 from sphinxwrapper  import PocketSphinx
 
+import dragonfly.engines
 from dragonfly.windows.window                         import Window
 from dragonfly.engines.base                           import (EngineBase, EngineError, MimicFailure,
                                                               DelegateTimerManagerInterface,
@@ -1065,11 +1066,8 @@ class SphinxEngine(EngineBase, DelegateTimerManagerInterface):
                                    % phrase)
 
     def speak(self, text):
-        """"""
-        self._log.warning("text-to-speech is not implemented for this "
-                          "engine.")
-        self._log.warning("Printing text instead.")
-        print(text)
+        """ Speak the given *text* using text-to-speech. """
+        dragonfly.engines.get_speaker().speak(text)
 
     def _get_language(self):
         return self.config.LANGUAGE

--- a/dragonfly/engines/backend_text/engine.py
+++ b/dragonfly/engines/backend_text/engine.py
@@ -21,15 +21,16 @@
 import sys
 import time
 
-from six                                    import string_types
+from six                                     import string_types
 
-from dragonfly.engines.base                 import (EngineBase,
-                                                    MimicFailure,
-                                                    ThreadedTimerManager,
-                                                    DictationContainerBase,
-                                                    GrammarWrapperBase)
-from dragonfly.engines.backend_text.recobs  import TextRecobsManager
-from dragonfly.windows.window               import Window
+import dragonfly.engines
+from dragonfly.engines.base                  import (EngineBase,
+                                                     MimicFailure,
+                                                     ThreadedTimerManager,
+                                                     DictationContainerBase,
+                                                     GrammarWrapperBase)
+from dragonfly.engines.backend_text.recobs   import TextRecobsManager
+from dragonfly.windows.window                import Window
 
 
 class TextInputEngine(EngineBase):
@@ -228,10 +229,8 @@ class TextInputEngine(EngineBase):
                                % (words,))
 
     def speak(self, text):
-        self._log.warning("text-to-speech is not implemented for this "
-                          "engine.")
-        self._log.warning("Printing text instead.")
-        print(text)
+        """ Speak the given *text* using text-to-speech. """
+        dragonfly.engines.get_speaker().speak(text)
 
     @property
     def language(self):

--- a/dragonfly/engines/backend_text/speaker.py
+++ b/dragonfly/engines/backend_text/speaker.py
@@ -29,7 +29,11 @@ from dragonfly.engines.base.speaker import SpeakerBase
 #---------------------------------------------------------------------------
 
 class TextSpeaker(SpeakerBase):
-    """ Speaker class that prints specified text to *stdout*. """
+    """
+    This speaker class is used as a fallback when no real speaker
+    implementation is available.  Specified text is written to *stdout*,
+    i.e., it is printed to the console.
+    """
 
     _name = "text"
 

--- a/dragonfly/engines/backend_text/speaker.py
+++ b/dragonfly/engines/backend_text/speaker.py
@@ -1,0 +1,42 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2022 by Dane Finlay
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+TextSpeaker class
+============================================================================
+
+"""
+
+from dragonfly.engines.base.speaker import SpeakerBase
+
+#---------------------------------------------------------------------------
+
+class TextSpeaker(SpeakerBase):
+    """ Speaker class that prints specified text to *stdout*. """
+
+    _name = "text"
+
+    def __init__(self):
+        self._register()
+
+    def speak(self, text):
+        self._log.warning("No text-to-speech is available, printing"
+                          " specified text.")
+        print(text)

--- a/dragonfly/engines/base/speaker.py
+++ b/dragonfly/engines/base/speaker.py
@@ -1,0 +1,50 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2021 by Dane Finlay
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+SpeakerBase class
+============================================================================
+
+"""
+
+import logging
+
+import dragonfly.engines
+
+#---------------------------------------------------------------------------
+
+class SpeakerBase(object):
+    """ Base Speaker class for text-to-speech back-ends. """
+
+    _log = logging.getLogger("speaker")
+    _name = "base"
+
+    def _register(self):
+        # Register initialization of this speaker.
+        dragonfly.engines.register_speaker_init(self)
+
+    @property
+    def name(self):
+        """ The human-readable name of this engine. """
+        return self._name
+
+    def speak(self, text):
+        """ Speak the given *text* using text-to-speech. """
+        raise NotImplementedError("Virtual method not implemented.")

--- a/dragonfly/engines/base/speaker.py
+++ b/dragonfly/engines/base/speaker.py
@@ -42,7 +42,7 @@ class SpeakerBase(object):
 
     @property
     def name(self):
-        """ The human-readable name of this engine. """
+        """ The human-readable name of this speaker. """
         return self._name
 
     def speak(self, text):

--- a/dragonfly/engines/base/speaker_stdin.py
+++ b/dragonfly/engines/base/speaker_stdin.py
@@ -1,0 +1,113 @@
+#
+# This file is part of Dragonfly.
+# (c) Copyright 2022 by Dane Finlay
+# Licensed under the LGPL.
+#
+#   Dragonfly is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU Lesser General Public License as published
+#   by the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   Dragonfly is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with Dragonfly.  If not, see
+#   <http://www.gnu.org/licenses/>.
+#
+
+"""
+eSpeakSpeaker and FliteSpeaker classes
+============================================================================
+
+"""
+
+from __future__                      import print_function
+
+from locale                          import getpreferredencoding
+from subprocess                      import Popen, PIPE
+import sys
+
+from six                             import text_type, binary_type
+
+from dragonfly.engines.base.speaker  import SpeakerBase
+
+#---------------------------------------------------------------------------
+
+class StdinSpeakerBase(SpeakerBase):
+
+    _read_stdin_command = []
+
+    @classmethod
+    def is_available(cls):
+        raise NotImplementedError("Virtual method not implemented.")
+
+    def speak(self, text):
+        if len(self._read_stdin_command) == 0:
+            raise NotImplementedError("Virtual method not implemented.")
+
+        # Encode input, if necessary.
+        encoding = getpreferredencoding()
+        if isinstance(text, text_type):
+            text = text.encode(encoding)
+
+        # Speak *text* using the specified command.
+        p = Popen(self._read_stdin_command, stdout=PIPE, stdin=PIPE,
+                  stderr=PIPE)
+        stdout, stderr = p.communicate(input=text)
+        returncode = p.wait()
+
+        # Decode output if it is binary.
+        if isinstance(stdout, binary_type): stdout = stdout.decode(encoding)
+        if isinstance(stderr, binary_type): stderr = stderr.decode(encoding)
+        if stdout: print(stdout)
+        if stderr: print(stderr, file=sys.stderr)
+
+        # Handle non-zero return codes.
+        if returncode != 0:
+            raise RuntimeError("%s exited with non-zero return code %d"
+                               % (self.name, p.returncode))
+
+
+#---------------------------------------------------------------------------
+
+class EspeakSpeaker(StdinSpeakerBase):
+
+    _name = "espeak"
+    _read_stdin_command = ["espeak", "--stdin"]
+
+    @classmethod
+    def is_available(cls):
+        # Check whether the *espeak* command-line program is available.
+        try:
+            p = Popen(["espeak", "--version"], stdout=PIPE, stderr=PIPE)
+            p.communicate()
+            return p.wait() == 0
+        except OSError:
+            return False
+
+    def __init__(self):
+        self._register()
+
+
+#---------------------------------------------------------------------------
+
+class FliteSpeaker(StdinSpeakerBase):
+
+    _name = "flite"
+    _read_stdin_command = ["flite"]
+
+    @classmethod
+    def is_available(cls):
+        # Check whether the *flite* command-line program is available.
+        try:
+            p = Popen(["flite", "--version"], stdout=PIPE, stderr=PIPE)
+            p.communicate()
+            return p.wait() == 1
+        except OSError:
+            return False
+
+    def __init__(self):
+        self._register()

--- a/dragonfly/engines/base/speaker_stdin.py
+++ b/dragonfly/engines/base/speaker_stdin.py
@@ -19,7 +19,7 @@
 #
 
 """
-eSpeakSpeaker and FliteSpeaker classes
+Stdin Speaker classes
 ============================================================================
 
 """
@@ -45,6 +45,7 @@ class StdinSpeakerBase(SpeakerBase):
         raise NotImplementedError("Virtual method not implemented.")
 
     def speak(self, text):
+        """ Speak the given *text* using text-to-speech. """
         if len(self._read_stdin_command) == 0:
             raise NotImplementedError("Virtual method not implemented.")
 
@@ -74,6 +75,12 @@ class StdinSpeakerBase(SpeakerBase):
 #---------------------------------------------------------------------------
 
 class EspeakSpeaker(StdinSpeakerBase):
+    """
+    This speaker class uses eSpeak to synthesize specified text into speech.
+
+    The ``espeak`` command-line program must be installed in order to use
+    this implementation.  eSpeak is available on most platforms.
+    """
 
     _name = "espeak"
     _read_stdin_command = ["espeak", "--stdin"]
@@ -95,6 +102,13 @@ class EspeakSpeaker(StdinSpeakerBase):
 #---------------------------------------------------------------------------
 
 class FliteSpeaker(StdinSpeakerBase):
+    """
+    This speaker class uses CMU Flite to synthesize specified text into
+    speech.
+
+    The ``flite`` command-line program must be installed in order to use
+    this implementation.  CMU Flite is available on most platforms.
+    """
 
     _name = "flite"
     _read_stdin_command = ["flite"]

--- a/dragonfly/log.py
+++ b/dragonfly/log.py
@@ -72,6 +72,7 @@ default_levels = {
                   "engine":               (_info, _info),
                   "engine.compiler":      (_warning, _info),
                   "engine.timer":         (_warning, _info),
+                  "speaker":              (_info, _info),
                   "grammar":              (_warning, _critical),
                   "grammar.load":         (_warning, _info),
                   "grammar.begin":        (_info, _info),


### PR DESCRIPTION
The code has been moved into `Speaker` classes as part of an effort to allow more flexible use of the (limited) text-to-speech
functionality.  The `speak()` methods of these engine classes have been adjusted accordingly.

@comodoro This is a start on the decoupling of Dragonfly's text-to-speech functionality. We spoke about this on the dragonfly gitter channel a little while back.

I still have to adjust the base engine code to utilise SAPI 5 on Windows, if it is available. I will probably use a design similar to `get_engine()`. It would be nice to have a `Speaker` class that works on Linux, but that could be implemented later.

I would also like to add an option for asynchronous playback, similar to what the Windows [`PlaySound()`](https://docs.microsoft.com/en-us/previous-versions//dd743680(v=vs.85)) function flags allow, as well as a `Speak` action class.