### PR TITLE
Support (but not require) build, editable installs, and github actions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,7 @@ directory:
 
 .. code:: shell
 
-    python setup.py install
+    pip install -e .
 
 If pip fails to install *dragonfly* or any of its required or extra
 dependencies, then you may need to upgrade pip with the following command:
@@ -168,6 +168,14 @@ dependencies, then you may need to upgrade pip with the following command:
 .. code:: shell
 
     pip install --upgrade pip
+
+To build the dragonfly python package, run these commands in the projects root directory.  
+
+.. code:: shell
+
+    pip install build  
+    Python -m build
+
 
 
 Speech recognition engine back-ends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/python-publish.yml
+++ b/python-publish.yml
@@ -1,0 +1,25 @@
+name: Publish Package 📦 to  PyPI
+on:
+  release:
+    types: [published] # with prerelease and release
+
+permissions:
+  contents: read
+  id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+jobs:
+  build_and_publish:
+    # Set up the environment `CI` references the secret `PYPI_API_TOKEN` in repository settings
+    # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#referencing-an-environment
+    environment: CI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Installing build Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
python build command and editable installs.
Added the github action for building python packages. Updated the readme to provide instructions for the editable install and use of the build command. 

Note that even though the github action is provided, it will not be activated unless dragonfly admin sets it up and adds the dragonfly repository [to a trusted publisher](https://pypi.org/help/#trusted-publishers) on pypi.  This would let you publish from github using the release feature, instead of a local build, if desired.

The advantages of running the `python build` command is that build knows how to build a project, whether it is built with flit, setuptools, poetry, etc.  and it creates a virtual environment for the build, to help catch errors.   However, it is not required to use `build`, the same commands that worked before `python setup.py build`.  