### PR TITLE
Make mention of AGPL v3 license and KaldiAG in the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Dragonfly currently supports the following speech recognition engines:
    similar editions of *Dragon* are supported. Other editions may work too
 -  *Windows Speech Recognition* (WSR), included with Microsoft Windows
    Vista, Windows 7+, and freely available for Windows XP
--  *Kaldi*, open source and multi-platform.
+-  *Kaldi*, open source (AGPL) and multi-platform.
 -  *CMU Pocket Sphinx*, open source and multi-platform.
 
 Documentation and FAQ

--- a/documentation/index.txt
+++ b/documentation/index.txt
@@ -30,7 +30,7 @@ Dragonfly currently supports the following speech recognition engines:
    work too
  - :ref:`Windows Speech Recognition <RefSapi5Engine>` (WSR), included with
    Microsoft Windows Vista, Windows 7+, and freely available for Windows XP
- - :ref:`Kaldi <RefKaldiEngine>`, open source and multi-platform.
+ - :ref:`Kaldi <RefKaldiEngine>`, open source (AGPL) and multi-platform.
  - :ref:`CMU Pocket Sphinx <RefSphinxEngine>`, open source and multi-
    platform.
 

--- a/documentation/kaldi_engine.txt
+++ b/documentation/kaldi_engine.txt
@@ -27,6 +27,11 @@ cross-platform engine for dragonfly as a competitive alternative to
 commercial offerings, kaldi-active-grammar accepts donations (not
 affiliated with the dragonfly project itself).
 
+Please note that Kaldi Active Grammar is licensed under the GNU Affero
+General Public License v3 (AGPL-3.0-or-later).  This has an effect on
+what Dragonfly can be used to do when used in conjunction with the Kaldi
+engine back-end.
+
 **Sections:**
 
 * `Setup`_


### PR DESCRIPTION
Re: #355.

Kaldi Active Grammar (KaldiAG) is licensed under the GNU Affero General Public License v3 (AGPL-3.0-or-later).  This has an effect on what Dragonfly can be used to do when used in conjunction with the Kaldi engine back-end.  These changes make this clearer in the docs.

@matthewmcintire @daanzu Do these changes look all right?