### PR TITLE
Fix number series sequence matching, length limits, and zero formatting

### DIFF
--- a/dragonfly/language/base/number.py
+++ b/dragonfly/language/base/number.py
@@ -31,12 +31,24 @@ from dragonfly.language.base.integer  import Integer
 
 
 #---------------------------------------------------------------------------
+
+class StringInt(int):
+    def __new__(cls, value, string_value):
+        obj = super(StringInt, cls).__new__(cls, value)
+        obj.string_value = string_value
+        return obj
+
+    def __str__(self):
+        return self.string_value
+
+
+#---------------------------------------------------------------------------
 # Number class.
 
 class Number(Alternative):
 
     _int_max = 1000000
-    _ser_len = 8
+    _ser_len = 32
 
     def __init__(self, name=None, zero=False, default=None):
         name = str(name)
@@ -54,7 +66,7 @@ class Number(Alternative):
             repetition = Repetition(item, 0, self._ser_len - 1)
             series = Sequence([first, repetition])
 
-        children = [single, series]
+        children = [series, single]
         Alternative.__init__(self, children, name=name, default=default)
 
     def value(self, node):
@@ -73,6 +85,9 @@ class Number(Alternative):
                 else:          factor = 100
                 value *= factor
                 value += item
+
+            string_value = "".join(str(item) for item in items)
+            value = StringInt(value, string_value)
 
         return value
 

--- a/dragonfly/test/test_language_en_number.py
+++ b/dragonfly/test/test_language_en_number.py
@@ -243,3 +243,48 @@ class ShortIntegerTestCase(ElementTestCase):
                     ("two hundred and thirty four thousand five hundred sixty seven", 234567),
                     ("five million two hundred and thirty four thousand five hundred sixty seven", 5234567),
                    ]
+
+
+class NumberTestCase(ElementTestCase):
+    """ Verify the Number element class """
+    def _build_element(self):
+        from dragonfly.language.base.number import Number
+        return Number(None, zero=True)
+    input_output = [
+                    ("zero",                  0),
+                    ("zero one one",          11),
+                    ("zero ninety",           90),
+                    ("one zero one one",      1011),
+                    ("one one zero one one",  11011),
+                    ("one one one zero one",  11101),
+                    ("one thousand",          1000),
+                    ("eight zero zero five five five zero one nine nine", 8005550199),
+                   ]
+
+
+class NumberStrTestCase(ElementTestCase):
+    """ Verify that str() of the parsed Number preserves leading zeros """
+    def _build_element(self):
+        from dragonfly.language.base.number import Number
+        return Number(None, zero=True)
+
+    def test_element(self):
+        element = self.element
+        from dragonfly.test.element_tester import ElementTester
+        tester = ElementTester(element)
+
+        input_expected_str = [
+            ("zero",                  "0"),
+            ("zero one one",          "011"),
+            ("zero ninety",           "090"),
+            ("one zero one one",      "1011"),
+            ("one one zero one one",  "11011"),
+            ("one one one zero one",  "11101"),
+            ("one thousand",          "1000"),
+            ("eight zero zero five five five zero one nine nine", "8005550199"),
+            ("one two three four five six seven eight nine zero one two three four five six", "1234567890123456"),
+        ]
+        for words, expected_str in input_expected_str:
+            val = tester.recognize(words)
+            self.assertEqual(str(val), expected_str)
+


### PR DESCRIPTION
Written by Agent in Antigravity IDE


## Description
This PR resolves issue matching conflicts, length limitations, and formatting losses in the Dragonfly `Number` class. 

This change is the **Dragonfly-side dependency** required to resolve Caster issues #938 and #857. A corresponding PR will be opened in the Caster repository to switch Caster's number rule extra from `ShortIntegerRef` to `NumberRef`.

### Dragonfly Changes in this PR:
1. **Greedy Prefix Matching**: The internal choice order in the `Number` element was compiled as `[single, series]`. This caused speech engines to greedily match a single number prefix (like "zero" in "zero one one") and stop, preventing digit sequences from decoding properly. We swapped the order to `[series, single]` to prioritize full digit sequences.
2. **Long Sequence Limit**: The internal repetition limit `_ser_len` was hardcoded to `8`. Because Dragonfly's `Repetition` element applies an exclusive upper bound, digit sequences were capped at exactly 7 digits. This broke long dictates like 10-digit phone numbers or 16-digit credit cards. We raised `_ser_len` to `32`.
3. **Leading Zeros Loss**: Parsed digit sequences were returned as standard Python `int` types, throwing away leading zeros (e.g. "0101" became `101`). We introduced a lightweight subclass of `int` called `StringInt` that preserves the original sequence formatting when coerced to a string (`str()`) while maintaining backward-compatible `int` functionality.

This has been fully tested and is currently running successfully with the **Kaldi backend**.

---

### Corresponding Caster Changes (Planned PR)
To complete the resolution of the referenced Caster issues, we will be opening a PR in the Caster repository to modify the `Numbers` rule in `castervoice/rules/core/numbers_rules/numeric.py`. 

Specifically, this updates `wnKK` from `ShortIntegerRef` to `NumberRef("wnKK", zero=True)` so it can leverage the updated Dragonfly digit-series parsing:

```python
# Caster numeric.py modification
class Numbers(MergeRule):
    pronunciation = "numbers"
    mapping = {
        "word number <wn>":
            R(Function(word_number, extra="wn")),
        "[<long>] numb <wnKK>":
            R(Text("%(long)s") + Function(numbers2, extra="wnKK") + Text("%(long)s"),
              rspec="Number"),
    }

    extras = [
        ShortIntegerRef("wn", 0, 10),
        NumberRef("wnKK", zero=True),  # Switched to NumberRef to support arbitrary digit sequences
        Choice(
            "long", {
                "long": " ",
            }),
    ]

    defaults = {
        "long": "",
    }
```

---

## Related Issues
- Steps toward resolving: [dictation-toolbox/Caster#938](https://github.com/dictation-toolbox/Caster/issues/938)
- Steps toward resolving: [dictation-toolbox/Caster#857](https://github.com/dictation-toolbox/Caster/issues/857)

## Tests Added
Added test coverage to `dragonfly/test/test_language_en_number.py`:
*   `NumberTestCase`: Verifies sequence parsing containing zeros (e.g. `eight zero zero...` -> `8005550199`).
*   `NumberStrTestCase`: Verifies string formatting and leading zero retention for short and long sequences (up to 16 digits).

## Question for Maintainers
Is it safe to increase `_ser_len` to `32` for other speech engines (like Dragon NaturallySpeaking / Natlink)? 

This has been tested and works great with the Kaldi backend. However, I want to make sure it is fully compatible with older engines. If complexity limits in other engines are a concern, should we make `_ser_len` dynamically scale down to `8` if Natlink/Dragon is the active engine, or perhaps expose it as a parameter in `Number`?

## Video Demo:
https://github.com/user-attachments/assets/1bcc858b-2878-4e6e-b84d-8ec5137debd5
