### PR TITLE
Cleanup keyboard code

### DIFF
--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -118,7 +118,6 @@ Text class reference
 """
 
 from locale import getpreferredencoding
-import sys
 
 from six import binary_type
 
@@ -127,9 +126,9 @@ from ..util.clipboard import Clipboard
 from .action_base import ActionError
 from .action_base_keyboard import BaseKeyboardAction
 from .action_key import Key
-from .typeables import typeables
 
-# ---------------------------------------------------------------------------
+#---------------------------------------------------------------------------
+
 
 class Text(BaseKeyboardAction):
     """
@@ -154,32 +153,18 @@ class Text(BaseKeyboardAction):
        keys.
     """
 
-    class Events(object):
-        def __init__(self,
-                     hardware_events,
-                     hardware_error_message,
-                     unicode_events,
-                     unicode_error_message):
-            self.hardware_events = hardware_events
-            self.hardware_error_message = hardware_error_message
-            self.unicode_events = unicode_events
-            self.unicode_error_message = unicode_error_message
-
     _specials = {
-        "\n": typeables["enter"],
-        "\t": typeables["tab"],
+        "\n": "enter",
+        "\t": "tab",
     }
 
     def __init__(self, spec=None, static=False, pause=None,
                  autofmt=False, use_hardware=False):
-        # Use the default pause time if pause in None.
-        # Use the class's _pause_default value so that Text sub-classes can
-        # easily override it.
+        # Use the default pause time if pause is None.
         self._pause = self._pause_default if pause is None else pause
 
         # Set other members and call the super constructor.
         self._autofmt = autofmt
-        self._on_windows = sys.platform.startswith("win")
 
         if isinstance(spec, binary_type):
             spec = spec.decode(getpreferredencoding())
@@ -189,40 +174,18 @@ class Text(BaseKeyboardAction):
 
     def _parse_spec(self, spec):
         """Convert the given *spec* to keyboard events."""
-        hardware_events = []
-        unicode_events = []
-        hardware_error_message = None
-        unicode_error_message = None
-
+        key_symbols = []
         for character in spec:
+            # The character is the key symbol, except in special cases.
             if character in self._specials:
-                typeable = self._specials[character]
-                hardware_events.extend(typeable.events(self._pause))
-                unicode_events.extend(typeable.events(self._pause))
+                key_symbol = self._specials[character]
             else:
-                # Add hardware events.
-                try:
-                    typeable = self._keyboard.get_typeable(character)
-                    hardware_events.extend(typeable.events(self._pause))
-                except ValueError:
-                    hardware_error_message = ("Keyboard interface cannot type this"
-                                              " character: %r (in %r)"
-                                              % (character, spec))
+                key_symbol = character
 
-                # Calculate and add Unicode events only if necessary.
-                if not self._on_windows or self._use_hardware:
-                    continue
+            # Add the key symbol to the list.
+            key_symbols.append(key_symbol)
 
-                try:
-                    typeable = self._keyboard.get_typeable(character,
-                                                           is_text=True)
-                    unicode_events.extend(typeable.events(self._pause * 0.5))
-                except ValueError:
-                    unicode_error_message = ("Keyboard interface cannot type "
-                                             "this character: %r (in %r)" %
-                                             (character, spec))
-        return self.Events(hardware_events, hardware_error_message,
-                           unicode_events, unicode_error_message)
+        return key_symbols
 
     def _execute_events(self, events):
         """
@@ -262,17 +225,24 @@ class Text(BaseKeyboardAction):
             suffix = word[index + 4:]
             events = self._parse_spec(prefix + text + suffix)
 
+        # Calculate keyboard events.
+        use_hardware = self.require_hardware_events()
+        keyboard_events = []
+        for key_symbol in events:
+            # Get a Typeable object for each key symbol, if possible.
+            typeable = self._get_typeable(key_symbol, use_hardware)
+
+            # Raise an error message if a Typeable could not be retrieved.
+            if typeable is None:
+                error_message = ("Keyboard interface cannot type this"
+                                 " character: %r" % key_symbol)
+                raise ActionError(error_message)
+
+            # Get keyboard events using the Typeable.
+            keyboard_events.extend(typeable.events(self._pause))
+
         # Send keyboard events.
-        if self.require_hardware_events():
-            error_message = events.hardware_error_message
-            keyboard_events = events.hardware_events
-        else:
-            error_message = events.unicode_error_message
-            keyboard_events = events.unicode_events
-        if error_message:
-            raise ActionError(error_message)
-        else:
-            self._keyboard.send_keyboard_events(keyboard_events)
+        self._keyboard.send_keyboard_events(keyboard_events)
         return True
 
     def __str__(self):

--- a/dragonfly/actions/action_text.py
+++ b/dragonfly/actions/action_text.py
@@ -160,17 +160,13 @@ class Text(BaseKeyboardAction):
 
     def __init__(self, spec=None, static=False, pause=None,
                  autofmt=False, use_hardware=False):
-        # Use the default pause time if pause is None.
-        self._pause = self._pause_default if pause is None else pause
-
-        # Set other members and call the super constructor.
-        self._autofmt = autofmt
-
         if isinstance(spec, binary_type):
             spec = spec.decode(getpreferredencoding())
