### PR TITLE
Optionally raise a timeout exception under context manager.

### DIFF
--- a/dragonfly/windows/win32_clipboard.py
+++ b/dragonfly/windows/win32_clipboard.py
@@ -217,7 +217,7 @@ class Win32Clipboard(BaseClipboard):
     @classmethod
     @contextlib.contextmanager
     def synchronized_changes(cls, timeout, step=0.001, formats=None,
-                             initial_clipboard=None):
+                             initial_clipboard=None, raise_exception_on_timeout=False):
         seq_no = win32clipboard.GetClipboardSequenceNumber()
         if formats and not initial_clipboard:
             initial_clipboard = cls(from_system=True)
@@ -226,8 +226,9 @@ class Win32Clipboard(BaseClipboard):
             yield
         finally:
             # Wait for the system clipboard to change.
-            cls._wait_for_change(timeout, step, formats, initial_clipboard,
-                                 seq_no)
+            if not cls._wait_for_change(timeout, step, formats, initial_clipboard,
+                                 seq_no) and raise_exception_on_timeout:
+                raise TimeoutError("Timed out waiting for clipboard to change.")
 
     #-----------------------------------------------------------------------
 


### PR DESCRIPTION
Currently, when using the context manager, there's no indication if the clipboard timed out when waiting for a change.

This change makes it so I could write the following and be (mostly) certain my text made it to the clipboard:

```
with clipboard.synchronized_changes(timeout=2, raise_exception_on_timeout=True):
    Key("c-c").execute()
```

This makes it simple to write rules that rely on getting the user's highlighted text and subsequently stop the action if not text was captured.