### PR TITLE
Change the project Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,102 +1,30 @@
-Code of Conduct
-===============
+Contributor Code of Conduct
+===========================
 
--  We are committed to providing a friendly, safe and welcoming environment
-   for all, regardless of level of experience, gender identity and
-   expression, sexual orientation, disability, personal appearance, body
-   size, race, ethnicity, age, religion, nationality, or other similar
-   characteristic.
--  Please avoid using overtly sexual aliases or other nicknames that might
-   detract from a friendly, safe and welcoming environment for all.
--  Please be kind and courteous. There’s no need to be mean or rude.
--  Respect that people have differences of opinion and that every design or
-   implementation choice carries a trade-off and numerous costs. There is
-   seldom a right answer.
--  Please keep unstructured critique to a minimum. If you have solid ideas
-   you want to experiment with, make a fork and see how it works.
--  We will exclude you from interaction if you insult, demean or harass
-   anyone. That is not welcome behavior. We interpret the term “harassment”
-   as including the definition in the `Citizen Code of Conduct`_; if you
-   have any lack of clarity about what might be included in that concept,
-   please read their definition. In particular, we don’t tolerate behavior
-   that excludes people in socially marginalized groups.
--  Private harassment is also unacceptable. No matter who you are, if you
-   feel you have been or are being harassed or made uncomfortable by a
-   community member, please contact one of the channel ops or any of the
-   Dragonfly moderation team immediately. Whether you’re a regular
-   contributor or a newcomer, we care about making this community a safe
-   place for you and we’ve got your back.
--  Likewise any spamming, trolling, flaming, baiting or other
-   attention-stealing behavior is not welcome.
+As contributors and maintainers of the Dragonfly project, we pledge to
+respect everyone who contributes by posting issues, updating
+documentation, submitting pull requests, providing feedback in comments,
+and any other activities.
 
-Email a member of the Moderation Team:
+Communication through any of Dragonfly’s channels (GitHub, Discord,
+Gitter, mailing lists, etc.) must be constructive and never resort to
+personal attacks, trolling, public or private harassment, insults, or
+other unprofessional conduct.
 
-- `@Danesprite <mailto:Danesprite@posteo.net>`__
-- `@LexiconCode <mailto:CasterVoice@protonmail.com>`__
+We promise to extend courtesy and respect to everyone involved in this
+project regardless of gender, gender identity, sexual orientation,
+disability, age, race, ethnicity, religion, or level of experience. We
+expect anyone contributing to the Dragonfly project to do the same.
 
-Moderation
-----------
+If any member of the community violates this code of conduct, the
+maintainers of the Dragonfly project may take action, removing issues,
+comments, and PRs or blocking accounts as deemed appropriate.
 
-These are the policies for upholding our community’s standards of conduct.
-If you feel that a thread needs moderation, please contact the Dragonfly
-moderation team.
+If you are subject to or witness unacceptable behavior, or have any
+other concerns, please email the project maintainer at
+Danesprite@posteo.net.
 
-1. Remarks that violate the Dragonfly standards of conduct, including
-   hateful, hurtful, oppressive, or exclusionary remarks, are not allowed.
-   (Cursing is allowed, but never targeting another user, and never in a
-   hateful manner.)
-2. Remarks that moderators find inappropriate, whether listed in the code of
-   conduct or not, are also not allowed.
-3. Moderators will first respond to such remarks with a warning, at the same
-   time the offending content will likely be removed whenever possible.
-4. If the warning is unheeded, the user will be “kicked,” i.e., kicked out
-   of the communication channel to cool off.
-5. If the user comes back and continues to make trouble, they will be
-   banned, i.e., indefinitely excluded.
-6. Moderators may choose at their discretion to un-ban the user if it was a
-   first offense and they offer the offended party a genuine apology.
-7. If a moderator bans someone and you think it was unjustified, please take
-   it up with that moderator, or with a different moderator, in private.
-   Complaints about bans in-channel are not allowed.
-8. Moderators are held to a higher standard than other community members. If
-   a moderator creates an inappropriate situation, they should expect less
-   leeway than others.
-
-In the Dragonfly community we strive to go the extra step to look out for
-each other. Don’t just aim to be technically unimpeachable, try to be your
-best self. In particular, avoid flirting with offensive or sensitive issues,
-particularly if they’re off-topic; this all too often leads to unnecessary
-fights, hurt feelings, and damaged trust; worse, it can drive people away
-from the community entirely.
-
-And if someone takes issue with something you said or did, resist the urge
-to be defensive. Just stop doing what it was they complained about and
-apologize. Even if you feel you were misinterpreted or unfairly accused,
-chances are good there was something you could’ve communicated better —
-remember that it’s your responsibility to make others comfortable. Everyone
-wants to get along and we are all here first and foremost because we want to
-talk about cool technology. You will find that people will be eager to
-assume good intent and forgive as long as you earn their trust.
-
-The enforcement policies listed above apply to all official Dragonfly
-venues; including the GitHub `dictation-toolbox/dragonfly repository`_; the
-`Gitter channel`_; and the `Matrix channel`_.
-For other projects adopting the Rust Code of Conduct, please contact the
-maintainers of those projects for enforcement. If you wish to use this code
-of conduct for your own project, consider explicitly mentioning your
-moderation policy or making a copy with your own moderation policy so as to
-avoid confusion.
-
-Adapted from the `Rust`_ and `Lemmy`_ codes of conduct, which are based on
-the `Node.js Policy on Trolling`_ as well as the `Contributor Covenant
-v1.3.0`_.
-
-.. Links.
-.. _Citizen Code of Conduct: http://citizencodeofconduct.org/
-.. _Contributor Covenant v1.3.0: https://www.contributor-covenant.org/version/1/3/0/
-.. _Gitter channel: https://gitter.im/dictation-toolbox/dragonfly
-.. _Lemmy: https://github.com/LemmyNet/lemmy/blob/master/CODE_OF_CONDUCT.md
-.. _Matrix channel: https://riot.im/app/#/room/#dragonfly2:matrix.org
-.. _Node.js Policy on Trolling: http://blog.izs.me/post/30036893703/policy-on-trolling
-.. _Rust: https://www.rust-lang.org/policies/code-of-conduct
-.. _dictation-toolbox/dragonfly repository: https://github.com/dictation-toolbox/dragonfly
+This *Contributor Code of Conduct* has been adapted from
+`Angular's Contributor Code of Conduct
+<https://github.com/angular/angular/blob/master/CODE_OF_CONDUCT.md>`__
+(Version 0.3b-angular).


### PR DESCRIPTION
CC @LexiconCode

This changes the project Code of Conduct, added in PR #260, to a new one based on [Angular's](https://github.com/angular/angular/blob/master/CODE_OF_CONDUCT.md). Attribution and a hyperlink to the original document are included at the end.

The new Code of Conduct is functionally the same, without language that, in my opinion, adds nothing and, in fact, somewhat explicitly conflates symptoms of larger societal issues with character flaws to be expunged from communities. It also seems to me that much of the language of the document that this PR replaces suggests that, if and when these problems arise, reasonable debate, e.g. the [Socratic method](https://en.wikipedia.org/wiki/Socratic_method), is always unlikely to yield results. I don't believe that these were the intentions of the original author(s) or others who use this or similar Codes of Conduct. Nevertheless, I feel obliged to state my reasoning here.

I am not at all against a Code of Conduct to formalise things like decent etiquette and keeping discussion on topic. This would be quite normal and is standard practice in many organisations and communities. I believe that the new Code better achieves this aim, does so succinctly and without reading like a political manifesto.