### PR TITLE
Disable Kaldi debug logging workaround for Windows Key action bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
 
 Changed
 ~~~~~~~
+* Disable Kaldi debug logging workaround for Windows Key action bug.
 * Make Clipboard class instances comparable based on content difference.
 
 Fixed

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -96,13 +96,6 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
             if not os.environ.get('DRAGONFLY_DEVELOP'):
                 raise EngineError("Incompatible kaldi_active_grammar version")
 
-        # Hack to avoid bug processing keyboard actions on Windows
-        if os.name == 'nt':
-            action_exec_logger = logging.getLogger('action.exec')
-            if action_exec_logger.getEffectiveLevel() > logging.DEBUG:
-                self._log.warning("%s: Enabling logging of actions execution to avoid bug processing keyboard actions on Windows", self)
-                action_exec_logger.setLevel(logging.DEBUG)
-
         # Handle engine parameters
         if input_device_index is not None:
             if audio_input_device is not None:
@@ -218,6 +211,16 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
     @staticmethod
     def print_mic_list():
         MicAudio.print_list()
+
+    def _apply_win32_kb_input_logging_fix(self):
+        # Hack to avoid bug processing keyboard actions on Windows
+        if os.name == 'nt':
+            action_exec_logger = logging.getLogger('action.exec')
+            if action_exec_logger.getEffectiveLevel() > logging.DEBUG:
+                self._log.warning("%s: Enabling logging of actions "
+                                  "execution to avoid bug processing "
+                                  "keyboard actions on Windows", self)
+                action_exec_logger.setLevel(logging.DEBUG)
 
     #-----------------------------------------------------------------------
     # Methods for working with grammars.


### PR DESCRIPTION
Re: #182.

This disables the logging workaround for a bug that has previously occurred on Windows using the Kaldi engine back-end.  I have reason to believe the bug no longer occurs, so the verbose debug logging can be disabled.

If I am mistaken in this, then the workaround may be enabled by calling the `KaldiEngine._apply_win32_kb_input_logging_fix()` method.