### PR TITLE
Change introductory descriptions of Kaldi and Sphinx engines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Dragonfly currently supports the following speech recognition engines:
    similar editions of *Dragon* are supported. Other editions may work too
 -  *Windows Speech Recognition* (WSR), included with Microsoft Windows
    Vista, Windows 7+, and freely available for Windows XP
--  *Kaldi* (under development)
--  *CMU Pocket Sphinx* (with caveats)
+-  *Kaldi*, open source and multi-platform.
+-  *CMU Pocket Sphinx*, open source and multi-platform.
 
 Documentation and FAQ
 ----------------------------------------------------------------------------

--- a/documentation/index.txt
+++ b/documentation/index.txt
@@ -30,8 +30,9 @@ Dragonfly currently supports the following speech recognition engines:
    work too
  - :ref:`Windows Speech Recognition <RefSapi5Engine>` (WSR), included with
    Microsoft Windows Vista, Windows 7+, and freely available for Windows XP
- - :ref:`Kaldi <RefKaldiEngine>` (under development)
- - :ref:`CMU Pocket Sphinx <RefSphinxEngine>` (with caveats)
+ - :ref:`Kaldi <RefKaldiEngine>`, open source and multi-platform.
+ - :ref:`CMU Pocket Sphinx <RefSphinxEngine>`, open source and multi-
+   platform.
 
 Dragonfly's documentation is available online at
 `Read the Docs <http://dragonfly2.readthedocs.org/en/latest/>`_.


### PR DESCRIPTION
The descriptions for both back-ends in the README and in the index of the documentation now read "open source and multi-platform".

@daanzu I think this is better. Does this look good to you?