-
         BaseKeyboardAction.__init__(self, spec=spec, static=static,
                                     use_hardware=use_hardware)
+        # Set other members.
+        self._autofmt = autofmt
+        self._pause = self._pause_default if pause is None else pause
 
     def _parse_spec(self, spec):
         """Convert the given *spec* to keyboard events."""

--- a/dragonfly/actions/keyboard/__init__.py
+++ b/dragonfly/actions/keyboard/__init__.py
@@ -19,8 +19,7 @@
 #
 
 """
-This module initializes the correct keyboard interface for the current
-platform.
+This module initializes the keyboard interface for the current platform.
 """
 
 import os
@@ -28,35 +27,43 @@ import sys
 
 # TODO Implement classes for Wayland (XDG_SESSION_TYPE == "wayland").
 
-# Import the Keyboard, KeySymbols and Typeable classes for the current
-# platform. Always use the base classes for building documentation.
-doc_build = bool(os.environ.get("SPHINX_BUILD_RUNNING"))
-if sys.platform.startswith("win") and not doc_build:
-    # Import classes for Windows.
-    from ._win32 import Keyboard, Typeable, Win32KeySymbols as KeySymbols
+if sys.platform.startswith("win"):
+    # Import Win32 classes.
+    from ._win32 import (
+        Win32Keyboard as Keyboard,
+        Win32Typeable as Typeable,
+        Win32KeySymbols as KeySymbols
+    )
 
-elif sys.platform == "darwin" and not doc_build:
-    # Import classes for Mac OS.
-    from ._pynput import Keyboard, Typeable, DarwinKeySymbols as KeySymbols
+elif sys.platform == "darwin":
+    from ._pynput import (
+        PynputKeyboard as Keyboard,
+        PynputTypeable as Typeable,
+        DarwinKeySymbols as KeySymbols)
 
-elif os.environ.get("XDG_SESSION_TYPE") == "x11" and not doc_build:
-    # Import classes for X11 (typically used on Linux systems).
+elif os.environ.get("XDG_SESSION_TYPE") == "x11":
+    # Import classes for X11.  This is typically used on Unix-like systems.
     # The XDG_SESSION_TYPE environment variable may not be set in some
-    # circumstances, in which case it can be set manually in ~/.profile.
-    from ._x11_base import Typeable, XdoKeySymbols as KeySymbols
+    #  circumstances, in which case it can be set manually in ~/.profile.
+    from ._x11_base import (
+        X11Typeable as Typeable,
+        XdoKeySymbols as KeySymbols
+    )
 
     # Import the keyboard for typing through xdotool.
     from ._x11_xdotool import XdotoolKeyboard as Keyboard
 
-    # libxdo does work and is a bit faster, but doesn't work with Python 3.
-    # Unfortunately python-libxdo also hasn't been updated recently.
+    # The libxdo implementation doesn't work with Python 3, so it is not
+    #  used.
     # from ._x11_libxdo import LibxdoKeyboard as Keyboard
 
 else:
     # No keyboard implementation is available. Dragonfly can function
-    # without a keyboard class, so don't raise an error or log any
-    # messages. Errors/messages will occur later if the keyboard is used.
-    from ._base import (BaseKeyboard as Keyboard, Typeable,
+    #  without a keyboard class, so don't raise an error or log any
+    #  messages.  Error messages will occur later if and when keyboard
+    #  events are sent.
+    from ._base import (BaseKeyboard as Keyboard,
+                        BaseTypeable as Typeable,
                         MockKeySymbols as KeySymbols)
 
 # Initialize a Keyboard instance.

--- a/dragonfly/actions/keyboard/_base.py
+++ b/dragonfly/actions/keyboard/_base.py
@@ -18,48 +18,53 @@
 #   <http://www.gnu.org/licenses/>.
 #
 
-""" This file defines the base keyboard interface and Typeables class. """
+""" This file defines the base keyboard interface classes. """
+
+import logging
 
 
-class MockKeySymbols(object):
+class BaseKeySymbols(object):
+    pass
+
+
+class MockKeySymbols(BaseKeySymbols):
     def __getattribute__(self, _):
-        # Always return -1 because no keys can be typed.
+        # No keys can be typed, so return -1.
         return -1
 
 
 class BaseKeyboard(object):
     """ Base keyboard interface. """
 
+    _log = logging.getLogger("keyboard")
+
     @classmethod
     def send_keyboard_events(cls, events):
         """ Send a sequence of keyboard events. """
+        # TODO Add a URL to the docs?
         raise NotImplementedError("Keyboard support is not implemented for "
                                   "this platform or your platform was not "
-                                  "detected correctly. On Linux, the "
-                                  "XDG_SESSION_TYPE environment variable may "
-                                  "not be set correctly in some circumstances, "
-                                  "in which case it can be set manually in "
-                                  "~/.profile.")
+                                  "detected correctly.  Please see the "
+                                  "documentation.")
 
     @classmethod
     def get_typeable(cls, char, is_text=False):
         """ Get a Typeable object. """
