### PR TITLE
Add Windows UI Automation accessibility backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Changed
   compiling them directly.
 - Change the CommandModule class' optional unload method to invoke top-level
   unload functions like the Natlink loader does.
+- Prefer the Windows UI Automation accessibility backend on Windows and keep
+  IAccessible2 as a fallback when UIA cannot be initialized.
 - Make the logging output of Dragonfly's CLI commands more sane.
 - Make some optimizations to the Natlink engine.
 - Rename the engines.backend_sphinx.misc module to config.

--- a/documentation/accessibility.txt
+++ b/documentation/accessibility.txt
@@ -16,11 +16,24 @@ command::
 Windows
 ----------------------------------------------------------------------------
 
-To use this API on Windows, install `pyia2
-<https://github.com/illinois-dres-aitg/pyia2>`__. To use this with Chrome,
-you may also need to register an additional 64-bit IAccessible2 DLL which
-can be obtained `here
+On Windows, Dragonfly now prefers Microsoft's UI Automation (UIA) API for
+accessibility text operations. The base ``dragonfly[accessibility]`` extra
+installs the ``comtypes`` dependency used for this path.
+
+If UIA cannot be initialized, Dragonfly falls back to the older
+IAccessible2-based implementation. To use that fallback path, install
+`pyia2 <https://github.com/illinois-dres-aitg/pyia2>`__. To use the IA2 path
+with Chrome, you may also need to register an additional 64-bit
+IAccessible2 DLL which can be obtained `here
 <https://github.com/ThePacielloGroup/aviewer/blob/Develop/package/IAccessible2Proxy64bit.dll>`__.
+
+Application support still depends on the target application exposing
+accessible text, caret and range information in a usable way. Tools such as
+`Accessibility Insights for Windows
+<https://accessibilityinsights.io/docs/en/windows/overview>`__ can help
+inspect what a given application exposes. Chromium-based applications may
+also require a temporary launch flag such as ``--force-renderer-accessibility``
+before their page content appears in the UIA tree.
 
 X11 (Linux)
 ----------------------------------------------------------------------------

