### PR TITLE
Fix KaldiError: Cannot use a KaldiRule after calling destroy() during deferred mid-phrase reloads

### DIFF
--- a/dragonfly/engines/backend_kaldi/compiler.py
+++ b/dragonfly/engines/backend_kaldi/compiler.py
@@ -1,4 +1,4 @@
-﻿#
+#
 # This file is part of Dragonfly.
 # (c) Copyright 2019 by David Zurow
 # Licensed under the LGPL.
@@ -195,11 +195,18 @@ class KaldiCompiler(CompilerBase, KaldiAGCompiler):
         return (outer_src_state, dst_state)
 
     def unload_grammar(self, grammar, rules, engine):
-        for rule in rules:
-            kaldi_rule = self.kaldi_rule_by_rule_dict[rule]
+        if isinstance(rules, dict):
+            items = list(rules.items())
+        else:
+            items = [(rule, self.kaldi_rule_by_rule_dict.get(rule)) for rule in rules]
+
+        for rule, kaldi_rule in items:
+            if kaldi_rule is None:
+                continue
             # Unload kaldi_rule: destroy() handles KaldiAGCompiler stuff; we must handle ours
             kaldi_rule.destroy()
-            del self.kaldi_rule_by_rule_dict[rule]
+            if self.kaldi_rule_by_rule_dict.get(rule) is kaldi_rule:
+                del self.kaldi_rule_by_rule_dict[rule]
             for kaldi_rules_set in self.kaldi_rules_by_listreflist_dict.values():
                 kaldi_rules_set.discard(kaldi_rule)
             # NOTE: the kaldi_rule_by_rule_dict we returned from compile_grammar() is not updated, but it should be dropped upon unload anyway!

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -262,7 +262,8 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
         """ Unload the given *grammar*. """
         self._log.debug("Unloading grammar %s." % grammar.name)
         def unload():
-            self._compiler.unload_grammar(grammar, wrapper.kaldi_rule_by_rule_dict, self)
+            rules = wrapper.kaldi_rule_by_rule_dict
+            self._compiler.unload_grammar(grammar, rules, self)
         if self._in_phrase:
             self._loadunload_queue.append(unload)
         else:

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -1,4 +1,4 @@
-﻿#
+#
 # This file is part of Dragonfly.
 # (c) Copyright 2019 by David Zurow
 # Licensed under the LGPL.
@@ -262,8 +262,7 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
         """ Unload the given *grammar*. """
         self._log.debug("Unloading grammar %s." % grammar.name)
         def unload():
-            rules = list(wrapper.kaldi_rule_by_rule_dict.keys())
-            self._compiler.unload_grammar(grammar, rules, self)
+            self._compiler.unload_grammar(grammar, wrapper.kaldi_rule_by_rule_dict, self)
         if self._in_phrase:
             self._loadunload_queue.append(unload)
         else:


### PR DESCRIPTION
Note: This pull request message was generated by the Gemini LLM, which I have been using alongside the Antigravity editor to develop this fix. The technical breakdown below represents the coding agent's understanding of the underlying engine behavior. From my personal usage, this issue specifically surfaced only when saying the voice command "caster sleep" when using Caster with the latest Dragonfly version.

Addresses an issue in the Kaldi engine where deferred grammar unloads can accidentally destroy newly compiled rules, leading to engine crashes. 

### Expected Behavior
When a grammar is unloaded and immediately reloaded mid-phrase (for example, when a voice command triggers a synchronous macro), the engine should correctly defer the unload of the old grammar while safely compiling and preparing the new grammar. The old KaldiRule instances should be cleanly destroyed when the audio phrase finishes, without affecting the newly loaded rules.

### Actual Behavior (The Bug)
It appears that when a grammar reloads mid-phrase, the engine properly defers the unload() operation to the _loadunload_queue. However, it compiles the new rules synchronously, which immediately overwrites the compiler's global lookup dictionary (self.kaldi_rule_by_rule_dict).

When the phrase ends and the deferred unload() finally executes, it seems to look up the rules to destroy from that now-updated global dictionary. As a result, it accidentally retrieves the newly compiled rule objects and calls destroy() on them. When the engine subsequently attempts to use these new rules, it crashes with: KaldiError: Cannot use a KaldiRule after calling destroy().

(Cross-reference: Caster Issue #943)

### Solution / Proposed Changes
To address this, the code has been modified to ensure the deferred unload targets the exact instances created during the original load cycle, rather than relying on the fluctuating global state:

* engine.py: _unload_grammar() now captures and passes the exact reference map (wrapper.kaldi_rule_by_rule_dict) directly to the compiler.
* compiler.py: unload_grammar() was updated to accept and iterate over this specific dictionary rather than falling back to the global dictionary.
* Reference Guard: Added an identity guard (is) in unload_grammar() so that a rule is only deleted from the global map if that map still points to the exact KaldiRule instance being destroyed. If the global entry was already overwritten by a subsequent compilation, it is safely preserved.

### Related Issues
* Fixes / Addresses https://github.com/dictation-toolbox/Caster/issues/943