-        return Typeable(cls, char, is_text=is_text)
+        return BaseTypeable(cls, char)
 
 
-class Typeable(object):
+class BaseTypeable(object):
     """Container for keypress events."""
 
     __slots__ = ("_code", "_modifiers", "_name", "_is_text")
+
+    _log = logging.getLogger("keyboard")
 
     def __init__(self, code, modifiers=(), name=None, is_text=False):
         """Set keypress information."""
         self._code = code
         self._modifiers = modifiers
         self._name = name
-
-        # Only used on Windows, but kept here for argument compatibility
-        # between platforms.
         self._is_text = is_text
 
     # pylint: disable=no-self-use,unused-argument
@@ -73,7 +78,7 @@ class Typeable(object):
         return True
 
     def __repr__(self):
-        """Return information useful for debugging."""
+        """ Return information useful for debugging. """
         return ("%s(%s)" % (self.__class__.__name__, self._name) +
                 repr(self.events()))
 

--- a/dragonfly/actions/keyboard/_x11_base.py
+++ b/dragonfly/actions/keyboard/_x11_base.py
@@ -1,4 +1,4 @@
-# This file is part of Aenea
+# This file was part of Aenea
 #
 # Aenea is free software: you can redistribute it and/or modify it under
 # the terms of version 3 of the GNU Lesser General Public License as
@@ -21,8 +21,8 @@
 
 from locale import getpreferredencoding
 
-from six import PY2
-from ._base import BaseKeyboard, Typeable
+from six import binary_type
+from ._base import BaseKeyboard, BaseTypeable, BaseKeySymbols
 
 
 KEY_TRANSLATION = {
@@ -85,7 +85,13 @@ def _update_key_translation(translation):
     for char in letters + digits:
         translation[chr(char)] = chr(char)
         translation[chr(char).upper()] = chr(char).upper()
+
+
 _update_key_translation(KEY_TRANSLATION)
+
+
+class X11Typeable(BaseTypeable):
+    pass
 
 
 class BaseX11Keyboard(BaseKeyboard):
@@ -94,16 +100,16 @@ class BaseX11Keyboard(BaseKeyboard):
     @classmethod
     def get_typeable(cls, char, is_text=False):
         """ Get a Typeable object. """
-        # Get a key translation if one exists. Otherwise use the character
-        # as the key name.
+        # Get a key translation if one exists.  Otherwise use the character
+        #  as the key name.
         key = KEY_TRANSLATION.get(char, char)
-        if PY2 and isinstance(key, str):
+        if isinstance(key, binary_type):
             key = key.decode(getpreferredencoding())
 
         # Convert single character keys to their Unicode code points.
-        # This allows typing any Unicode character with the Text and Key
-        # actions. It works with both X11 keyboard implementations.
-        if not is_text and len(key) == 1:
+        #  This allows typing any Unicode character with the Text and Key
+        #  actions.  It works with both X11 keyboard implementations.
+        if len(key) == 1:
             # Get the Unicode code point for the character.
             encoding = getpreferredencoding()
             code_point = key.encode("unicode_escape")[2:].decode(encoding)
@@ -114,10 +120,10 @@ class BaseX11Keyboard(BaseKeyboard):
 
             # Create a key name that xdotool will accept (e.g. U20AC).
             key = 'U' + code_point.upper()
-        return Typeable(code=key, name=char, is_text=is_text)
+        return X11Typeable(code=key, name=char, is_text=is_text)
 
 
-class XdoKeySymbols(object):
+class XdoKeySymbols(BaseKeySymbols):
     """ Key symbols for libxdo. """
 
     # Whitespace and editing keys

--- a/dragonfly/actions/keyboard/_x11_libxdo.py
+++ b/dragonfly/actions/keyboard/_x11_libxdo.py
@@ -1,4 +1,4 @@
-# This file is part of Aenea
+# This file was part of Aenea
 #
 # Aenea is free software: you can redistribute it and/or modify it under
 # the terms of version 3 of the GNU Lesser General Public License as

--- a/dragonfly/actions/keyboard/_x11_xdotool.py
+++ b/dragonfly/actions/keyboard/_x11_xdotool.py
@@ -1,4 +1,4 @@
-# This file is part of Aenea
+# This file was part of Aenea
 #
 # Aenea is free software: you can redistribute it and/or modify it under
 # the terms of version 3 of the GNU Lesser General Public License as


### PR DESCRIPTION
This PR cleans up the keyboard code a little and fixes some bugs.

Summary:
- Change the Key and Text action classes to calculate keyboard
  events at execution time instead of initialization time.
- Fix a regression with keyboard input actions on Windows.
  This restores the list of extended keys removed from sendinput.py in PR 343.  If the specified virtual-key is in this list, e.g. the insert key, then the KEYEVENTF_EXTENDEDKEY flag is used.
- Fix a bug with Text action default pause values.
  This change fixes a bug where the PAUSE_DEFAULT setting in the Windows-only settings.cfg file is not used properly by Text actions.
- Fix numerous code style issues.
- Remove doc build conditionals from keyboard/__init__.py.
  These should be removed from other files too.  I plan to do that as part of a more general clean up of the platform code.