--- a/dragonfly/accessibility/__init__.py
+++ b/dragonfly/accessibility/__init__.py
@@ -4,12 +4,29 @@ platform.
 """
 
 import contextlib
+import importlib
+import logging
 import os
 import sys
 
 from . import controller
 
 from .utils import (CursorPosition, TextQuery)
+
+_log = logging.getLogger("accessibility")
+
+
+def _load_controller_classes(*module_names):
+    controller_classes = []
+    for module_name in module_names:
+        try:
+            module = importlib.import_module("." + module_name, __name__)
+        except ImportError:
+            continue
+        controller_class = getattr(module, "Controller", None)
+        if controller_class:
+            controller_classes.append(controller_class)
+    return controller_classes
 
 # Import and set the controller class based on the current platform.
 # Note: dragonfly._platform_checks is not used here in an effort to keep the
@@ -18,28 +35,35 @@ from .utils import (CursorPosition, TextQuery)
 #
 if ":" in os.environ.get("DISPLAY", ""):
     # Use the AT-SPI controller on X11.
-    from . import atspi
-    os_controller_class = atspi.Controller
+    os_controller_classes = _load_controller_classes("atspi")
 
 elif sys.platform.startswith("win"):
-    # Use the IAccessible2 controller on Windows.
-    from . import ia2
-    os_controller_class = ia2.Controller
+    # Prefer UIA on Windows and keep IA2 as a fallback.
+    os_controller_classes = _load_controller_classes("uia", "ia2")
 
 else:
-    os_controller_class = None
+    os_controller_classes = []
 
 controller_instance = None
+
 
 def get_accessibility_controller():
     """Get the OS-independent accessibility controller which is the gateway to all
     accessibility functionality. Returns None if OS is not supported."""
 
     global controller_instance
-    if os_controller_class and (not controller_instance or controller_instance.stopped):
-        os_controller = os_controller_class()
-        controller_instance = controller.AccessibilityController(os_controller)
+    if (not controller_instance or controller_instance.stopped):
+        controller_instance = None
+        for os_controller_class in os_controller_classes:
+            try:
+                os_controller = os_controller_class()
+                controller_instance = controller.AccessibilityController(os_controller)
+                break
+            except Exception as exception:
+                _log.debug("Failed to initialize %s: %s" %
+                           (os_controller_class, exception))
     return controller_instance
+
 
 @contextlib.contextmanager
 def get_stopping_accessibility_controller():

--- a/dragonfly/accessibility/uia.py
+++ b/dragonfly/accessibility/uia.py
@@ -1,0 +1,262 @@
+"""UI Automation backend helpers for Dragonfly accessibility."""
+
+import importlib
+import logging
+import threading
+import traceback
+
+from six.moves import queue
+
+from dragonfly.accessibility import base
+
+
+class _UIAConstants(object):
+    TextPatternRangeEndpoint_Start = "start"
+    TextPatternRangeEndpoint_End = "end"
+    TextUnit_Character = "character"
+
+
+UIA = _UIAConstants
+_log = logging.getLogger("accessibility")
+
+
+def _load_uia_modules():
+    comtypes = importlib.import_module("comtypes")
+    comtypes_client = importlib.import_module("comtypes.client")
+    try:
+        uia_client = importlib.import_module("comtypes.gen.UIAutomationClient")
+    except ImportError:
+        comtypes_client.GetModule("UIAutomationCore.dll")
+        uia_client = importlib.import_module("comtypes.gen.UIAutomationClient")
+    return comtypes, comtypes_client, uia_client
+
+
+def _create_automation():
+    global UIA
+    _comtypes, comtypes_client, uia_client = _load_uia_modules()
+    UIA = uia_client
+    return comtypes_client.CreateObject(
+        "{ff48dba4-60ef-4201-aa87-54103eef594e}",
+        interface=uia_client.IUIAutomation,
+    )
+
+
+def _query_interface(pattern, interface_name):
+    if not _is_supported_pattern(pattern):
+        return None
+    interface = getattr(UIA, interface_name, None)
+    if hasattr(pattern, "QueryInterface"):
+        try:
+            queried_pattern = pattern.QueryInterface(interface)
+        except Exception:
+            _log.debug("Failed to query %s on %r" % (interface_name, pattern))
+            return pattern
+        if _is_supported_pattern(queried_pattern):
+            return queried_pattern
+    return pattern
+
+
+def _is_supported_pattern(pattern):
+    if pattern is None:
+        return False
+    try:
+        return bool(pattern)
+    except Exception:
+        return True
+
+
+class Controller(object):
+
+    class Capture(object):
+
+        def __init__(self, closure):
+            self.closure = closure
+            self.done_event = threading.Event()
+            self.exception = None
+            self.return_value = None
+
+    def __init__(self):
+        _load_uia_modules()
+        self._context = Context()
+        self._closure_queue = queue.Queue(1)
+        self._shutdown_event = threading.Event()
+        self._startup_done_event = threading.Event()
+        self._startup_exception = None
+
+    def _start_blocking(self):
+        try:
+            self._context.initialize()
+        except Exception as exception:
+            self._startup_exception = exception
+            self._startup_done_event.set()
+            return
+        self._startup_done_event.set()
+        while not self._shutdown_event.is_set():
+            self._context.update_focus()
+            try:
+                capture = self._closure_queue.get(timeout=0.01)
+            except queue.Empty:
+                continue
+            try:
+                capture.return_value = capture.closure(self._context)
+            except base.AccessibilityError as exception:
+                capture.exception = exception
+            except Exception as exception:
+                capture.exception = exception
+                traceback.print_exc()
+            capture.done_event.set()
+
+    def start(self):
+        self._shutdown_event.clear()
+        self._startup_exception = None
+        self._startup_done_event.clear()
+        thread = threading.Thread(target=self._start_blocking)
+        thread.daemon = True
+        thread.start()
+        self._startup_done_event.wait()
+        if self._startup_exception:
+            self._shutdown_event.set()
+            raise self._startup_exception
+
+    def stop(self):
+        self._shutdown_event.set()
+
+    def run_sync(self, closure):
+        capture = self.Capture(closure)
+        self._closure_queue.put(capture)
+        capture.done_event.wait()
+        if capture.exception:
+            raise capture.exception
+        return capture.return_value
+
+
+class Context(object):
+
+    def __init__(self, automation=None):
+        self.automation = automation
+        self.focused = None
+
+    def initialize(self):
+        if self.automation is None:
+            self.automation = _create_automation()
+
+    def update_focus(self):
+        if self.automation is None:
+            self.focused = None
+            return
+        try:
+            focused = self.automation.GetFocusedElement()
+        except Exception:
+            self.focused = None
+            return
+        self.focused = Accessible(focused) if focused else None
+
+
+class Accessible(object):
+
+    def __init__(self, element):
+        self._element = element
+
+    def as_text(self):
+        pattern = self._element.GetCurrentPattern(UIA.UIA_TextPatternId)
+        if not _is_supported_pattern(pattern):
+            return None
+        pattern = _query_interface(pattern, "IUIAutomationTextPattern")
+        if not _is_supported_pattern(pattern):
+            return None
+        return UiaAccessibleTextNode(self._element, pattern)
+
+    def is_editable(self):
+        value_pattern = self._element.GetCurrentPattern(UIA.UIA_ValuePatternId)
+        if _is_supported_pattern(value_pattern):
+            value_pattern = _query_interface(value_pattern, "IUIAutomationValuePattern")
+            if _is_supported_pattern(value_pattern):
+                return not value_pattern.CurrentIsReadOnly
+        return self._element.CurrentControlType in (
+            UIA.UIA_EditControlTypeId,
+            UIA.UIA_DocumentControlTypeId,
+        )
+
+
+class BoundingBox(object):
+
+    def __init__(self, x, y, width, height):
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+
+    def __str__(self):
+        return "x=%s, y=%s, width=%s, height=%s" % (
+            self.x, self.y, self.width, self.height
+        )
+
+
+class UiaAccessibleTextNode(object):
+    """Minimal UIA text-node contract for accessibility controller integration."""
+
+    def __init__(self, element, text_pattern):
+        self._element = element
+        self._text_pattern = text_pattern
+        self._document_range = text_pattern.DocumentRange
+        self.expanded_text = self._document_range.GetText(-1)
+
+        selection = text_pattern.GetSelection()
+        if selection.Length:
+            selected_range = selection.GetElement(0)
+            self.cursor = self._get_offset(selected_range)
+        else:
+            self.cursor = 0
+
+    def _get_collapsed_range_at_start(self):
+        collapsed_range = self._document_range.Clone()
+        collapsed_range.MoveEndpointByRange(
+            UIA.TextPatternRangeEndpoint_End,
+            collapsed_range,
+            UIA.TextPatternRangeEndpoint_Start,
+        )
+        return collapsed_range
+
+    def _get_offset(self, text_range):
+        offset = 0
+        probe = self._get_collapsed_range_at_start()
+        # CompareEndpoints only tells us relative ordering, so walk forward
+        # from the start of the document to derive a character offset.
+        while offset < len(self.expanded_text) and probe.CompareEndpoints(
+                UIA.TextPatternRangeEndpoint_Start,
+                text_range,
+                UIA.TextPatternRangeEndpoint_Start,
+        ) < 0:
+            moved = probe.Move(UIA.TextUnit_Character, 1)
+            if moved <= 0:
+                break
+            offset += moved
+        return offset
+
+    def _make_range(self, start, end):
+        start = max(0, min(start, len(self.expanded_text)))
+        end = max(start, min(end, len(self.expanded_text)))
+        text_range = self._get_collapsed_range_at_start()
+        if start:
+            text_range.Move(UIA.TextUnit_Character, start)
+        if end > start:
+            text_range.MoveEndpointByUnit(
+                UIA.TextPatternRangeEndpoint_End,
+                UIA.TextUnit_Character,
+                end - start,
+            )
+        return text_range
+
+    def select_range(self, start, end):
+        range_to_select = self._make_range(start, end)
+        range_to_select.Select()
+
+    def set_cursor(self, offset):
+        cursor_range = self._make_range(offset, offset)
+        cursor_range.Select()
+        self.cursor = offset
+
+    def get_bounding_box(self, offset):
+        char_range = self._make_range(offset, offset + 1)
+        rect = char_range.GetBoundingRectangles()
+        return BoundingBox(rect[0], rect[1], rect[2], rect[3])

--- a/dragonfly/test/test_accessibility_uia.py
+++ b/dragonfly/test/test_accessibility_uia.py
@@ -1,0 +1,474 @@
+import unittest
+import importlib
+import os
+import sys
+import types
+
+from dragonfly.accessibility import uia
+
+
+class _FakeUIAConstants(object):
+    UIA_TextPatternId = "text-pattern"
+    UIA_ValuePatternId = "value-pattern"
+    UIA_EditControlTypeId = "edit"
+    UIA_DocumentControlTypeId = "document"
+    TextPatternRangeEndpoint_Start = "start"
+    TextPatternRangeEndpoint_End = "end"
+    TextUnit_Character = "character"
+
+
+class _FakeSelectionArray(object):
+
+    def __init__(self, ranges):
+        self._ranges = ranges
+        self.Length = len(ranges)
+
+    def GetElement(self, index):
+        return self._ranges[index]
+
+
+class _FakeTextRange(object):
+
+    def __init__(self, text, start=0, end=None, selection_state=None):
+        self._text = text
+        self.start = start
+        self.end = len(text) if end is None else end
+        self._selection_state = selection_state if selection_state is not None else {"selected": None}
+
+    @property
+    def selected(self):
+        return self._selection_state["selected"]
+
+    def Clone(self):
+        return _FakeTextRange(self._text, self.start, self.end, self._selection_state)
+
+    def GetText(self, _max_count):
+        return self._text[self.start:self.end]
+
+    def MoveEndpointByUnit(self, endpoint, _unit, count):
+        if endpoint == _FakeUIAConstants.TextPatternRangeEndpoint_Start:
+            self.start += count
+        else:
+            self.end += count
+
+    def MoveEndpointByRange(self, endpoint, other_range, other_endpoint):
+        value = other_range.start if other_endpoint == _FakeUIAConstants.TextPatternRangeEndpoint_Start else other_range.end
+        if endpoint == _FakeUIAConstants.TextPatternRangeEndpoint_Start:
+            self.start = value
+        else:
+            self.end = value
+
+    def Move(self, _unit, count):
+        self.start += count
+        self.end += count
+        return count
+
+    def CompareEndpoints(self, this_endpoint, other_range, other_endpoint):
+        this_value = self.start if this_endpoint == _FakeUIAConstants.TextPatternRangeEndpoint_Start else self.end
+        other_value = other_range.start if other_endpoint == _FakeUIAConstants.TextPatternRangeEndpoint_Start else other_range.end
+        if this_value < other_value:
+            return -1
+        if this_value > other_value:
+            return 1
+        return 0
+
+    def Select(self):
+        self._selection_state["selected"] = (self.start, self.end)
+
+    def GetBoundingRectangles(self):
+        width = max(1, self.end - self.start)
+        return [self.start, 10, width, 5]
+
+
+class _FakeTextPattern(object):
+
+    def __init__(self, text, selection_start):
+        self.DocumentRange = _FakeTextRange(text, 0, len(text))
+        self._selection = [_FakeTextRange(text, selection_start, selection_start)]
+
+    def GetSelection(self):
+        return _FakeSelectionArray(self._selection)
+
+
+class _FakeValuePattern(object):
+
+    def __init__(self, read_only):
+        self.CurrentIsReadOnly = read_only
+
+
+class _FakePatternWrapper(object):
+
+    def __init__(self, value):
+        self._value = value
+
+    def QueryInterface(self, _interface):
+        return self._value
+
+
+class _FakeNullPattern(object):
+
+    def __bool__(self):
+        return False
+
+    __nonzero__ = __bool__
+
+    def QueryInterface(self, _interface):
+        raise ValueError("NULL COM pointer access")
+
+
+class _FakeFailingPattern(object):
+
+    def __init__(self, text):
+        self.DocumentRange = _FakeTextRange(text, 0, len(text))
+        self._selection = [_FakeTextRange(text, 0, 0)]
+
+    def GetSelection(self):
+        return _FakeSelectionArray(self._selection)
+
+    def QueryInterface(self, _interface):
+        raise ValueError("already typed")
+
+
+class _FakeElement(object):
+
+    def __init__(self, patterns=None, control_type=None):
+        self._patterns = patterns or {}
+        self.CurrentControlType = control_type
+
+    def GetCurrentPattern(self, pattern_id):
+        return self._patterns.get(pattern_id)
+
+
+class _FakeAutomation(object):
+
+    def __init__(self, focused_element=None):
+        self._focused_element = focused_element
+
+    def GetFocusedElement(self):
+        return self._focused_element
+
+
+class _FakeOsController(object):
+
+    def __init__(self, fail=False):
+        if fail:
+            raise RuntimeError("controller init failed")
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
+class AccessibilityUiaTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self._old_uia = uia.UIA
+        self._old_create_automation = getattr(uia, "_create_automation", None)
+        self._old_load_uia_modules = getattr(uia, "_load_uia_modules", None)
+        self._old_import_module = uia.importlib.import_module
+        uia.UIA = _FakeUIAConstants
+
+    def tearDown(self):
+        uia.UIA = self._old_uia
+        if self._old_create_automation is not None:
+            uia._create_automation = self._old_create_automation
+        if self._old_load_uia_modules is not None:
+            uia._load_uia_modules = self._old_load_uia_modules
+        uia.importlib.import_module = self._old_import_module
+
+    def test_text_node_exposes_expanded_text_and_cursor(self):
+        text_pattern = _FakeTextPattern("alpha beta", 6)
+
+        node = uia.UiaAccessibleTextNode(None, text_pattern)
+
+        self.assertEqual("alpha beta", node.expanded_text)
+        self.assertEqual(6, node.cursor)
+
+    def test_text_node_select_range_tracks_selected_offsets(self):
+        text_pattern = _FakeTextPattern("alpha beta", 0)
+
+        node = uia.UiaAccessibleTextNode(None, text_pattern)
+        node.select_range(2, 5)
+
+        self.assertEqual((2, 5), text_pattern.DocumentRange.selected)
+
+    def test_text_node_sets_cursor_with_collapsed_selection(self):
+        text_pattern = _FakeTextPattern("alpha beta", 0)
+
+        node = uia.UiaAccessibleTextNode(None, text_pattern)
+        node.set_cursor(4)
+
+        self.assertEqual((4, 4), text_pattern.DocumentRange.selected)
+        self.assertEqual(4, node.cursor)
+
+    def test_text_node_returns_character_bounding_box(self):
+        text_pattern = _FakeTextPattern("alpha beta", 0)
+
+        node = uia.UiaAccessibleTextNode(None, text_pattern)
+        box = node.get_bounding_box(3)
+
+        self.assertEqual(3, box.x)
+        self.assertEqual(10, box.y)
+        self.assertEqual(1, box.width)
+        self.assertEqual(5, box.height)
+
+    def test_accessible_returns_text_node_when_text_pattern_present(self):
+        text_pattern = _FakeTextPattern("alpha beta", 6)
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_TextPatternId: text_pattern,
+        })
+
+        accessible = uia.Accessible(element)
+        text_node = accessible.as_text()
+
+        self.assertIsInstance(text_node, uia.UiaAccessibleTextNode)
+        self.assertEqual("alpha beta", text_node.expanded_text)
+
+    def test_accessible_uses_query_interface_wrapper_for_text_pattern(self):
+        text_pattern = _FakeTextPattern("alpha beta", 6)
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_TextPatternId: _FakePatternWrapper(text_pattern),
+        })
+
+        accessible = uia.Accessible(element)
+        text_node = accessible.as_text()
+
+        self.assertIsInstance(text_node, uia.UiaAccessibleTextNode)
+        self.assertEqual(6, text_node.cursor)
+
+    def test_accessible_ignores_null_text_pattern_pointer(self):
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_TextPatternId: _FakeNullPattern(),
+        })
+
+        accessible = uia.Accessible(element)
+
+        self.assertIsNone(accessible.as_text())
+
+    def test_accessible_uses_pattern_directly_if_query_interface_fails(self):
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_TextPatternId: _FakeFailingPattern("alpha beta"),
+        })
+
+        accessible = uia.Accessible(element)
+        text_node = accessible.as_text()
+
+        self.assertIsInstance(text_node, uia.UiaAccessibleTextNode)
+        self.assertEqual("alpha beta", text_node.expanded_text)
+
+    def test_accessible_reports_editable_from_value_pattern(self):
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_ValuePatternId: _FakeValuePattern(False),
+        })
+
+        accessible = uia.Accessible(element)
+
+        self.assertTrue(accessible.is_editable())
+
+    def test_accessible_falls_back_to_control_type_for_editable(self):
+        element = _FakeElement(control_type=_FakeUIAConstants.UIA_EditControlTypeId)
+
+        accessible = uia.Accessible(element)
+
+        self.assertTrue(accessible.is_editable())
+
+    def test_accessible_ignores_null_value_pattern_pointer(self):
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_ValuePatternId: _FakeNullPattern(),
+        }, control_type=_FakeUIAConstants.UIA_DocumentControlTypeId)
+
+        accessible = uia.Accessible(element)
+
+        self.assertTrue(accessible.is_editable())
+
+    def test_controller_requires_available_automation_backend(self):
+        uia._load_uia_modules = lambda: (_ for _ in ()).throw(ImportError("missing uia"))
+
+        with self.assertRaises(ImportError):
+            uia.Controller()
+
+    def test_load_uia_modules_generates_type_library_when_wrapper_missing(self):
+        calls = []
+
+        def fake_import_module(name):
+            if name == "comtypes":
+                return types.SimpleNamespace()
+            if name == "comtypes.client":
+                return types.SimpleNamespace(
+                    GetModule=lambda path: calls.append(path)
+                )
+            if name == "comtypes.gen.UIAutomationClient":
+                if not calls:
+                    raise ImportError("wrapper missing")
+                return _FakeUIAConstants
+            raise ImportError(name)
+
+        uia.importlib.import_module = fake_import_module
+
+        _comtypes, client, uia_client = uia._load_uia_modules()
+
+        self.assertEqual(["UIAutomationCore.dll"], calls)
+        self.assertEqual(_FakeUIAConstants, uia_client)
+
+    def test_controller_init_does_not_create_automation_until_context_initializes(self):
+        calls = []
+        uia._load_uia_modules = lambda: ("comtypes", "client", _FakeUIAConstants)
+        uia._create_automation = lambda: calls.append("create") or _FakeAutomation()
+
+        uia.Controller()
+
+        self.assertEqual([], calls)
+
+    def test_controller_start_surfaces_initialization_failure(self):
+        uia._load_uia_modules = lambda: ("comtypes", "client", _FakeUIAConstants)
+        uia._create_automation = lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        controller = uia.Controller()
+
+        with self.assertRaises(RuntimeError):
+            controller.start()
+
+    def test_controller_runs_closure_from_background_thread(self):
+        old_start_blocking = uia.Controller._start_blocking
+
+        def fake_start_blocking(controller):
+            controller._startup_done_event.set()
+            while not controller._shutdown_event.is_set():
+                capture = controller._closure_queue.get()
+                capture.return_value = capture.closure(controller._context)
+                capture.done_event.set()
+                controller._shutdown_event.set()
+
+        try:
+            uia._load_uia_modules = lambda: ("comtypes", "client", _FakeUIAConstants)
+            uia.Controller._start_blocking = fake_start_blocking
+            uia._create_automation = lambda: _FakeAutomation()
+            controller = uia.Controller()
+            controller._context = types.SimpleNamespace(marker="ok")
+            controller.start()
+
+            result = controller.run_sync(lambda context: context.marker)
+
+            self.assertEqual("ok", result)
+        finally:
+            uia.Controller._start_blocking = old_start_blocking
+
+    def test_context_update_focus_wraps_focused_element(self):
+        text_pattern = _FakeTextPattern("alpha beta", 6)
+        element = _FakeElement({
+            _FakeUIAConstants.UIA_TextPatternId: text_pattern,
+            _FakeUIAConstants.UIA_ValuePatternId: _FakeValuePattern(False),
+        })
+        uia._create_automation = lambda: _FakeAutomation(element)
+
+        context = uia.Context()
+        context.initialize()
+        context.update_focus()
+
+        self.assertIsInstance(context.focused, uia.Accessible)
+        self.assertTrue(context.focused.is_editable())
+
+    def test_windows_selector_prefers_uia_controller(self):
+        accessibility = importlib.import_module("dragonfly.accessibility")
+        old_platform = sys.platform
+        old_display = os.environ.get("DISPLAY")
+        old_uia = sys.modules.get("dragonfly.accessibility.uia")
+        old_ia2 = sys.modules.get("dragonfly.accessibility.ia2")
+        try:
+            sys.platform = "win32"
+            os.environ.pop("DISPLAY", None)
+            sys.modules["dragonfly.accessibility.uia"] = types.SimpleNamespace(
+                Controller=lambda: _FakeOsController()
+            )
+            sys.modules["dragonfly.accessibility.ia2"] = types.SimpleNamespace(
+                Controller=lambda: _FakeOsController()
+            )
+
+            accessibility = importlib.reload(accessibility)
+            controller = accessibility.get_accessibility_controller()
+
+            self.assertIsInstance(controller.os_controller, _FakeOsController)
+        finally:
+            sys.platform = old_platform
+            if old_display is None:
+                os.environ.pop("DISPLAY", None)
+            else:
+                os.environ["DISPLAY"] = old_display
+            if old_uia is None:
+                sys.modules.pop("dragonfly.accessibility.uia", None)
+            else:
+                sys.modules["dragonfly.accessibility.uia"] = old_uia
+            if old_ia2 is None:
+                sys.modules.pop("dragonfly.accessibility.ia2", None)
+            else:
+                sys.modules["dragonfly.accessibility.ia2"] = old_ia2
+            importlib.reload(accessibility)
+
+    def test_windows_selector_falls_back_to_ia2_when_uia_init_fails(self):
+        accessibility = importlib.import_module("dragonfly.accessibility")
+        old_platform = sys.platform
+        old_display = os.environ.get("DISPLAY")
+        old_uia = sys.modules.get("dragonfly.accessibility.uia")
+        old_ia2 = sys.modules.get("dragonfly.accessibility.ia2")
+        try:
+            sys.platform = "win32"
+            os.environ.pop("DISPLAY", None)
+            sys.modules["dragonfly.accessibility.uia"] = types.SimpleNamespace(
+                Controller=lambda: _FakeOsController(fail=True)
+            )
+            sys.modules["dragonfly.accessibility.ia2"] = types.SimpleNamespace(
+                Controller=lambda: _FakeOsController()
+            )
+
+            accessibility = importlib.reload(accessibility)
+            controller = accessibility.get_accessibility_controller()
+
+            self.assertIsInstance(controller.os_controller, _FakeOsController)
+            self.assertTrue(controller.os_controller.started)
+        finally:
+            sys.platform = old_platform
+            if old_display is None:
+                os.environ.pop("DISPLAY", None)
+            else:
+                os.environ["DISPLAY"] = old_display
+            if old_uia is None:
+                sys.modules.pop("dragonfly.accessibility.uia", None)
+            else:
+                sys.modules["dragonfly.accessibility.uia"] = old_uia
+            if old_ia2 is None:
+                sys.modules.pop("dragonfly.accessibility.ia2", None)
+            else:
+                sys.modules["dragonfly.accessibility.ia2"] = old_ia2
+            importlib.reload(accessibility)
+
+    def test_windows_selector_does_not_return_stopped_instance_when_reinit_fails(self):
+        accessibility = importlib.import_module("dragonfly.accessibility")
+        old_controller_instance = accessibility.controller_instance
+        old_classes = accessibility.os_controller_classes
+
+        class _StoppedController(object):
+            stopped = True
+
+        class _FailingController(object):
+
+            def __init__(self):
+                raise RuntimeError("reinit failed")
+
+        try:
+            accessibility.controller_instance = _StoppedController()
+            accessibility.os_controller_classes = [_FailingController]
+
+            controller = accessibility.get_accessibility_controller()
+
+            self.assertIsNone(controller)
+            self.assertIsNone(accessibility.controller_instance)
+        finally:
+            accessibility.controller_instance = old_controller_instance
+            accessibility.os_controller_classes = old_classes
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Windows UI Automation accessibility backend and prefer it ahead of IA2 on Windows
- handle null COM patterns and startup failures so UIA can fall back cleanly without hanging callers
- document the Windows UIA path and add focused regression coverage for UIA text behavior and selector fallback

## Test Plan
- [x] `python -m pytest dragonfly/test/test_accessibility.py dragonfly/test/test_accessibility_uia.py`
- [x] `python setup.py test --test-suite=text`

## Context
- related tracking issue: dictation-toolbox/Caster#814