### PR TITLE
add the apostrophe possesive ('s) to Natlink word formatter property map

### DIFF
--- a/dragonfly/engines/backend_natlink/dictation_format.py
+++ b/dragonfly/engines/backend_natlink/dictation_format.py
@@ -360,6 +360,7 @@ class WordParserDns11(WordParserBase):
         "open paren":       WordFlags("no_space_after"),
         "close paren":      WordFlags("no_space_before"),
         "slash":            WordFlags("no_space_after", "no_space_before"),
+        "z":                WordFlags("no_space_before"),
 
         # below are two examples of Dragon custom vocabulary with formatting
         # these would have to be added to the Dragon vocabulary for users to use them


### PR DESCRIPTION
This fixes the bug where words with an ('s) are formatted incorrectly with dragonfly's Text action for users with Dragon Naturally Speaking.
This removes the space between the (word) and the ('s).

When I dictate the phrase:
The RFI's are due tomorrow.

I get a 'NatlinkDictationContainer._words' result of:
('the', 'RFI', "'s\\z\\z", 'are', 'due', 'tomorrow', '.\\period\\period')

Dragon treats the ('s) as a separate word. The "z" property is needed to remove the space before the ('s).
Otherwise I get the incorrectly formatted "The RFI 's are due tomorrow. " as the text output.

I am using Dragron v16.
- Cheers